### PR TITLE
Sprad/mobile styles proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-simple-maps": "^2.1.2",
     "semiotic": "^1.20.5",
     "styled-components": "^5.1.1",
+    "styled-components-breakpoint": "^3.0.0-preview.20",
     "styled-normalize": "^8.0.7",
     "topojson": "^3.0.2"
   },

--- a/src/branding-bar/BrandingBar.js
+++ b/src/branding-bar/BrandingBar.js
@@ -12,7 +12,7 @@ const brandingBarFlexProperties = css`
 const BrandingBarContainer = styled.header`
   display: flex;
   justify-content: space-between;
-  margin-bottom: 75px;
+  margin-bottom: ${(props) => props.theme.spacing[20]};
 `;
 
 const BrandingBarHeader = styled.div`
@@ -25,7 +25,7 @@ const BrandingBarTitle = styled.h1`
   color: ${(props) => props.theme.colors.heading};
   font: ${(props) => props.theme.fonts.display};
   display: inline;
-  margin-left: 16px;
+  margin-left: ${(props) => props.theme.spacing[4]};
 `;
 
 const BrandingBarLinkContainer = styled.div``;
@@ -37,7 +37,7 @@ const BrandingBarLinksList = styled.ul`
 
 const BrandingBarLink = styled.li`
   list-style-type: none;
-  margin-left: 16px;
+  margin-left: ${(props) => props.theme.spacing[4]};
 `;
 
 export default function BrandingBar() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,13 @@ const lightGray = "#ECEDEF";
 const white = "#fff";
 
 export const THEME = {
+  breakpoints: {
+    xs: 320,
+    sm: 640,
+    md: 768,
+    lg: 1024,
+    xl: 1280,
+  },
   colors: {
     // descriptive
     blue: "#3e8df7",

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,6 +82,31 @@ export const THEME = {
       fill: darkGreen,
     },
   },
+  // Spacing Scale copied from Tailwind:
+  // https://tailwindcss.com/docs/customizing-spacing/#default-spacing-scale
+  spacing: {
+    px: "1px",
+    "0": "0",
+    "1": "0.25rem", // 4px
+    "2": "0.5rem", // 8px
+    "3": "0.75rem", // 12px
+    "4": "1rem", // 16px
+    "5": "1.25rem", // 20px
+    "6": "1.5rem", // 24px
+    "8": "2rem", // 32px
+    "10": "2.5rem", // 40px
+    "12": "3rem", // 48px
+    "16": "4rem", // 64px
+    "20": "5rem", // 80px
+    "24": "6rem", // 96px
+    "32": "8rem", // 128px
+    "40": "10rem", // 160px
+    "48": "12rem", // 192px
+    "56": "14rem", // 224px
+    "64": "16rem", // 256px
+    "70": "18rem", // 288px
+    "74": "20rem", // 320px
+  },
   zIndex: {
     base: 1,
     menu: 10,

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -15,11 +15,11 @@ const FooterContent = styled.div`
   justify-content: space-between;
   margin: 0 auto;
   max-width: ${CONTAINER_WIDTH}px;
-  min-height: 300px;
+  min-height: ${(props) => props.theme.spacing[74]};
 `;
 
 const FooterCredits = styled.div`
-  min-height: 100px;
+  min-height: ${(props) => props.theme.spacing[24]};
   width: 40%;
 `;
 
@@ -27,7 +27,7 @@ const FooterLegal = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height: 100px;
+  min-height: ${(props) => props.theme.spacing[24]};
   text-align: right;
   width: 40%;
 `;
@@ -37,7 +37,7 @@ const RecidivizBrandingContainer = styled.div``;
 const RecidivizBranding = styled.img``;
 
 const FooterLegalese = styled.span`
-  margin-left: 32px;
+  margin-left: ${(props) => props.theme.spacing[8]};
 `;
 
 const PrivacyLink = styled.a`

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -66,7 +66,7 @@ export default function Footer() {
           </RecidivizBrandingContainer>
           <FooterLegalContent>
             <FooterLegalese>
-              &copy; 2019 Recidiviz. All Rights Reserved.
+              &copy; 2020 Recidiviz. All Rights Reserved.
             </FooterLegalese>
             <FooterLegalese>
               <PrivacyLink href="#">Privacy Policy</PrivacyLink>

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -1,5 +1,7 @@
 import React from "react";
+import breakpoint from "styled-components-breakpoint";
 import styled from "styled-components";
+
 import { CONTAINER_WIDTH } from "../constants";
 import RecidivizSrc from "../assets/icons/recidiviz.svg";
 
@@ -12,32 +14,70 @@ const FooterContainer = styled.footer`
 const FooterContent = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
