### PR TITLE
Revocation data breakdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@accessible/slider": "^2.0.2",
     "@reach/router": "^1.3.4",
+    "case": "^1.6.3",
     "classnames": "^2.2.6",
     "d3-array": "^2.4.0",
     "d3-force": "^2.0.1",
@@ -26,6 +27,7 @@
     "react-scripts": "3.4.1",
     "react-simple-maps": "^2.1.2",
     "semiotic": "^1.20.5",
+    "set-order": "^0.3.5",
     "styled-components": "^5.1.1",
     "styled-normalize": "^8.0.7",
     "topojson": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@accessible/slider": "^2.0.2",
     "@reach/router": "^1.3.4",
-    "case": "^1.6.3",
     "classnames": "^2.2.6",
     "d3-array": "^2.4.0",
     "d3-force": "^2.0.1",

--- a/src/bubble-chart/BubbleChart.js
+++ b/src/bubble-chart/BubbleChart.js
@@ -27,7 +27,7 @@ const BubbleValueLabel = styled.text`
 `;
 
 export default function BubbleChart({ data: initialData, height, width }) {
-  const data = getDataWithPct(initialData);
+  const data = getDataWithPct(initialData).filter(({ value }) => value > 0);
 
   const vizWidth = width - margin.left - margin.right;
   const vizHeight = height - margin.top - margin.bottom;

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,11 +34,31 @@ export const DIMENSIONS_LIST = [
   { id: DIMENSION_KEYS.age, label: DIMENSIONS.age },
 ];
 
-export const VIOLATION_TYPES = {
-  ABSCONDED: "Absconsion",
-  FELONY: "New Offense",
-  TECHNICAL: "Technical Violation",
-  EXTERNAL_UNKNOWN: "Unknown Type",
+const VIOLATION_TYPES = {
+  abscond: "abscond",
+  offend: "offend",
+  technical: "technical",
+  unknown: "unknown",
+};
+
+export const VIOLATION_LABELS = {
+  [VIOLATION_TYPES.abscond]: "Absconsion",
+  [VIOLATION_TYPES.offend]: "New Offense",
+  [VIOLATION_TYPES.technical]: "Technical Violation",
+  [VIOLATION_TYPES.unknown]: "Unknown Type",
+};
+
+// these correspond to expected fields in fetched data
+export const VIOLATION_COUNT_KEYS = {
+  [VIOLATION_TYPES.abscond]: "absconsion_count",
+  [VIOLATION_TYPES.offend]: "new_crime_count",
+  [VIOLATION_TYPES.technical]: "technical_count",
+  [VIOLATION_TYPES.unknown]: "unknown_count",
+};
+
+export const SUPERVISION_TYPES = {
+  parole: "PAROLE",
+  probation: "PROBATION",
 };
 
 export const CONTAINER_WIDTH = 1144;
@@ -83,10 +103,10 @@ export const THEME = {
     pillValue: darkGray,
     tooltipBackground: "#132c52",
     violationReasons: {
-      ABSCONDED: "#327672",
-      FELONY: "#659795",
-      TECHNICAL: darkGreen,
-      EXTERNAL_UNKNOWN: "#97b9b7",
+      [VIOLATION_TYPES.abscond]: "#327672",
+      [VIOLATION_TYPES.offend]: "#659795",
+      [VIOLATION_TYPES.technical]: darkGreen,
+      [VIOLATION_TYPES.unknown]: "#97b9b7",
     },
   },
   fonts: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,24 +14,28 @@ export const DIMENSION_KEYS = {
   age: "age",
   gender: "gender",
   race: "race",
-  raceAndGender: "raceAndGender",
   total: "total",
 };
 
-const DIMENSIONS = {
+// these correspond to fields in fetched data
+export const DIMENSION_DATA_KEYS = {
+  [DIMENSION_KEYS.age]: "age_bucket",
+  [DIMENSION_KEYS.gender]: "gender",
+  [DIMENSION_KEYS.race]: "race_or_ethnicity",
+};
+
+const DIMENSION_LABELS = {
   [DIMENSION_KEYS.age]: "Age",
   [DIMENSION_KEYS.gender]: "Gender",
   [DIMENSION_KEYS.race]: "Race",
-  [DIMENSION_KEYS.raceAndGender]: "Race & Gender",
   [DIMENSION_KEYS.total]: "Total",
 };
 
 export const DIMENSIONS_LIST = [
-  { id: DIMENSION_KEYS.total, label: DIMENSIONS.total },
-  { id: DIMENSION_KEYS.race, label: DIMENSIONS.race },
-  { id: DIMENSION_KEYS.gender, label: DIMENSIONS.gender },
-  { id: DIMENSION_KEYS.raceAndGender, label: DIMENSIONS.raceAndGender },
-  { id: DIMENSION_KEYS.age, label: DIMENSIONS.age },
+  { id: DIMENSION_KEYS.total, label: DIMENSION_LABELS.total },
+  { id: DIMENSION_KEYS.race, label: DIMENSION_LABELS.race },
+  { id: DIMENSION_KEYS.gender, label: DIMENSION_LABELS.gender },
+  { id: DIMENSION_KEYS.age, label: DIMENSION_LABELS.age },
 ];
 
 const VIOLATION_TYPES = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -65,17 +65,35 @@ export const SUPERVISION_TYPES = {
   probation: "PROBATION",
 };
 
+export const DEMOGRAPHIC_OTHER = "OTHER";
+
+export const DEMOGRAPHIC_UNKNOWN = "EXTERNAL_UNKNOWN";
+
+const DEMOGRAPHIC_UNKNOWN_MAPPING = {
+  [DEMOGRAPHIC_UNKNOWN]: "Unknown",
+};
+
+export const AGE_KEYS = {
+  under25: "<25",
+  "25_29": "25-29",
+  "30_34": "30-34",
+  "35_39": "35-39",
+  over40: "40<",
+};
+
 export const AGES = {
-  "<25": "<25",
-  "25-29": "25-29",
-  "30-34": "30-34",
-  "35-39": "35-39",
-  "40<": "40<",
+  [AGE_KEYS.under25]: "<25",
+  [AGE_KEYS["25_29"]]: "25-29",
+  [AGE_KEYS["30_34"]]: "30-34",
+  [AGE_KEYS["35_39"]]: "35-39",
+  [AGE_KEYS.over40]: "40<",
+  ...DEMOGRAPHIC_UNKNOWN_MAPPING,
 };
 
 export const GENDERS = {
   FEMALE: "Female",
   MALE: "Male",
+  ...DEMOGRAPHIC_UNKNOWN_MAPPING,
 };
 
 export const RACES = {
@@ -84,9 +102,15 @@ export const RACES = {
   BLACK: "Black",
   HISPANIC: "Hispanic",
   NATIVE_HAWAIIAN_PACIFIC_ISLANDER: "Native Hawaiian or Pacific Islander",
-  OTHER: "Other",
+  [DEMOGRAPHIC_OTHER]: "Other",
   WHITE: "White",
 };
+
+export const DIMENSION_MAPPINGS = new Map([
+  [DIMENSION_KEYS.gender, GENDERS],
+  [DIMENSION_KEYS.age, AGES],
+  [DIMENSION_KEYS.race, RACES],
+]);
 
 export const CONTAINER_WIDTH = 1144;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ export const DIMENSION_DATA_KEYS = {
   [DIMENSION_KEYS.race]: "race_or_ethnicity",
 };
 
-const DIMENSION_LABELS = {
+export const DIMENSION_LABELS = {
   [DIMENSION_KEYS.age]: "Age",
   [DIMENSION_KEYS.gender]: "Gender",
   [DIMENSION_KEYS.race]: "Race",
@@ -63,6 +63,29 @@ export const VIOLATION_COUNT_KEYS = {
 export const SUPERVISION_TYPES = {
   parole: "PAROLE",
   probation: "PROBATION",
+};
+
+export const AGES = {
+  "<25": "<25",
+  "25-29": "25-29",
+  "30-34": "30-34",
+  "35-39": "35-39",
+  "40<": "40<",
+};
+
+export const GENDERS = {
+  FEMALE: "Female",
+  MALE: "Male",
+};
+
+export const RACES = {
+  AMERICAN_INDIAN_ALASKAN_NATIVE: "American Indian or Alaskan Native",
+  ASIAN: "Asian",
+  BLACK: "Black",
+  HISPANIC: "Hispanic",
+  NATIVE_HAWAIIAN_PACIFIC_ISLANDER: "Native Hawaiian or Pacific Islander",
+  OTHER: "Other",
+  WHITE: "White",
 };
 
 export const CONTAINER_WIDTH = 1144;

--- a/src/page-parole/PageParole.js
+++ b/src/page-parole/PageParole.js
@@ -6,9 +6,10 @@ import parolePopulationData from "../assets/test_data/US_ND_parole_population_by
 // eslint-disable-next-line import/no-unresolved
 import paroleDistrictOffices from "../assets/test_data/US_ND_site_offices.json";
 // eslint-disable-next-line import/no-unresolved
-import paroleRevocationByMonth from "../assets/test_data/US_ND_parole_revocations_by_month_by_type_by_demographics.json";
+import supervisionRevocationByMonth from "../assets/test_data/US_ND_supervision_revocations_by_month_by_type_by_demographics.json";
 import VizParolePopulation from "../viz-parole-population";
 import VizParoleRevocation from "../viz-parole-revocation";
+import { SUPERVISION_TYPES } from "../constants";
 
 const TITLE = "Parole";
 const DESCRIPTION = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -48,7 +49,11 @@ const SECTIONS = [
     showDimensionControl: true,
     showMonthControl: true,
     VizComponent: VizParoleRevocation,
-    vizData: { paroleRevocationByMonth },
+    vizData: {
+      paroleRevocationByMonth: supervisionRevocationByMonth.filter(
+        (record) => record.supervision_type === SUPERVISION_TYPES.parole
+      ),
+    },
   },
   {
     title: "Free Through Recovery Program",

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -49,7 +49,7 @@ const ProportionalBarTooltipText = styled.p`
 // the chart height will adjust as necessary
 const INITIAL_METADATA_HEIGHT = 28;
 
-export default function ProportionalBar({ data, title }) {
+export default function ProportionalBar({ data, showLegend, title }) {
   // to both avoid janky chart animations and avoid height overflows
   // when the legend wraps to multiple lines, we need to measure its height
   // explicitly to determine the chart height
@@ -105,7 +105,7 @@ export default function ProportionalBar({ data, title }) {
         {({ measureRef }) => (
           <ProportionalBarMetadata ref={measureRef}>
             <ProportionalBarTitle>{title}</ProportionalBarTitle>
-            <ColorLegend items={data} />
+            {showLegend && <ColorLegend items={data} />}
           </ProportionalBarMetadata>
         )}
       </Measure>
@@ -121,5 +121,10 @@ ProportionalBar.propTypes = {
       color: PropTypes.string.isRequired,
     })
   ).isRequired,
+  showLegend: PropTypes.bool,
   title: PropTypes.string.isRequired,
+};
+
+ProportionalBar.defaultProps = {
+  showLegend: true,
 };

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -26,7 +26,7 @@ const ProportionalBarMetadata = styled.figcaption`
   bottom: 0;
   display: flex;
   justify-content: space-between;
-  padding-top: 10px;
+  padding-top: 4px;
   position: absolute;
   width: 100%;
   z-index: ${(props) => props.theme.zIndex.base};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+// Jest may require this for e.g. regenerator runtime
+import "react-app-polyfill/stable";

--- a/src/utils/demographicsAscending.js
+++ b/src/utils/demographicsAscending.js
@@ -1,0 +1,13 @@
+import { ascending } from "d3-array";
+import { exact, head, tail } from "set-order";
+
+// demographic values have various special values that should be sorted
+// non-alphabetically for display
+const sortFn = exact(
+  [head("<25"), tail("OTHER"), tail("EXTERNAL_UNKNOWN")],
+  ascending
+);
+
+export default function demographicsAscending(a, b) {
+  return sortFn(a, b);
+}

--- a/src/utils/demographicsAscending.js
+++ b/src/utils/demographicsAscending.js
@@ -1,10 +1,11 @@
 import { ascending } from "d3-array";
 import { exact, head, tail } from "set-order";
+import { AGE_KEYS, DEMOGRAPHIC_OTHER, DEMOGRAPHIC_UNKNOWN } from "../constants";
 
 // demographic values have various special values that should be sorted
 // non-alphabetically for display
 const sortFn = exact(
-  [head("<25"), tail("OTHER"), tail("EXTERNAL_UNKNOWN")],
+  [head(AGE_KEYS.under25), tail(DEMOGRAPHIC_OTHER), tail(DEMOGRAPHIC_UNKNOWN)],
   ascending
 );
 

--- a/src/utils/formatDemographicValue.js
+++ b/src/utils/formatDemographicValue.js
@@ -1,0 +1,14 @@
+import { title } from "case";
+
+const CUSTOM_DEMOGRAPHIC_VALUES = {
+  EXTERNAL_UNKNOWN: "Unknown",
+};
+
+const NUMBER_RANGE_PATTERN = /<?\d+(-\d+|<)?/;
+
+export default function formatDemographicValue(val) {
+  return (
+    CUSTOM_DEMOGRAPHIC_VALUES[val] ||
+    (NUMBER_RANGE_PATTERN.test(val) ? val : title(val))
+  );
+}

--- a/src/utils/formatDemographicValue.js
+++ b/src/utils/formatDemographicValue.js
@@ -1,14 +1,5 @@
-import { title } from "case";
+import { DIMENSION_MAPPINGS } from "../constants";
 
-const CUSTOM_DEMOGRAPHIC_VALUES = {
-  EXTERNAL_UNKNOWN: "Unknown",
-};
-
-const NUMBER_RANGE_PATTERN = /<?\d+(-\d+|<)?/;
-
-export default function formatDemographicValue(val) {
-  return (
-    CUSTOM_DEMOGRAPHIC_VALUES[val] ||
-    (NUMBER_RANGE_PATTERN.test(val) ? val : title(val))
-  );
+export default function formatDemographicValue(val, dimensionType) {
+  return DIMENSION_MAPPINGS.get(dimensionType)[val];
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,5 @@
+export { default as demographicsAscending } from "./demographicsAscending";
 export { default as formatAsPct } from "./formatAsPct";
+export { default as formatDemographicValue } from "./formatDemographicValue";
 export { default as getDataWithPct } from "./getDataWithPct";
+export { default as recordIsTotal } from "./recordIsTotal";

--- a/src/utils/recordIsTotal.js
+++ b/src/utils/recordIsTotal.js
@@ -1,0 +1,9 @@
+import { DIMENSION_DATA_KEYS, TOTAL_KEY } from "../constants";
+
+export default function recordIsTotal(record) {
+  return (
+    record[DIMENSION_DATA_KEYS.race] === TOTAL_KEY &&
+    record[DIMENSION_DATA_KEYS.gender] === TOTAL_KEY &&
+    record[DIMENSION_DATA_KEYS.age] === TOTAL_KEY
+  );
+}

--- a/src/viz-parole-population/VizParolePopulation.js
+++ b/src/viz-parole-population/VizParolePopulation.js
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
-import { TOTAL_KEY } from "../constants";
 import StateDistrictMap from "../state-district-map";
+import { recordIsTotal } from "../utils";
 
 const VizParolePopulationContainer = styled.div`
   display: flex;
@@ -27,12 +27,7 @@ export default function VizParolePopulation({
   onDistrictClick,
 }) {
   const districtTotals = populationDemographics
-    .filter(
-      (record) =>
-        record.race_or_ethnicity === TOTAL_KEY &&
-        record.gender === TOTAL_KEY &&
-        record.age_bucket === TOTAL_KEY
-    )
+    .filter(recordIsTotal)
     .map((record) => {
       const districtData = districtOffices.find(
         // these are stored as both strings and numbers;

--- a/src/viz-parole-revocation/VizParoleRevocation.js
+++ b/src/viz-parole-revocation/VizParoleRevocation.js
@@ -31,12 +31,12 @@ const BreakdownBarWrapper = styled.div`
   padding-bottom: 24px;
 `;
 
-function Breakdowns({ data }) {
+function Breakdowns({ data, dimension }) {
   const breakdownHeight = HEIGHT / data.size;
   return Array.from(data, ([key, value], i) => (
     <BreakdownBarWrapper key={key} height={breakdownHeight}>
       <ProportionalBar
-        title={formatDemographicValue(key)}
+        title={formatDemographicValue(key, dimension)}
         data={value}
         showLegend={i === data.size - 1}
       />
@@ -64,7 +64,7 @@ function VizParoleRevocation({ currentMonthData, dimension }) {
                 />
               )
             ) : (
-              <Breakdowns data={currentMonthData} />
+              <Breakdowns data={currentMonthData} dimension={dimension} />
             )}
           </VizParoleRevocationWrapper>
         );

--- a/src/viz-parole-revocation/VizParoleRevocation.js
+++ b/src/viz-parole-revocation/VizParoleRevocation.js
@@ -28,7 +28,7 @@ const VizParoleRevocationWrapper = styled.div`
 
 const BreakdownBarWrapper = styled.div`
   height: ${(props) => props.height}px;
-  padding-bottom: 16px;
+  padding-bottom: 24px;
 `;
 
 function Breakdowns({ data }) {

--- a/src/viz-parole-revocation/VizParoleRevocation.js
+++ b/src/viz-parole-revocation/VizParoleRevocation.js
@@ -28,13 +28,19 @@ const VizParoleRevocationWrapper = styled.div`
 
 const BreakdownBarWrapper = styled.div`
   height: ${(props) => props.height}px;
-  padding-bottom: 24px;
+  padding-bottom: 16px;
+  position: relative;
+  z-index: ${(props) => props.theme.zIndex.base + props.stackOrder};
 `;
 
 function Breakdowns({ data, dimension }) {
   const breakdownHeight = HEIGHT / data.size;
   return Array.from(data, ([key, value], i) => (
-    <BreakdownBarWrapper key={key} height={breakdownHeight}>
+    <BreakdownBarWrapper
+      key={key}
+      height={breakdownHeight}
+      stackOrder={data.size - i}
+    >
       <ProportionalBar
         title={formatDemographicValue(key, dimension)}
         data={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,6 +2527,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bi-cycle@~0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/bi-cycle/-/bi-cycle-0.1.6.tgz#2c52a0a04b7ac1fe9119d0c2fa86a5447357876b"
+  integrity sha1-LFKgoEt6wf6RGdDC+oalRHNXh2s=
+  dependencies:
+    ramda "^0.21.0"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2898,6 +2905,11 @@ case-sensitive-paths-webpack-plugin@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
   integrity sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==
+
+case@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -7860,10 +7872,15 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@0.11.4:
+object-path@0.11.4, object-path@~0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
   integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+
+object-path@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.6.0.tgz#b69a7d110937934f336ca561fd9be1ad7b7e0cb7"
+  integrity sha1-tpp9EQk3k08zbKVh/ZvhrXt+DLc=
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -9347,6 +9364,16 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
+  integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
+
+ramda@~0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
+  integrity sha1-zNE//3NJepOXTj6GMnv9h71ujis=
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10240,6 +10267,16 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
+set-order@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/set-order/-/set-order-0.3.5.tgz#cbd94f474d145589f6e3ffd7cdcb6e30a72df1e7"
+  integrity sha512-xAfgbYACNiLitc8viSo7Nh/k46W05CNYrizV3tzTTlyRDtF+rSXMZFYWu8cCPNX2JYxYCDlmovQiJLpId0SNRw==
+  dependencies:
+    bi-cycle "~0.1.6"
+    object-path "~0.11.4"
+    ramda "~0.23.0"
+    sort-by "~1.2.0"
+
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -10445,6 +10482,13 @@ sockjs@0.3.19:
   dependencies:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
+
+sort-by@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sort-by/-/sort-by-1.2.0.tgz#ed92bbff9fd2284b41f6503e38496607b225fe6f"
+  integrity sha1-7ZK7/5/SKEtB9lA+OElmB7Il/m8=
+  dependencies:
+    object-path "0.6.0"
 
 sort-keys@^1.0.0:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,11 +2906,6 @@ case-sensitive-paths-webpack-plugin@2.3.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
   integrity sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==
 
-case@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
-  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
## Description of the change

Displays demographic breakdowns for monthly revocation data as a set of proportional bar charts (at a fixed height with the number of charts changing to match the number of categories present in the current dimension+month selection).

![Screen Shot 2020-07-13 at 11 23 17 AM](https://user-images.githubusercontent.com/5385319/87340308-b96db980-c4fc-11ea-9d11-8244a016fd9a.png)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #17

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