-  margin: 0 auto;
-  max-width: ${CONTAINER_WIDTH}px;
+  flex-direction: column;
   min-height: ${(props) => props.theme.spacing[74]};
+
+  ${breakpoint("md")`
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0 auto;
+    max-width: ${CONTAINER_WIDTH}px;
+  `}
 `;
 
 const FooterCredits = styled.div`
-  min-height: ${(props) => props.theme.spacing[24]};
-  width: 40%;
+  padding: ${(props) => props.theme.spacing[8]};
+
+  ${breakpoint("md")`
+    min-height: ${(props) => props.theme.spacing[24]};
+    width: 40%;
+  `}
+
+  /* 
+    There is a bug in styled-components-breakpoint libary which doesn't allow multiple
+    interpreted values to be used within the same 'breakpoint' block:
+    https://github.com/jameslnewell/styled-components-breakpoint/issues/26
+
+    As a workaround, it is possible to achieve the desired result by using a separate
+    breakpoint block for each interpreted property.
+  */
+  ${breakpoint("md")`
+    padding: ${(props) => props.theme.spacing[0]};
+  `}
 `;
 
 const FooterLegal = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height: ${(props) => props.theme.spacing[24]};
-  text-align: right;
-  width: 40%;
+  text-align: center;
+
+  ${breakpoint("md")`
+    min-height: ${(props) => props.theme.spacing[24]};
+    text-align: right;
+    width: 40%;
+  `}
 `;
 
 const FooterLegalContent = styled.div``;
-const RecidivizBrandingContainer = styled.div``;
+
+const RecidivizBrandingContainer = styled.div`
+  margin-bottom: ${(props) => props.theme.spacing[8]};
+
+  ${breakpoint("md")`
+    margin-bottom: ${(props) => props.theme.spacing[0]};
+  `}
+`;
+
 const RecidivizBranding = styled.img``;
 
 const FooterLegalese = styled.span`
-  margin-left: ${(props) => props.theme.spacing[8]};
+  display: block;
+
+  ${breakpoint("md")`
+    display: inline;
+    margin-left: ${(props) => props.theme.spacing[8]};
+  `}
 `;
 
 const PrivacyLink = styled.a`

--- a/src/pill/LinkPill.js
+++ b/src/pill/LinkPill.js
@@ -10,14 +10,16 @@ const LinkPillContainer = styled(PillContainer)`
   }
 `;
 
+const LinkPillLink = styled.a``;
+
 const LinkPillValue = styled(PillValue)``;
 
 export default function LinkControl({ href, children }) {
   return (
     <LinkPillContainer>
-      <a href={href}>
+      <LinkPillLink href={href}>
         <LinkPillValue>{children}</LinkPillValue>
-      </a>
+      </LinkPillLink>
     </LinkPillContainer>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10838,6 +10838,11 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+styled-components-breakpoint@^3.0.0-preview.20:
+  version "3.0.0-preview.20"
+  resolved "https://registry.yarnpkg.com/styled-components-breakpoint/-/styled-components-breakpoint-3.0.0-preview.20.tgz#877e88a00c0cf66976f610a1d347839a1a0b6d70"
+  integrity sha512-rZ+Upo9lJfzK4xXRZxlvAsT90jaONa5VtoNT18fXaMLd+J75vCD1MU4/pwT/Y5Jw4rzGztMtZpelVC6P+AuNeA==
+
 styled-components@^5, styled-components@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.1.tgz#96dfb02a8025794960863b9e8e365e3b6be5518d"


### PR DESCRIPTION
## Description of the change

This PR is not meant to be merged but is rather meant to facilitate a discussion by way of an example.  The code shown here proposes a possible solution for managing responsive CSS code within our styled-components setup.  The specific example shows the incomplete, but illustrative code for a responsive footer.  The visual output is as follows:

**Desktop**

<img width="1680" alt="Screen Shot 2020-07-08 at 10 42 11 PM" src="https://user-images.githubusercontent.com/25503/87041385-29f49d80-c1c0-11ea-9926-5bdff6a355f2.png">

**Mobile Device**

<img width="375" alt="Screen Shot 2020-07-09 at 8 29 06 AM" src="https://user-images.githubusercontent.com/25503/87041401-2eb95180-c1c0-11ea-85f8-18b5ae2bfcaa.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
