### PR TITLE
Timeseries for parole success metrics

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,8 +10,9 @@
       "error",
       { "declaration": false, "assignment": false }
     ],
-    // this doesn't always play nice with prettier; let prettier win
-    "react/jsx-one-expression-per-line": 0
+    // these rules conflict with prettier; let prettier win
+    "react/jsx-one-expression-per-line": 0,
+    "react/jsx-curly-newline": 0
   },
   "env": {
     "browser": true,

--- a/src/assets/test_data/US_ND_supervision_success_by_month.json
+++ b/src/assets/test_data/US_ND_supervision_success_by_month.json
@@ -1,0 +1,10145 @@
+[
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.505376344086",
+    "projected_completion_count": "93",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "18",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "35",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.739130434783",
+    "projected_completion_count": "46",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "79",
+    "success_rate": "0.79",
+    "projected_completion_count": "100",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.4",
+    "projected_completion_count": "35",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.9375",
+    "projected_completion_count": "16",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.48",
+    "projected_completion_count": "50",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "30",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.329113924051",
+    "projected_completion_count": "79",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.893617021277",
+    "projected_completion_count": "47",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.746835443038",
+    "projected_completion_count": "79",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.607142857143",
+    "projected_completion_count": "28",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.4",
+    "projected_completion_count": "80",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.796610169492",
+    "projected_completion_count": "59",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "1.0",
+    "projected_completion_count": "9",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "1.0",
+    "projected_completion_count": "8",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.722222222222",
+    "projected_completion_count": "36",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.746478873239",
+    "projected_completion_count": "71",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "14",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.85",
+    "projected_completion_count": "40",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.347826086957",
+    "projected_completion_count": "69",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "69",
+    "success_rate": "0.851851851852",
+    "projected_completion_count": "81",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.785714285714",
+    "projected_completion_count": "56",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.9375",
+    "projected_completion_count": "16",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "88",
+    "success_rate": "0.926315789474",
+    "projected_completion_count": "95",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.481927710843",
+    "projected_completion_count": "83",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.646341463415",
+    "projected_completion_count": "82",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.973333333333",
+    "projected_completion_count": "75",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.870588235294",
+    "projected_completion_count": "85",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.386363636364",
+    "projected_completion_count": "88",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.878787878788",
+    "projected_completion_count": "33",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.52380952381",
+    "projected_completion_count": "42",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.971428571429",
+    "projected_completion_count": "35",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.558441558442",
+    "projected_completion_count": "77",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.346153846154",
+    "projected_completion_count": "78",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "60",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.4375",
+    "projected_completion_count": "96",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.461538461538",
+    "projected_completion_count": "13",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "11",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "62",
+    "success_rate": "0.898550724638",
+    "projected_completion_count": "69",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "0.912087912088",
+    "projected_completion_count": "91",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "63",
+    "success_rate": "0.768292682927",
+    "projected_completion_count": "82",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.52",
+    "projected_completion_count": "50",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.608695652174",
+    "projected_completion_count": "46",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.983333333333",
+    "projected_completion_count": "60",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "18",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.6",
+    "projected_completion_count": "70",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.511627906977",
+    "projected_completion_count": "43",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "1.0",
+    "projected_completion_count": "8",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.82",
+    "projected_completion_count": "50",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.86",
+    "projected_completion_count": "50",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.516129032258",
+    "projected_completion_count": "31",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "45",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.430555555556",
+    "projected_completion_count": "72",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.941176470588",
+    "projected_completion_count": "51",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "42",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "93",
+    "success_rate": "0.948979591837",
+    "projected_completion_count": "98",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "1.0",
+    "projected_completion_count": "6",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.5",
+    "projected_completion_count": "14",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.869565217391",
+    "projected_completion_count": "69",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.709677419355",
+    "projected_completion_count": "31",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.934210526316",
+    "projected_completion_count": "76",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "21",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.866666666667",
+    "projected_completion_count": "15",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.9",
+    "projected_completion_count": "20",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.472972972973",
+    "projected_completion_count": "74",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "67",
+    "success_rate": "0.930555555556",
+    "projected_completion_count": "72",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.413043478261",
+    "projected_completion_count": "46",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.742857142857",
+    "projected_completion_count": "70",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.5",
+    "projected_completion_count": "54",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.9",
+    "projected_completion_count": "10",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "97",
+    "success_rate": "0.979797979798",
+    "projected_completion_count": "99",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "54",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.46875",
+    "projected_completion_count": "64",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.903846153846",
+    "projected_completion_count": "52",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "99",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "18",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.6",
+    "projected_completion_count": "5",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.75",
+    "projected_completion_count": "24",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.558139534884",
+    "projected_completion_count": "86",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.377777777778",
+    "projected_completion_count": "90",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.7",
+    "projected_completion_count": "20",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "77",
+    "success_rate": "0.79381443299",
+    "projected_completion_count": "97",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "66",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "60",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.660714285714",
+    "projected_completion_count": "56",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.4",
+    "projected_completion_count": "35",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.83908045977",
+    "projected_completion_count": "87",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.488372093023",
+    "projected_completion_count": "43",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.575757575758",
+    "projected_completion_count": "33",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.704918032787",
+    "projected_completion_count": "61",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.84375",
+    "projected_completion_count": "32",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.757575757576",
+    "projected_completion_count": "33",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.928571428571",
+    "projected_completion_count": "14",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "78",
+    "success_rate": "0.896551724138",
+    "projected_completion_count": "87",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "45",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.7",
+    "projected_completion_count": "10",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.425",
+    "projected_completion_count": "40",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.2",
+    "projected_completion_count": "5",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "1.0",
+    "projected_completion_count": "27",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.375",
+    "projected_completion_count": "40",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.657142857143",
+    "projected_completion_count": "70",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.642857142857",
+    "projected_completion_count": "28",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.722222222222",
+    "projected_completion_count": "36",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.576923076923",
+    "projected_completion_count": "26",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.875",
+    "projected_completion_count": "64",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.779220779221",
+    "projected_completion_count": "77",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.813333333333",
+    "projected_completion_count": "75",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.866666666667",
+    "projected_completion_count": "15",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.494845360825",
+    "projected_completion_count": "97",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.910256410256",
+    "projected_completion_count": "78",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.740740740741",
+    "projected_completion_count": "54",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.814285714286",
+    "projected_completion_count": "70",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.65",
+    "projected_completion_count": "20",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.607142857143",
+    "projected_completion_count": "28",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "80",
+    "success_rate": "0.975609756098",
+    "projected_completion_count": "82",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.721518987342",
+    "projected_completion_count": "79",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.426229508197",
+    "projected_completion_count": "61",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.407407407407",
+    "projected_completion_count": "27",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.315789473684",
+    "projected_completion_count": "38",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.348484848485",
+    "projected_completion_count": "66",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.633333333333",
+    "projected_completion_count": "30",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.743243243243",
+    "projected_completion_count": "74",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.58904109589",
+    "projected_completion_count": "73",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.76",
+    "projected_completion_count": "25",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "84",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.625",
+    "projected_completion_count": "16",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "69",
+    "success_rate": "0.75",
+    "projected_completion_count": "92",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "9",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.372093023256",
+    "projected_completion_count": "43",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "1.0",
+    "projected_completion_count": "49",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.660714285714",
+    "projected_completion_count": "56",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.918032786885",
+    "projected_completion_count": "61",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.75",
+    "projected_completion_count": "4",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "72",
+    "success_rate": "0.827586206897",
+    "projected_completion_count": "87",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.893939393939",
+    "projected_completion_count": "66",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "1.0",
+    "projected_completion_count": "24",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.966666666667",
+    "projected_completion_count": "90",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "7",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.272727272727",
+    "projected_completion_count": "11",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "81",
+    "success_rate": "0.975903614458",
+    "projected_completion_count": "83",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.440677966102",
+    "projected_completion_count": "59",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.814814814815",
+    "projected_completion_count": "27",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.625",
+    "projected_completion_count": "8",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.9375",
+    "projected_completion_count": "64",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.538461538462",
+    "projected_completion_count": "13",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.783333333333",
+    "projected_completion_count": "60",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.536082474227",
+    "projected_completion_count": "97",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.522727272727",
+    "projected_completion_count": "44",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "6",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "63",
+    "success_rate": "0.670212765957",
+    "projected_completion_count": "94",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.830985915493",
+    "projected_completion_count": "71",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.5",
+    "projected_completion_count": "44",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.679012345679",
+    "projected_completion_count": "81",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.878787878788",
+    "projected_completion_count": "99",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.409090909091",
+    "projected_completion_count": "22",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.763440860215",
+    "projected_completion_count": "93",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "18",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.68115942029",
+    "projected_completion_count": "69",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.738636363636",
+    "projected_completion_count": "88",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.285714285714",
+    "projected_completion_count": "7",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.518072289157",
+    "projected_completion_count": "83",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.8",
+    "projected_completion_count": "75",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.696202531646",
+    "projected_completion_count": "79",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.691358024691",
+    "projected_completion_count": "81",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.55223880597",
+    "projected_completion_count": "67",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "9",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.386666666667",
+    "projected_completion_count": "75",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.409090909091",
+    "projected_completion_count": "66",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "24",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "36",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.466666666667",
+    "projected_completion_count": "30",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.43137254902",
+    "projected_completion_count": "51",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.677419354839",
+    "projected_completion_count": "31",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.36170212766",
+    "projected_completion_count": "47",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "11",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "15",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.785714285714",
+    "projected_completion_count": "14",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "1",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.76",
+    "projected_completion_count": "25",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.761904761905",
+    "projected_completion_count": "21",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.75",
+    "projected_completion_count": "12",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "0.902173913043",
+    "projected_completion_count": "92",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.75",
+    "projected_completion_count": "16",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.424242424242",
+    "projected_completion_count": "66",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "1.0",
+    "projected_completion_count": "4",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.541666666667",
+    "projected_completion_count": "96",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.884057971014",
+    "projected_completion_count": "69",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.9",
+    "projected_completion_count": "40",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.628205128205",
+    "projected_completion_count": "78",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "1.0",
+    "projected_completion_count": "4",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "70",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.65",
+    "projected_completion_count": "100",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.744186046512",
+    "projected_completion_count": "86",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "11",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.406976744186",
+    "projected_completion_count": "86",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.675324675325",
+    "projected_completion_count": "77",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "92",
+    "success_rate": "0.92",
+    "projected_completion_count": "100",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "33",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.8",
+    "projected_completion_count": "10",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.655172413793",
+    "projected_completion_count": "87",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "78",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.546666666667",
+    "projected_completion_count": "75",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "94",
+    "success_rate": "0.969072164948",
+    "projected_completion_count": "97",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.604651162791",
+    "projected_completion_count": "43",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.71875",
+    "projected_completion_count": "32",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.764705882353",
+    "projected_completion_count": "51",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "66",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.711111111111",
+    "projected_completion_count": "45",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.354838709677",
+    "projected_completion_count": "31",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.387755102041",
+    "projected_completion_count": "49",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.423529411765",
+    "projected_completion_count": "85",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.5625",
+    "projected_completion_count": "16",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.783783783784",
+    "projected_completion_count": "74",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.944444444444",
+    "projected_completion_count": "36",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.83908045977",
+    "projected_completion_count": "87",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.875",
+    "projected_completion_count": "16",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.828125",
+    "projected_completion_count": "64",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.578947368421",
+    "projected_completion_count": "76",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.463768115942",
+    "projected_completion_count": "69",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.5",
+    "projected_completion_count": "50",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.489130434783",
+    "projected_completion_count": "92",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "24",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.796296296296",
+    "projected_completion_count": "54",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.5",
+    "projected_completion_count": "46",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "1.0",
+    "projected_completion_count": "11",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.927272727273",
+    "projected_completion_count": "55",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.348837209302",
+    "projected_completion_count": "86",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.644444444444",
+    "projected_completion_count": "45",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "18",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.640625",
+    "projected_completion_count": "64",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.528301886792",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "42",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.904761904762",
+    "projected_completion_count": "42",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.65625",
+    "projected_completion_count": "64",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "62",
+    "success_rate": "0.837837837838",
+    "projected_completion_count": "74",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "39",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "11",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.8",
+    "projected_completion_count": "65",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "7",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.443298969072",
+    "projected_completion_count": "97",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.616438356164",
+    "projected_completion_count": "73",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.676056338028",
+    "projected_completion_count": "71",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "52",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.63768115942",
+    "projected_completion_count": "69",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.384615384615",
+    "projected_completion_count": "78",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.25",
+    "projected_completion_count": "4",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.679487179487",
+    "projected_completion_count": "78",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "72",
+    "success_rate": "0.986301369863",
+    "projected_completion_count": "73",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.973684210526",
+    "projected_completion_count": "38",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.641509433962",
+    "projected_completion_count": "53",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.375",
+    "projected_completion_count": "8",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.947368421053",
+    "projected_completion_count": "19",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.84",
+    "projected_completion_count": "50",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.5",
+    "projected_completion_count": "20",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.927536231884",
+    "projected_completion_count": "69",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.916666666667",
+    "projected_completion_count": "36",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.392405063291",
+    "projected_completion_count": "79",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.701298701299",
+    "projected_completion_count": "77",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.569892473118",
+    "projected_completion_count": "93",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.854545454545",
+    "projected_completion_count": "55",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.654320987654",
+    "projected_completion_count": "81",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.358974358974",
+    "projected_completion_count": "39",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.951219512195",
+    "projected_completion_count": "41",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.804347826087",
+    "projected_completion_count": "46",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.622950819672",
+    "projected_completion_count": "61",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.5",
+    "projected_completion_count": "20",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.970588235294",
+    "projected_completion_count": "34",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.738095238095",
+    "projected_completion_count": "42",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.411764705882",
+    "projected_completion_count": "17",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.9125",
+    "projected_completion_count": "80",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "68",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "92",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.846153846154",
+    "projected_completion_count": "13",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.684210526316",
+    "projected_completion_count": "38",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.962962962963",
+    "projected_completion_count": "27",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.870967741935",
+    "projected_completion_count": "31",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.487179487179",
+    "projected_completion_count": "78",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "18",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.397590361446",
+    "projected_completion_count": "83",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.605263157895",
+    "projected_completion_count": "38",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.681818181818",
+    "projected_completion_count": "22",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "51",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.493975903614",
+    "projected_completion_count": "83",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.614583333333",
+    "projected_completion_count": "96",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "11",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.8",
+    "projected_completion_count": "30",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.716666666667",
+    "projected_completion_count": "60",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.607594936709",
+    "projected_completion_count": "79",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.617647058824",
+    "projected_completion_count": "68",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.821428571429",
+    "projected_completion_count": "56",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.547368421053",
+    "projected_completion_count": "95",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.954545454545",
+    "projected_completion_count": "22",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.378048780488",
+    "projected_completion_count": "82",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.528571428571",
+    "projected_completion_count": "70",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "27",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.727272727273",
+    "projected_completion_count": "44",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.609756097561",
+    "projected_completion_count": "41",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "1.0",
+    "projected_completion_count": "40",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.413043478261",
+    "projected_completion_count": "46",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "86",
+    "success_rate": "0.924731182796",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.326086956522",
+    "projected_completion_count": "46",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.861111111111",
+    "projected_completion_count": "36",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.631578947368",
+    "projected_completion_count": "38",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.978260869565",
+    "projected_completion_count": "46",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.565217391304",
+    "projected_completion_count": "46",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.815789473684",
+    "projected_completion_count": "38",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "1.0",
+    "projected_completion_count": "30",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.511627906977",
+    "projected_completion_count": "86",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.986486486486",
+    "projected_completion_count": "74",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.981818181818",
+    "projected_completion_count": "55",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.527777777778",
+    "projected_completion_count": "72",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.4",
+    "projected_completion_count": "15",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.986111111111",
+    "projected_completion_count": "72",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.82",
+    "projected_completion_count": "50",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "51",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "63",
+    "success_rate": "0.984375",
+    "projected_completion_count": "64",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.770491803279",
+    "projected_completion_count": "61",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.626865671642",
+    "projected_completion_count": "67",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.378378378378",
+    "projected_completion_count": "37",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.826086956522",
+    "projected_completion_count": "69",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.510638297872",
+    "projected_completion_count": "94",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.318181818182",
+    "projected_completion_count": "22",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "35",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.78125",
+    "projected_completion_count": "96",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.315789473684",
+    "projected_completion_count": "19",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.635294117647",
+    "projected_completion_count": "85",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.517647058824",
+    "projected_completion_count": "85",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.5",
+    "projected_completion_count": "18",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.5",
+    "projected_completion_count": "18",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.390243902439",
+    "projected_completion_count": "41",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.378787878788",
+    "projected_completion_count": "66",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.892307692308",
+    "projected_completion_count": "65",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.464285714286",
+    "projected_completion_count": "28",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.439024390244",
+    "projected_completion_count": "82",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "93",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.986842105263",
+    "projected_completion_count": "76",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.740740740741",
+    "projected_completion_count": "54",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.4",
+    "projected_completion_count": "30",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "62",
+    "success_rate": "0.953846153846",
+    "projected_completion_count": "65",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.789473684211",
+    "projected_completion_count": "95",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "23",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.479166666667",
+    "projected_completion_count": "48",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "68",
+    "success_rate": "0.8",
+    "projected_completion_count": "85",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "96",
+    "success_rate": "0.989690721649",
+    "projected_completion_count": "97",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "27",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "13",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.693548387097",
+    "projected_completion_count": "62",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "12",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.590163934426",
+    "projected_completion_count": "61",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "9",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.722891566265",
+    "projected_completion_count": "83",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.84126984127",
+    "projected_completion_count": "63",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.619047619048",
+    "projected_completion_count": "21",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "81",
+    "success_rate": "0.910112359551",
+    "projected_completion_count": "89",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "22",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.746478873239",
+    "projected_completion_count": "71",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.340659340659",
+    "projected_completion_count": "91",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.431578947368",
+    "projected_completion_count": "95",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.685185185185",
+    "projected_completion_count": "54",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.934782608696",
+    "projected_completion_count": "46",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "23",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.566265060241",
+    "projected_completion_count": "83",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "14",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.681818181818",
+    "projected_completion_count": "22",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.653333333333",
+    "projected_completion_count": "75",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.849056603774",
+    "projected_completion_count": "53",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.760869565217",
+    "projected_completion_count": "46",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.9",
+    "projected_completion_count": "20",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.684210526316",
+    "projected_completion_count": "57",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.965517241379",
+    "projected_completion_count": "29",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.294117647059",
+    "projected_completion_count": "17",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "45",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.39175257732",
+    "projected_completion_count": "97",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.641791044776",
+    "projected_completion_count": "67",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.583333333333",
+    "projected_completion_count": "96",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.894736842105",
+    "projected_completion_count": "38",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.554347826087",
+    "projected_completion_count": "92",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "95",
+    "success_rate": "0.959595959596",
+    "projected_completion_count": "99",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.25",
+    "projected_completion_count": "8",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.528301886792",
+    "projected_completion_count": "53",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.795698924731",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.556962025316",
+    "projected_completion_count": "79",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.603174603175",
+    "projected_completion_count": "63",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.804347826087",
+    "projected_completion_count": "92",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "1.0",
+    "projected_completion_count": "83",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.720588235294",
+    "projected_completion_count": "68",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.465909090909",
+    "projected_completion_count": "88",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.88",
+    "projected_completion_count": "25",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.344827586207",
+    "projected_completion_count": "29",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.597222222222",
+    "projected_completion_count": "72",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "13",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.432432432432",
+    "projected_completion_count": "37",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.8",
+    "projected_completion_count": "10",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "1.0",
+    "projected_completion_count": "4",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "75",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "1.0",
+    "projected_completion_count": "29",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.602409638554",
+    "projected_completion_count": "83",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "68",
+    "success_rate": "0.731182795699",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.56976744186",
+    "projected_completion_count": "86",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.410256410256",
+    "projected_completion_count": "39",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "7",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "67",
+    "success_rate": "0.779069767442",
+    "projected_completion_count": "86",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.585106382979",
+    "projected_completion_count": "94",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.644736842105",
+    "projected_completion_count": "76",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.546875",
+    "projected_completion_count": "64",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.380952380952",
+    "projected_completion_count": "21",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "12",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.851063829787",
+    "projected_completion_count": "47",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.421052631579",
+    "projected_completion_count": "19",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "1.0",
+    "projected_completion_count": "25",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "12",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.595238095238",
+    "projected_completion_count": "84",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "88",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.791666666667",
+    "projected_completion_count": "24",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "13",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.46511627907",
+    "projected_completion_count": "86",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.458333333333",
+    "projected_completion_count": "24",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.884615384615",
+    "projected_completion_count": "52",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "66",
+    "success_rate": "1.0",
+    "projected_completion_count": "66",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "12",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "66",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.672413793103",
+    "projected_completion_count": "58",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.736842105263",
+    "projected_completion_count": "19",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.782608695652",
+    "projected_completion_count": "23",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.347826086957",
+    "projected_completion_count": "23",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.382352941176",
+    "projected_completion_count": "34",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.535714285714",
+    "projected_completion_count": "28",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.878048780488",
+    "projected_completion_count": "41",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.578313253012",
+    "projected_completion_count": "83",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "15",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "62",
+    "success_rate": "0.953846153846",
+    "projected_completion_count": "65",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.574074074074",
+    "projected_completion_count": "54",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "77",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "12",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "89",
+    "success_rate": "1.0",
+    "projected_completion_count": "89",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "84",
+    "success_rate": "0.903225806452",
+    "projected_completion_count": "93",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "24",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.954545454545",
+    "projected_completion_count": "22",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.629032258065",
+    "projected_completion_count": "62",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.44776119403",
+    "projected_completion_count": "67",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "27",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.875",
+    "projected_completion_count": "32",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.5",
+    "projected_completion_count": "14",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.583333333333",
+    "projected_completion_count": "12",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.744897959184",
+    "projected_completion_count": "98",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "2",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.375",
+    "projected_completion_count": "96",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.555555555556",
+    "projected_completion_count": "18",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.5",
+    "projected_completion_count": "32",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.809523809524",
+    "projected_completion_count": "21",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.6875",
+    "projected_completion_count": "48",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "9",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "82",
+    "success_rate": "0.987951807229",
+    "projected_completion_count": "83",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.5",
+    "projected_completion_count": "20",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "11",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.515625",
+    "projected_completion_count": "64",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.392857142857",
+    "projected_completion_count": "84",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.573770491803",
+    "projected_completion_count": "61",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.610526315789",
+    "projected_completion_count": "95",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.652173913043",
+    "projected_completion_count": "46",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.548387096774",
+    "projected_completion_count": "31",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "1.0",
+    "projected_completion_count": "70",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.691358024691",
+    "projected_completion_count": "81",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.423076923077",
+    "projected_completion_count": "26",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "23",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.755555555556",
+    "projected_completion_count": "45",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "18",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "79",
+    "success_rate": "0.887640449438",
+    "projected_completion_count": "89",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.561224489796",
+    "projected_completion_count": "98",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.697674418605",
+    "projected_completion_count": "86",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.655737704918",
+    "projected_completion_count": "61",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.681818181818",
+    "projected_completion_count": "66",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.652173913043",
+    "projected_completion_count": "23",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "26",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.947368421053",
+    "projected_completion_count": "57",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.568181818182",
+    "projected_completion_count": "88",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.405405405405",
+    "projected_completion_count": "74",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.661538461538",
+    "projected_completion_count": "65",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.717647058824",
+    "projected_completion_count": "85",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.866666666667",
+    "projected_completion_count": "15",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.515151515152",
+    "projected_completion_count": "99",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.35",
+    "projected_completion_count": "80",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.349397590361",
+    "projected_completion_count": "83",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.821428571429",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.632653061224",
+    "projected_completion_count": "49",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.916666666667",
+    "projected_completion_count": "36",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.8125",
+    "projected_completion_count": "32",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.611111111111",
+    "projected_completion_count": "36",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.795918367347",
+    "projected_completion_count": "49",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.346153846154",
+    "projected_completion_count": "26",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "77",
+    "success_rate": "0.802083333333",
+    "projected_completion_count": "96",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.622641509434",
+    "projected_completion_count": "53",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "11",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "1.0",
+    "projected_completion_count": "28",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "42",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.652173913043",
+    "projected_completion_count": "92",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.384615384615",
+    "projected_completion_count": "39",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.816326530612",
+    "projected_completion_count": "49",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.431034482759",
+    "projected_completion_count": "58",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "33",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "30",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "6",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.373626373626",
+    "projected_completion_count": "91",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "76",
+    "success_rate": "0.974358974359",
+    "projected_completion_count": "78",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.684210526316",
+    "projected_completion_count": "19",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "1",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.4",
+    "projected_completion_count": "10",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.375",
+    "projected_completion_count": "64",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.388888888889",
+    "projected_completion_count": "36",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.357142857143",
+    "projected_completion_count": "14",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.679012345679",
+    "projected_completion_count": "81",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.688524590164",
+    "projected_completion_count": "61",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.526315789474",
+    "projected_completion_count": "19",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.466666666667",
+    "projected_completion_count": "15",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.75",
+    "projected_completion_count": "4",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.652173913043",
+    "projected_completion_count": "23",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.621951219512",
+    "projected_completion_count": "82",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.7",
+    "projected_completion_count": "50",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.783783783784",
+    "projected_completion_count": "37",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.75",
+    "projected_completion_count": "12",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.941176470588",
+    "projected_completion_count": "17",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "1.0",
+    "projected_completion_count": "3",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.9",
+    "projected_completion_count": "10",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.88",
+    "projected_completion_count": "50",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.541666666667",
+    "projected_completion_count": "72",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "72",
+    "success_rate": "0.765957446809",
+    "projected_completion_count": "94",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.5",
+    "projected_completion_count": "36",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "48",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.646153846154",
+    "projected_completion_count": "65",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "78",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.632183908046",
+    "projected_completion_count": "87",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.542168674699",
+    "projected_completion_count": "83",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.307692307692",
+    "projected_completion_count": "26",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.347826086957",
+    "projected_completion_count": "46",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.40243902439",
+    "projected_completion_count": "82",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.6",
+    "projected_completion_count": "25",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "9",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.9375",
+    "projected_completion_count": "16",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "30",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.6",
+    "projected_completion_count": "90",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.494117647059",
+    "projected_completion_count": "85",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.510638297872",
+    "projected_completion_count": "47",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.614035087719",
+    "projected_completion_count": "57",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "1.0",
+    "projected_completion_count": "56",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.6",
+    "projected_completion_count": "5",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.717948717949",
+    "projected_completion_count": "78",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.824175824176",
+    "projected_completion_count": "91",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.344444444444",
+    "projected_completion_count": "90",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.420289855072",
+    "projected_completion_count": "69",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.340909090909",
+    "projected_completion_count": "88",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.35",
+    "projected_completion_count": "60",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.928571428571",
+    "projected_completion_count": "14",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.46",
+    "projected_completion_count": "50",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.74358974359",
+    "projected_completion_count": "78",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "78",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.342105263158",
+    "projected_completion_count": "76",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "1.0",
+    "projected_completion_count": "58",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "55",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.48",
+    "projected_completion_count": "25",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "45",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.344827586207",
+    "projected_completion_count": "58",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.756756756757",
+    "projected_completion_count": "37",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.8125",
+    "projected_completion_count": "32",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.753246753247",
+    "projected_completion_count": "77",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.75",
+    "projected_completion_count": "20",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "15",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.75",
+    "projected_completion_count": "4",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.323529411765",
+    "projected_completion_count": "34",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.747126436782",
+    "projected_completion_count": "87",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.977528089888",
+    "projected_completion_count": "89",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.766233766234",
+    "projected_completion_count": "77",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "15",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.7375",
+    "projected_completion_count": "80",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.5875",
+    "projected_completion_count": "80",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "6",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.784615384615",
+    "projected_completion_count": "65",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.6",
+    "projected_completion_count": "95",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "1.0",
+    "projected_completion_count": "8",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.5125",
+    "projected_completion_count": "80",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "1.0",
+    "projected_completion_count": "9",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.45652173913",
+    "projected_completion_count": "46",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.45",
+    "projected_completion_count": "20",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "3",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.488372093023",
+    "projected_completion_count": "86",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "78",
+    "success_rate": "0.962962962963",
+    "projected_completion_count": "81",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.808510638298",
+    "projected_completion_count": "47",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.522222222222",
+    "projected_completion_count": "90",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "24",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.488095238095",
+    "projected_completion_count": "84",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.96",
+    "projected_completion_count": "25",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.307692307692",
+    "projected_completion_count": "13",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.542168674699",
+    "projected_completion_count": "83",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.90625",
+    "projected_completion_count": "64",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.54347826087",
+    "projected_completion_count": "46",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.944444444444",
+    "projected_completion_count": "36",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.459183673469",
+    "projected_completion_count": "98",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.747126436782",
+    "projected_completion_count": "87",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "34",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "60",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.634615384615",
+    "projected_completion_count": "52",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.6875",
+    "projected_completion_count": "48",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "0.932584269663",
+    "projected_completion_count": "89",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.824561403509",
+    "projected_completion_count": "57",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.673076923077",
+    "projected_completion_count": "52",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.652173913043",
+    "projected_completion_count": "69",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.424242424242",
+    "projected_completion_count": "66",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.52808988764",
+    "projected_completion_count": "89",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "28",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.753846153846",
+    "projected_completion_count": "65",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.8",
+    "projected_completion_count": "25",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.538461538462",
+    "projected_completion_count": "13",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.534090909091",
+    "projected_completion_count": "88",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "21",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.642857142857",
+    "projected_completion_count": "70",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.727272727273",
+    "projected_completion_count": "77",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.369565217391",
+    "projected_completion_count": "46",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "39",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.440476190476",
+    "projected_completion_count": "84",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.880952380952",
+    "projected_completion_count": "42",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.964285714286",
+    "projected_completion_count": "28",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.352941176471",
+    "projected_completion_count": "51",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.5",
+    "projected_completion_count": "20",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.587628865979",
+    "projected_completion_count": "97",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "65",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.846153846154",
+    "projected_completion_count": "39",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.6",
+    "projected_completion_count": "50",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "1.0",
+    "projected_completion_count": "37",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.35",
+    "projected_completion_count": "60",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.588235294118",
+    "projected_completion_count": "34",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "28",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.5",
+    "projected_completion_count": "8",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.696202531646",
+    "projected_completion_count": "79",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.771428571429",
+    "projected_completion_count": "35",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.818181818182",
+    "projected_completion_count": "11",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.486486486486",
+    "projected_completion_count": "37",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.509090909091",
+    "projected_completion_count": "55",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "9",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.641791044776",
+    "projected_completion_count": "67",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.75",
+    "projected_completion_count": "100",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.402597402597",
+    "projected_completion_count": "77",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.770833333333",
+    "projected_completion_count": "48",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "55",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.272727272727",
+    "projected_completion_count": "11",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.483870967742",
+    "projected_completion_count": "93",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "0.736842105263",
+    "projected_completion_count": "95",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.864864864865",
+    "projected_completion_count": "37",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "1.0",
+    "projected_completion_count": "13",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.933333333333",
+    "projected_completion_count": "30",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.730158730159",
+    "projected_completion_count": "63",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.357894736842",
+    "projected_completion_count": "95",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.320754716981",
+    "projected_completion_count": "53",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.733333333333",
+    "projected_completion_count": "15",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.553191489362",
+    "projected_completion_count": "47",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "99",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.810344827586",
+    "projected_completion_count": "58",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.742424242424",
+    "projected_completion_count": "66",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.764705882353",
+    "projected_completion_count": "34",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.842105263158",
+    "projected_completion_count": "76",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.872340425532",
+    "projected_completion_count": "47",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.620689655172",
+    "projected_completion_count": "29",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "1.0",
+    "projected_completion_count": "6",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.860465116279",
+    "projected_completion_count": "43",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.612244897959",
+    "projected_completion_count": "49",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.434782608696",
+    "projected_completion_count": "23",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.625",
+    "projected_completion_count": "40",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.565217391304",
+    "projected_completion_count": "46",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.866666666667",
+    "projected_completion_count": "30",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.342857142857",
+    "projected_completion_count": "35",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.35632183908",
+    "projected_completion_count": "87",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "22",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.4",
+    "projected_completion_count": "5",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.692307692308",
+    "projected_completion_count": "65",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.573333333333",
+    "projected_completion_count": "75",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.484536082474",
+    "projected_completion_count": "97",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.466666666667",
+    "projected_completion_count": "15",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.44",
+    "projected_completion_count": "100",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.68",
+    "projected_completion_count": "75",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.380952380952",
+    "projected_completion_count": "21",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.588235294118",
+    "projected_completion_count": "34",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.425",
+    "projected_completion_count": "40",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "22",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.672131147541",
+    "projected_completion_count": "61",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "75",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "34",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.322033898305",
+    "projected_completion_count": "59",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "80",
+    "success_rate": "0.93023255814",
+    "projected_completion_count": "86",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.384615384615",
+    "projected_completion_count": "39",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.34375",
+    "projected_completion_count": "96",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "31",
+    "success_rate": "0.794871794872",
+    "projected_completion_count": "39",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.318181818182",
+    "projected_completion_count": "22",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.627450980392",
+    "projected_completion_count": "51",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.947368421053",
+    "projected_completion_count": "19",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "28",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "1.0",
+    "projected_completion_count": "11",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.329268292683",
+    "projected_completion_count": "82",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "1",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "11",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "0.96511627907",
+    "projected_completion_count": "86",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.550561797753",
+    "projected_completion_count": "89",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.807692307692",
+    "projected_completion_count": "52",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.52808988764",
+    "projected_completion_count": "89",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.342857142857",
+    "projected_completion_count": "70",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.820512820513",
+    "projected_completion_count": "39",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "63",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "81",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.643835616438",
+    "projected_completion_count": "73",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.7625",
+    "projected_completion_count": "80",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.932203389831",
+    "projected_completion_count": "59",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.373333333333",
+    "projected_completion_count": "75",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.904761904762",
+    "projected_completion_count": "21",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.575757575758",
+    "projected_completion_count": "99",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.388888888889",
+    "projected_completion_count": "36",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.795454545455",
+    "projected_completion_count": "44",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.485294117647",
+    "projected_completion_count": "68",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.461538461538",
+    "projected_completion_count": "13",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.8",
+    "projected_completion_count": "50",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.875",
+    "projected_completion_count": "8",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.533333333333",
+    "projected_completion_count": "90",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.830508474576",
+    "projected_completion_count": "59",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.588235294118",
+    "projected_completion_count": "17",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.741935483871",
+    "projected_completion_count": "31",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.6",
+    "projected_completion_count": "5",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.816326530612",
+    "projected_completion_count": "49",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "63",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.782051282051",
+    "projected_completion_count": "78",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "40",
+    "success_rate": "0.459770114943",
+    "projected_completion_count": "87",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.862068965517",
+    "projected_completion_count": "87",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.469135802469",
+    "projected_completion_count": "81",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.55",
+    "projected_completion_count": "40",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.7",
+    "projected_completion_count": "10",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.457627118644",
+    "projected_completion_count": "59",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.611111111111",
+    "projected_completion_count": "36",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.506666666667",
+    "projected_completion_count": "75",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.768115942029",
+    "projected_completion_count": "69",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "9",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "7",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.491525423729",
+    "projected_completion_count": "59",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "18",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "0.958904109589",
+    "projected_completion_count": "73",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.928571428571",
+    "projected_completion_count": "14",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "30",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.9",
+    "projected_completion_count": "20",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.708333333333",
+    "projected_completion_count": "48",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.4",
+    "projected_completion_count": "40",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.602272727273",
+    "projected_completion_count": "88",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "69",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.779661016949",
+    "projected_completion_count": "59",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "78",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.452830188679",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.4",
+    "projected_completion_count": "15",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.5",
+    "projected_completion_count": "24",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.492307692308",
+    "projected_completion_count": "65",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.452830188679",
+    "projected_completion_count": "53",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.415094339623",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.47",
+    "projected_completion_count": "100",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.5625",
+    "projected_completion_count": "32",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "66",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.466666666667",
+    "projected_completion_count": "60",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "2",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.871794871795",
+    "projected_completion_count": "39",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.58064516129",
+    "projected_completion_count": "31",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.393939393939",
+    "projected_completion_count": "33",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.623188405797",
+    "projected_completion_count": "69",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.326923076923",
+    "projected_completion_count": "52",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.75",
+    "projected_completion_count": "56",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.741935483871",
+    "projected_completion_count": "62",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "80",
+    "success_rate": "0.842105263158",
+    "projected_completion_count": "95",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "83",
+    "success_rate": "0.954022988506",
+    "projected_completion_count": "87",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "84",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "33",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.890909090909",
+    "projected_completion_count": "55",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.53",
+    "projected_completion_count": "100",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.756756756757",
+    "projected_completion_count": "74",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "42",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.373333333333",
+    "projected_completion_count": "75",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.460526315789",
+    "projected_completion_count": "76",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.433962264151",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.75",
+    "projected_completion_count": "28",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.901639344262",
+    "projected_completion_count": "61",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.402777777778",
+    "projected_completion_count": "72",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "1.0",
+    "projected_completion_count": "17",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.476744186047",
+    "projected_completion_count": "86",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "62",
+    "success_rate": "0.62",
+    "projected_completion_count": "100",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.468085106383",
+    "projected_completion_count": "47",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "33",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.830769230769",
+    "projected_completion_count": "65",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "24",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.5",
+    "projected_completion_count": "8",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "76",
+    "success_rate": "0.95",
+    "projected_completion_count": "80",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.375",
+    "projected_completion_count": "24",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.934210526316",
+    "projected_completion_count": "76",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.790322580645",
+    "projected_completion_count": "62",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.632183908046",
+    "projected_completion_count": "87",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "94",
+    "success_rate": "0.979166666667",
+    "projected_completion_count": "96",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.430769230769",
+    "projected_completion_count": "65",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.762886597938",
+    "projected_completion_count": "97",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.941176470588",
+    "projected_completion_count": "17",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.884615384615",
+    "projected_completion_count": "26",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "68",
+    "success_rate": "0.739130434783",
+    "projected_completion_count": "92",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.75",
+    "projected_completion_count": "64",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.586956521739",
+    "projected_completion_count": "46",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.369565217391",
+    "projected_completion_count": "46",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "68",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.5",
+    "projected_completion_count": "50",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.924528301887",
+    "projected_completion_count": "53",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.8",
+    "projected_completion_count": "5",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "95",
+    "success_rate": "0.979381443299",
+    "projected_completion_count": "97",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.67032967033",
+    "projected_completion_count": "91",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.625",
+    "projected_completion_count": "8",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.59595959596",
+    "projected_completion_count": "99",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "67",
+    "success_rate": "0.690721649485",
+    "projected_completion_count": "97",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.346153846154",
+    "projected_completion_count": "26",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.358208955224",
+    "projected_completion_count": "67",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.663043478261",
+    "projected_completion_count": "92",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "81",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.5",
+    "projected_completion_count": "10",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "1.0",
+    "projected_completion_count": "3",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.675675675676",
+    "projected_completion_count": "37",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.80487804878",
+    "projected_completion_count": "41",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "72",
+    "success_rate": "0.757894736842",
+    "projected_completion_count": "95",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "77",
+    "success_rate": "0.895348837209",
+    "projected_completion_count": "86",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.507936507937",
+    "projected_completion_count": "63",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.9375",
+    "projected_completion_count": "16",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "85",
+    "success_rate": "0.934065934066",
+    "projected_completion_count": "91",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.463414634146",
+    "projected_completion_count": "41",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.48275862069",
+    "projected_completion_count": "29",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.607142857143",
+    "projected_completion_count": "28",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "14",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.7",
+    "projected_completion_count": "20",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.730158730159",
+    "projected_completion_count": "63",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.47619047619",
+    "projected_completion_count": "21",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.604166666667",
+    "projected_completion_count": "48",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "1.0",
+    "projected_completion_count": "57",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.722222222222",
+    "projected_completion_count": "18",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.346153846154",
+    "projected_completion_count": "26",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.780487804878",
+    "projected_completion_count": "82",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "42",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.644736842105",
+    "projected_completion_count": "76",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.776119402985",
+    "projected_completion_count": "67",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.75",
+    "projected_completion_count": "72",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.627659574468",
+    "projected_completion_count": "94",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.565217391304",
+    "projected_completion_count": "69",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.425",
+    "projected_completion_count": "40",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.944444444444",
+    "projected_completion_count": "18",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.322580645161",
+    "projected_completion_count": "31",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.838709677419",
+    "projected_completion_count": "31",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.896551724138",
+    "projected_completion_count": "58",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.655555555556",
+    "projected_completion_count": "90",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.709677419355",
+    "projected_completion_count": "31",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "45",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.560606060606",
+    "projected_completion_count": "66",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "12",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.896551724138",
+    "projected_completion_count": "58",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.381818181818",
+    "projected_completion_count": "55",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.432835820896",
+    "projected_completion_count": "67",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.955882352941",
+    "projected_completion_count": "68",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.842105263158",
+    "projected_completion_count": "19",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "79",
+    "success_rate": "0.877777777778",
+    "projected_completion_count": "90",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.855072463768",
+    "projected_completion_count": "69",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.868421052632",
+    "projected_completion_count": "38",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.576923076923",
+    "projected_completion_count": "78",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "66",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "42",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.648648648649",
+    "projected_completion_count": "37",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "36",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.384615384615",
+    "projected_completion_count": "13",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "82",
+    "success_rate": "0.82",
+    "projected_completion_count": "100",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.618556701031",
+    "projected_completion_count": "97",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.892857142857",
+    "projected_completion_count": "84",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.351063829787",
+    "projected_completion_count": "94",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.338235294118",
+    "projected_completion_count": "68",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "69",
+    "success_rate": "0.793103448276",
+    "projected_completion_count": "87",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.924528301887",
+    "projected_completion_count": "53",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.733333333333",
+    "projected_completion_count": "45",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "28",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.848484848485",
+    "projected_completion_count": "66",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "11",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.7625",
+    "projected_completion_count": "80",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.488888888889",
+    "projected_completion_count": "45",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.321428571429",
+    "projected_completion_count": "28",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "13",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "99",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "1.0",
+    "projected_completion_count": "59",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "99",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.4",
+    "projected_completion_count": "75",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "82",
+    "success_rate": "0.828282828283",
+    "projected_completion_count": "99",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.5625",
+    "projected_completion_count": "16",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.589743589744",
+    "projected_completion_count": "39",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.44776119403",
+    "projected_completion_count": "67",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "67",
+    "success_rate": "0.87012987013",
+    "projected_completion_count": "77",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "44",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "63",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.357142857143",
+    "projected_completion_count": "14",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "21",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.535714285714",
+    "projected_completion_count": "84",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.75",
+    "projected_completion_count": "20",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.609756097561",
+    "projected_completion_count": "82",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.695652173913",
+    "projected_completion_count": "46",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.95652173913",
+    "projected_completion_count": "23",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.513888888889",
+    "projected_completion_count": "72",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "1.0",
+    "projected_completion_count": "2",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.351063829787",
+    "projected_completion_count": "94",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.640449438202",
+    "projected_completion_count": "89",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.825",
+    "projected_completion_count": "40",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "84",
+    "success_rate": "0.943820224719",
+    "projected_completion_count": "89",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.905660377358",
+    "projected_completion_count": "53",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.783783783784",
+    "projected_completion_count": "37",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.604651162791",
+    "projected_completion_count": "43",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "1.0",
+    "projected_completion_count": "17",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "47",
+    "success_rate": "0.635135135135",
+    "projected_completion_count": "74",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "12",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "1.0",
+    "projected_completion_count": "3",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "72",
+    "success_rate": "0.727272727273",
+    "projected_completion_count": "99",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.272727272727",
+    "projected_completion_count": "11",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "1.0",
+    "projected_completion_count": "28",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.8",
+    "projected_completion_count": "80",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.55",
+    "projected_completion_count": "40",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.523076923077",
+    "projected_completion_count": "65",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.977528089888",
+    "projected_completion_count": "89",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.389830508475",
+    "projected_completion_count": "59",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.452054794521",
+    "projected_completion_count": "73",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "91",
+    "success_rate": "0.978494623656",
+    "projected_completion_count": "93",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.384615384615",
+    "projected_completion_count": "78",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.307692307692",
+    "projected_completion_count": "26",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.691358024691",
+    "projected_completion_count": "81",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.352941176471",
+    "projected_completion_count": "34",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.426229508197",
+    "projected_completion_count": "61",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "63",
+    "success_rate": "0.692307692308",
+    "projected_completion_count": "91",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.967741935484",
+    "projected_completion_count": "31",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.322033898305",
+    "projected_completion_count": "59",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.863636363636",
+    "projected_completion_count": "44",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "1.0",
+    "projected_completion_count": "10",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.2",
+    "projected_completion_count": "5",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "14",
+    "success_rate": "0.5",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "67",
+    "success_rate": "0.917808219178",
+    "projected_completion_count": "73",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "1.0",
+    "projected_completion_count": "1",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.69387755102",
+    "projected_completion_count": "49",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.405063291139",
+    "projected_completion_count": "79",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "25",
+    "success_rate": "0.390625",
+    "projected_completion_count": "64",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.46875",
+    "projected_completion_count": "96",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.75",
+    "projected_completion_count": "36",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.397058823529",
+    "projected_completion_count": "68",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.733333333333",
+    "projected_completion_count": "30",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.679012345679",
+    "projected_completion_count": "81",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "49",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "77",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "5",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "11",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "39",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "93",
+    "success_rate": "0.939393939394",
+    "projected_completion_count": "99",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.359375",
+    "projected_completion_count": "64",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.478260869565",
+    "projected_completion_count": "46",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.920634920635",
+    "projected_completion_count": "63",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.472727272727",
+    "projected_completion_count": "55",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "21",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.867924528302",
+    "projected_completion_count": "53",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.825396825397",
+    "projected_completion_count": "63",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.77358490566",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "14",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "1.0",
+    "projected_completion_count": "3",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "52",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.351351351351",
+    "projected_completion_count": "37",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.491803278689",
+    "projected_completion_count": "61",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "66",
+    "success_rate": "0.66",
+    "projected_completion_count": "100",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "44",
+    "success_rate": "0.448979591837",
+    "projected_completion_count": "98",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "2",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "59",
+    "success_rate": "0.655555555556",
+    "projected_completion_count": "90",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "1.0",
+    "projected_completion_count": "1",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.53125",
+    "projected_completion_count": "32",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.4",
+    "projected_completion_count": "15",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.86",
+    "projected_completion_count": "50",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.547619047619",
+    "projected_completion_count": "42",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.825",
+    "projected_completion_count": "40",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.758620689655",
+    "projected_completion_count": "29",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.555555555556",
+    "projected_completion_count": "27",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.66265060241",
+    "projected_completion_count": "83",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.630136986301",
+    "projected_completion_count": "73",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "43",
+    "success_rate": "0.796296296296",
+    "projected_completion_count": "54",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.625",
+    "projected_completion_count": "56",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "36",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "69",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "26",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "39",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.875",
+    "projected_completion_count": "24",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.988636363636",
+    "projected_completion_count": "88",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "0.909090909091",
+    "projected_completion_count": "77",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.753623188406",
+    "projected_completion_count": "69",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.621621621622",
+    "projected_completion_count": "37",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.547619047619",
+    "projected_completion_count": "42",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "27",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.806451612903",
+    "projected_completion_count": "62",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.631578947368",
+    "projected_completion_count": "38",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "0.897435897436",
+    "projected_completion_count": "78",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.638554216867",
+    "projected_completion_count": "83",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "35",
+    "success_rate": "0.686274509804",
+    "projected_completion_count": "51",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.389830508475",
+    "projected_completion_count": "59",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.795698924731",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.657142857143",
+    "projected_completion_count": "35",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.969696969697",
+    "projected_completion_count": "66",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.802197802198",
+    "projected_completion_count": "91",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "45",
+    "success_rate": "0.473684210526",
+    "projected_completion_count": "95",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "57",
+    "success_rate": "0.76",
+    "projected_completion_count": "75",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.372549019608",
+    "projected_completion_count": "51",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.887096774194",
+    "projected_completion_count": "62",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "82",
+    "success_rate": "0.845360824742",
+    "projected_completion_count": "97",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.25",
+    "projected_completion_count": "4",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.4375",
+    "projected_completion_count": "64",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.961538461538",
+    "projected_completion_count": "52",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "33",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.5",
+    "projected_completion_count": "56",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.947368421053",
+    "projected_completion_count": "19",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "0",
+    "success_rate": "0.0",
+    "projected_completion_count": "1",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.585365853659",
+    "projected_completion_count": "41",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "18",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "15",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "18",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "42",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "9",
+    "success_rate": "0.310344827586",
+    "projected_completion_count": "29",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "1.0",
+    "projected_completion_count": "17",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "16",
+    "success_rate": "0.457142857143",
+    "projected_completion_count": "35",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.623376623377",
+    "projected_completion_count": "77",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "20",
+    "success_rate": "0.689655172414",
+    "projected_completion_count": "29",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.659090909091",
+    "projected_completion_count": "44",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "29",
+    "success_rate": "0.783783783784",
+    "projected_completion_count": "37",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "75",
+    "success_rate": "0.925925925926",
+    "projected_completion_count": "81",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "56",
+    "success_rate": "0.602150537634",
+    "projected_completion_count": "93",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "68",
+    "success_rate": "0.83950617284",
+    "projected_completion_count": "81",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "27",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.569892473118",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "13",
+    "success_rate": "0.764705882353",
+    "projected_completion_count": "17",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "66",
+    "success_rate": "0.758620689655",
+    "projected_completion_count": "87",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.362637362637",
+    "projected_completion_count": "91",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.548387096774",
+    "projected_completion_count": "31",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "52",
+    "success_rate": "0.881355932203",
+    "projected_completion_count": "59",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.492307692308",
+    "projected_completion_count": "65",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.410714285714",
+    "projected_completion_count": "56",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "7",
+    "success_rate": "0.538461538462",
+    "projected_completion_count": "13",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "19",
+    "success_rate": "0.487179487179",
+    "projected_completion_count": "39",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "42",
+    "success_rate": "0.42",
+    "projected_completion_count": "100",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "53",
+    "success_rate": "0.569892473118",
+    "projected_completion_count": "93",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "6",
+    "success_rate": "0.375",
+    "projected_completion_count": "16",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "21",
+    "success_rate": "1.0",
+    "projected_completion_count": "21",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.528735632184",
+    "projected_completion_count": "87",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "81",
+    "success_rate": "0.910112359551",
+    "projected_completion_count": "89",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.74",
+    "projected_completion_count": "50",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "61",
+    "success_rate": "0.734939759036",
+    "projected_completion_count": "83",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "4",
+    "success_rate": "0.307692307692",
+    "projected_completion_count": "13",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "78",
+    "success_rate": "0.876404494382",
+    "projected_completion_count": "89",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.674418604651",
+    "projected_completion_count": "86",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "71",
+    "success_rate": "0.845238095238",
+    "projected_completion_count": "84",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.894736842105",
+    "projected_completion_count": "38",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.475609756098",
+    "projected_completion_count": "82",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "86",
+    "success_rate": "0.977272727273",
+    "projected_completion_count": "88",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "50",
+    "success_rate": "0.892857142857",
+    "projected_completion_count": "56",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "46",
+    "success_rate": "0.901960784314",
+    "projected_completion_count": "51",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.52380952381",
+    "projected_completion_count": "21",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "60",
+    "success_rate": "0.625",
+    "projected_completion_count": "96",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "76",
+    "success_rate": "0.767676767677",
+    "projected_completion_count": "99",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.566666666667",
+    "projected_completion_count": "30",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "3",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "74",
+    "success_rate": "0.74",
+    "projected_completion_count": "100",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "39",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.58064516129",
+    "projected_completion_count": "93",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.628571428571",
+    "projected_completion_count": "35",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "65",
+    "success_rate": "0.677083333333",
+    "projected_completion_count": "96",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "10",
+    "success_rate": "0.625",
+    "projected_completion_count": "16",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "70",
+    "success_rate": "0.864197530864",
+    "projected_completion_count": "81",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "32",
+    "success_rate": "0.864864864865",
+    "projected_completion_count": "37",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "33",
+    "success_rate": "0.375",
+    "projected_completion_count": "88",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "39",
+    "success_rate": "0.4875",
+    "projected_completion_count": "80",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "87",
+    "success_rate": "0.915789473684",
+    "projected_completion_count": "95",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.653846153846",
+    "projected_completion_count": "52",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.980769230769",
+    "projected_completion_count": "52",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "1",
+    "success_rate": "0.5",
+    "projected_completion_count": "2",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "41",
+    "success_rate": "0.532467532468",
+    "projected_completion_count": "77",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "11",
+    "success_rate": "0.6875",
+    "projected_completion_count": "16",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "77",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "99",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "28",
+    "success_rate": "0.549019607843",
+    "projected_completion_count": "51",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.770833333333",
+    "projected_completion_count": "48",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.421052631579",
+    "projected_completion_count": "57",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "37",
+    "success_rate": "0.637931034483",
+    "projected_completion_count": "58",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "51",
+    "success_rate": "0.796875",
+    "projected_completion_count": "64",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "30",
+    "success_rate": "0.37037037037",
+    "projected_completion_count": "81",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "15",
+    "success_rate": "0.46875",
+    "projected_completion_count": "32",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "17",
+    "success_rate": "0.548387096774",
+    "projected_completion_count": "31",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "2",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "3",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "27",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.876712328767",
+    "projected_completion_count": "73",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "27",
+    "success_rate": "0.658536585366",
+    "projected_completion_count": "41",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "58",
+    "success_rate": "0.716049382716",
+    "projected_completion_count": "81",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.948275862069",
+    "projected_completion_count": "58",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "24",
+    "success_rate": "0.8",
+    "projected_completion_count": "30",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "38",
+    "success_rate": "0.904761904762",
+    "projected_completion_count": "42",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.447368421053",
+    "projected_completion_count": "76",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "23",
+    "success_rate": "0.851851851852",
+    "projected_completion_count": "27",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.68",
+    "projected_completion_count": "50",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "0.66265060241",
+    "projected_completion_count": "83",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "7",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "34",
+    "success_rate": "0.607142857143",
+    "projected_completion_count": "56",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "22",
+    "success_rate": "0.52380952381",
+    "projected_completion_count": "42",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "8",
+    "success_rate": "0.32",
+    "projected_completion_count": "25",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "55",
+    "success_rate": "1.0",
+    "projected_completion_count": "55",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "73",
+    "success_rate": "0.935897435897",
+    "projected_completion_count": "78",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "54",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "63",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "64",
+    "success_rate": "0.831168831169",
+    "projected_completion_count": "77",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "48",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "56",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.272727272727",
+    "projected_completion_count": "11",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "3",
+    "success_rate": "0.75",
+    "projected_completion_count": "4",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "12",
+    "success_rate": "0.413793103448",
+    "projected_completion_count": "29",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  }
+]

--- a/src/assets/test_data/US_ND_supervision_success_by_month.json
+++ b/src/assets/test_data/US_ND_supervision_success_by_month.json
@@ -1,6550 +1,878 @@
 [
   {
-    "successful_termination_count": "47",
-    "success_rate": "0.505376344086",
-    "projected_completion_count": "93",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "18",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "35",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.739130434783",
-    "projected_completion_count": "46",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "79",
-    "success_rate": "0.79",
-    "projected_completion_count": "100",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.4",
-    "projected_completion_count": "35",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.9375",
-    "projected_completion_count": "16",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.48",
-    "projected_completion_count": "50",
+    "district": "1",
+    "successful_termination_count": "173",
+    "success_rate": "0.683794466403",
+    "projected_completion_count": "253",
     "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "30",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.329113924051",
-    "projected_completion_count": "79",
-    "projected_month": "11",
-    "projected_year": "2018",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "42",
-    "success_rate": "0.893617021277",
-    "projected_completion_count": "47",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.746835443038",
-    "projected_completion_count": "79",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.607142857143",
-    "projected_completion_count": "28",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.4",
-    "projected_completion_count": "80",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.796610169492",
-    "projected_completion_count": "59",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "1.0",
-    "projected_completion_count": "9",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "1.0",
-    "projected_completion_count": "8",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.722222222222",
-    "projected_completion_count": "36",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.746478873239",
-    "projected_completion_count": "71",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "14",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.85",
-    "projected_completion_count": "40",
+    "district": "15",
+    "successful_termination_count": "165",
+    "success_rate": "0.723684210526",
+    "projected_completion_count": "228",
     "projected_month": "10",
-    "projected_year": "2019",
+    "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "24",
-    "success_rate": "0.347826086957",
-    "projected_completion_count": "69",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "69",
-    "success_rate": "0.851851851852",
-    "projected_completion_count": "81",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.785714285714",
-    "projected_completion_count": "56",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "3",
     "successful_termination_count": "15",
     "success_rate": "0.9375",
     "projected_completion_count": "16",
-    "projected_month": "2",
-    "projected_year": "2020",
+    "projected_month": "11",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "4",
+    "successful_termination_count": "142",
+    "success_rate": "0.625550660793",
+    "projected_completion_count": "227",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "307",
+    "success_rate": "0.968454258675",
+    "projected_completion_count": "317",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
     "successful_termination_count": "88",
-    "success_rate": "0.926315789474",
-    "projected_completion_count": "95",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.481927710843",
-    "projected_completion_count": "83",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.646341463415",
-    "projected_completion_count": "82",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.973333333333",
-    "projected_completion_count": "75",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "74",
-    "success_rate": "0.870588235294",
-    "projected_completion_count": "85",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.386363636364",
-    "projected_completion_count": "88",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.878787878788",
-    "projected_completion_count": "33",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.52380952381",
-    "projected_completion_count": "42",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.971428571429",
-    "projected_completion_count": "35",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.558441558442",
-    "projected_completion_count": "77",
+    "success_rate": "0.553459119497",
+    "projected_completion_count": "159",
     "projected_month": "5",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "27",
-    "success_rate": "0.346153846154",
-    "projected_completion_count": "78",
+    "district": "5",
+    "successful_termination_count": "126",
+    "success_rate": "0.818181818182",
+    "projected_completion_count": "154",
     "projected_month": "6",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "60",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.4375",
-    "projected_completion_count": "96",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.461538461538",
-    "projected_completion_count": "13",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "11",
-    "projected_month": "3",
-    "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "62",
-    "success_rate": "0.898550724638",
-    "projected_completion_count": "69",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "0.912087912088",
-    "projected_completion_count": "91",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "63",
-    "success_rate": "0.768292682927",
-    "projected_completion_count": "82",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.52",
-    "projected_completion_count": "50",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.608695652174",
-    "projected_completion_count": "46",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.983333333333",
-    "projected_completion_count": "60",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "18",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.6",
-    "projected_completion_count": "70",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.511627906977",
-    "projected_completion_count": "43",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "1.0",
-    "projected_completion_count": "8",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.82",
-    "projected_completion_count": "50",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.86",
-    "projected_completion_count": "50",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.516129032258",
-    "projected_completion_count": "31",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "45",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.430555555556",
-    "projected_completion_count": "72",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.941176470588",
-    "projected_completion_count": "51",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "42",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "93",
-    "success_rate": "0.948979591837",
-    "projected_completion_count": "98",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "1.0",
-    "projected_completion_count": "6",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.5",
-    "projected_completion_count": "14",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.869565217391",
-    "projected_completion_count": "69",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.709677419355",
-    "projected_completion_count": "31",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "71",
-    "success_rate": "0.934210526316",
-    "projected_completion_count": "76",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "21",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.866666666667",
-    "projected_completion_count": "15",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.9",
-    "projected_completion_count": "20",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.472972972973",
-    "projected_completion_count": "74",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "8",
     "successful_termination_count": "67",
-    "success_rate": "0.930555555556",
-    "projected_completion_count": "72",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.413043478261",
-    "projected_completion_count": "46",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.742857142857",
-    "projected_completion_count": "70",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.5",
-    "projected_completion_count": "54",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.9",
-    "projected_completion_count": "10",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "97",
-    "success_rate": "0.979797979798",
-    "projected_completion_count": "99",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.62962962963",
-    "projected_completion_count": "54",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.46875",
-    "projected_completion_count": "64",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.903846153846",
-    "projected_completion_count": "52",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "99",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "18",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.6",
-    "projected_completion_count": "5",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.75",
-    "projected_completion_count": "24",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.558139534884",
-    "projected_completion_count": "86",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.377777777778",
-    "projected_completion_count": "90",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.7",
-    "projected_completion_count": "20",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "77",
-    "success_rate": "0.79381443299",
-    "projected_completion_count": "97",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "66",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.416666666667",
-    "projected_completion_count": "60",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.660714285714",
-    "projected_completion_count": "56",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.4",
-    "projected_completion_count": "35",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.83908045977",
-    "projected_completion_count": "87",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.488372093023",
-    "projected_completion_count": "43",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.575757575758",
-    "projected_completion_count": "33",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.704918032787",
-    "projected_completion_count": "61",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.84375",
-    "projected_completion_count": "32",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.757575757576",
-    "projected_completion_count": "33",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.928571428571",
-    "projected_completion_count": "14",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "78",
-    "success_rate": "0.896551724138",
-    "projected_completion_count": "87",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "45",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.7",
-    "projected_completion_count": "10",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.425",
-    "projected_completion_count": "40",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.2",
-    "projected_completion_count": "5",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "1.0",
-    "projected_completion_count": "27",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.375",
-    "projected_completion_count": "40",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.657142857143",
-    "projected_completion_count": "70",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.642857142857",
-    "projected_completion_count": "28",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.722222222222",
-    "projected_completion_count": "36",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.576923076923",
-    "projected_completion_count": "26",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.875",
-    "projected_completion_count": "64",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.779220779221",
-    "projected_completion_count": "77",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.813333333333",
-    "projected_completion_count": "75",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.866666666667",
-    "projected_completion_count": "15",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.494845360825",
-    "projected_completion_count": "97",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "71",
-    "success_rate": "0.910256410256",
-    "projected_completion_count": "78",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.740740740741",
-    "projected_completion_count": "54",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.814285714286",
-    "projected_completion_count": "70",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.65",
-    "projected_completion_count": "20",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.607142857143",
-    "projected_completion_count": "28",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "80",
-    "success_rate": "0.975609756098",
-    "projected_completion_count": "82",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.721518987342",
-    "projected_completion_count": "79",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.426229508197",
-    "projected_completion_count": "61",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.407407407407",
-    "projected_completion_count": "27",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.315789473684",
-    "projected_completion_count": "38",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.348484848485",
-    "projected_completion_count": "66",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.633333333333",
-    "projected_completion_count": "30",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.743243243243",
-    "projected_completion_count": "74",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.58904109589",
-    "projected_completion_count": "73",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.76",
-    "projected_completion_count": "25",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "84",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.625",
-    "projected_completion_count": "16",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "69",
-    "success_rate": "0.75",
-    "projected_completion_count": "92",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "9",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.372093023256",
-    "projected_completion_count": "43",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "1.0",
-    "projected_completion_count": "49",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.660714285714",
-    "projected_completion_count": "56",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.918032786885",
-    "projected_completion_count": "61",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.75",
-    "projected_completion_count": "4",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "72",
-    "success_rate": "0.827586206897",
-    "projected_completion_count": "87",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "1.0",
-    "projected_completion_count": "5",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.893939393939",
-    "projected_completion_count": "66",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "1.0",
-    "projected_completion_count": "24",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.966666666667",
-    "projected_completion_count": "90",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "7",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.272727272727",
-    "projected_completion_count": "11",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "81",
-    "success_rate": "0.975903614458",
-    "projected_completion_count": "83",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.440677966102",
-    "projected_completion_count": "59",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.814814814815",
-    "projected_completion_count": "27",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.625",
-    "projected_completion_count": "8",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.9375",
-    "projected_completion_count": "64",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.538461538462",
-    "projected_completion_count": "13",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.783333333333",
-    "projected_completion_count": "60",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.536082474227",
-    "projected_completion_count": "97",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.522727272727",
-    "projected_completion_count": "44",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "6",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "63",
-    "success_rate": "0.670212765957",
-    "projected_completion_count": "94",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.830985915493",
-    "projected_completion_count": "71",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.5",
-    "projected_completion_count": "44",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.679012345679",
-    "projected_completion_count": "81",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.878787878788",
-    "projected_completion_count": "99",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.409090909091",
-    "projected_completion_count": "22",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "71",
-    "success_rate": "0.763440860215",
-    "projected_completion_count": "93",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "18",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.68115942029",
-    "projected_completion_count": "69",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.738636363636",
-    "projected_completion_count": "88",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.285714285714",
-    "projected_completion_count": "7",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.518072289157",
-    "projected_completion_count": "83",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.8",
-    "projected_completion_count": "75",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.696202531646",
-    "projected_completion_count": "79",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.691358024691",
-    "projected_completion_count": "81",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.55223880597",
-    "projected_completion_count": "67",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "9",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.386666666667",
-    "projected_completion_count": "75",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.409090909091",
-    "projected_completion_count": "66",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "24",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "36",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.466666666667",
-    "projected_completion_count": "30",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.43137254902",
-    "projected_completion_count": "51",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.677419354839",
-    "projected_completion_count": "31",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.36170212766",
-    "projected_completion_count": "47",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "11",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "15",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.785714285714",
-    "projected_completion_count": "14",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "1",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.76",
-    "projected_completion_count": "25",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.761904761905",
-    "projected_completion_count": "21",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.75",
-    "projected_completion_count": "12",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "0.902173913043",
-    "projected_completion_count": "92",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.75",
-    "projected_completion_count": "16",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.424242424242",
-    "projected_completion_count": "66",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "1.0",
-    "projected_completion_count": "4",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.541666666667",
-    "projected_completion_count": "96",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.884057971014",
-    "projected_completion_count": "69",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.9",
-    "projected_completion_count": "40",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.628205128205",
-    "projected_completion_count": "78",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "1.0",
-    "projected_completion_count": "4",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "70",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.65",
-    "projected_completion_count": "100",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.744186046512",
-    "projected_completion_count": "86",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "11",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.406976744186",
-    "projected_completion_count": "86",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.675324675325",
-    "projected_completion_count": "77",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "92",
-    "success_rate": "0.92",
-    "projected_completion_count": "100",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "33",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.8",
-    "projected_completion_count": "10",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.655172413793",
-    "projected_completion_count": "87",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "78",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.546666666667",
-    "projected_completion_count": "75",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "94",
-    "success_rate": "0.969072164948",
-    "projected_completion_count": "97",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.604651162791",
-    "projected_completion_count": "43",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.71875",
-    "projected_completion_count": "32",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.764705882353",
-    "projected_completion_count": "51",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "66",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.711111111111",
-    "projected_completion_count": "45",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.354838709677",
-    "projected_completion_count": "31",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.387755102041",
-    "projected_completion_count": "49",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.423529411765",
-    "projected_completion_count": "85",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.5625",
-    "projected_completion_count": "16",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.783783783784",
-    "projected_completion_count": "74",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.944444444444",
-    "projected_completion_count": "36",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.83908045977",
-    "projected_completion_count": "87",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.875",
-    "projected_completion_count": "16",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.828125",
-    "projected_completion_count": "64",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.578947368421",
-    "projected_completion_count": "76",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.463768115942",
-    "projected_completion_count": "69",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.5",
-    "projected_completion_count": "50",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.489130434783",
-    "projected_completion_count": "92",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "24",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.796296296296",
-    "projected_completion_count": "54",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.5",
-    "projected_completion_count": "46",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "1.0",
-    "projected_completion_count": "11",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.927272727273",
-    "projected_completion_count": "55",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.348837209302",
-    "projected_completion_count": "86",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.644444444444",
-    "projected_completion_count": "45",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.888888888889",
-    "projected_completion_count": "18",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.640625",
-    "projected_completion_count": "64",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.528301886792",
-    "projected_completion_count": "53",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "42",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.904761904762",
-    "projected_completion_count": "42",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.65625",
-    "projected_completion_count": "64",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "62",
-    "success_rate": "0.837837837838",
-    "projected_completion_count": "74",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "39",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "11",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.8",
-    "projected_completion_count": "65",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "7",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.443298969072",
-    "projected_completion_count": "97",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.616438356164",
-    "projected_completion_count": "73",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.676056338028",
-    "projected_completion_count": "71",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "52",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.63768115942",
-    "projected_completion_count": "69",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.384615384615",
-    "projected_completion_count": "78",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.25",
-    "projected_completion_count": "4",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.679487179487",
-    "projected_completion_count": "78",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "72",
-    "success_rate": "0.986301369863",
-    "projected_completion_count": "73",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.973684210526",
-    "projected_completion_count": "38",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.641509433962",
-    "projected_completion_count": "53",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.375",
-    "projected_completion_count": "8",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.947368421053",
-    "projected_completion_count": "19",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.84",
-    "projected_completion_count": "50",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.5",
-    "projected_completion_count": "20",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.927536231884",
-    "projected_completion_count": "69",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.916666666667",
-    "projected_completion_count": "36",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.392405063291",
-    "projected_completion_count": "79",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.701298701299",
-    "projected_completion_count": "77",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.569892473118",
-    "projected_completion_count": "93",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.854545454545",
-    "projected_completion_count": "55",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.654320987654",
-    "projected_completion_count": "81",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.358974358974",
-    "projected_completion_count": "39",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.951219512195",
-    "projected_completion_count": "41",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.804347826087",
-    "projected_completion_count": "46",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.622950819672",
-    "projected_completion_count": "61",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.5",
-    "projected_completion_count": "20",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.970588235294",
-    "projected_completion_count": "34",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.738095238095",
-    "projected_completion_count": "42",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.411764705882",
-    "projected_completion_count": "17",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.9125",
-    "projected_completion_count": "80",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.794117647059",
-    "projected_completion_count": "68",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.521739130435",
-    "projected_completion_count": "92",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.846153846154",
-    "projected_completion_count": "13",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.684210526316",
-    "projected_completion_count": "38",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.962962962963",
-    "projected_completion_count": "27",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.870967741935",
-    "projected_completion_count": "31",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.487179487179",
-    "projected_completion_count": "78",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "18",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.397590361446",
-    "projected_completion_count": "83",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.605263157895",
-    "projected_completion_count": "38",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.681818181818",
-    "projected_completion_count": "22",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "51",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.493975903614",
-    "projected_completion_count": "83",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.614583333333",
-    "projected_completion_count": "96",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "11",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.8",
-    "projected_completion_count": "30",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.716666666667",
-    "projected_completion_count": "60",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.607594936709",
-    "projected_completion_count": "79",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.617647058824",
-    "projected_completion_count": "68",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.821428571429",
-    "projected_completion_count": "56",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.547368421053",
+    "success_rate": "0.705263157895",
     "projected_completion_count": "95",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "109",
+    "success_rate": "0.358552631579",
+    "projected_completion_count": "304",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "251",
+    "success_rate": "0.922794117647",
+    "projected_completion_count": "272",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "178",
+    "success_rate": "0.864077669903",
+    "projected_completion_count": "206",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "106",
+    "success_rate": "0.963636363636",
+    "projected_completion_count": "110",
     "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "286",
+    "success_rate": "0.89375",
+    "projected_completion_count": "320",
+    "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "21",
-    "success_rate": "0.954545454545",
-    "projected_completion_count": "22",
+    "district": "ALL",
+    "successful_termination_count": "167",
+    "success_rate": "0.662698412698",
+    "projected_completion_count": "252",
     "projected_month": "2",
-    "projected_year": "2020",
+    "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "31",
-    "success_rate": "0.378048780488",
-    "projected_completion_count": "82",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.528571428571",
-    "projected_completion_count": "70",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "27",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
+    "district": "15",
+    "successful_termination_count": "64",
     "success_rate": "0.727272727273",
-    "projected_completion_count": "44",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.609756097561",
-    "projected_completion_count": "41",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "1.0",
-    "projected_completion_count": "40",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.413043478261",
-    "projected_completion_count": "46",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "86",
-    "success_rate": "0.924731182796",
-    "projected_completion_count": "93",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.326086956522",
-    "projected_completion_count": "46",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.861111111111",
-    "projected_completion_count": "36",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.631578947368",
-    "projected_completion_count": "38",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.978260869565",
-    "projected_completion_count": "46",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.565217391304",
-    "projected_completion_count": "46",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.815789473684",
-    "projected_completion_count": "38",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "1.0",
-    "projected_completion_count": "30",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.511627906977",
-    "projected_completion_count": "86",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.986486486486",
-    "projected_completion_count": "74",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.981818181818",
-    "projected_completion_count": "55",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.527777777778",
-    "projected_completion_count": "72",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.4",
-    "projected_completion_count": "15",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "71",
-    "success_rate": "0.986111111111",
-    "projected_completion_count": "72",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.82",
-    "projected_completion_count": "50",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "51",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "63",
-    "success_rate": "0.984375",
-    "projected_completion_count": "64",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.770491803279",
-    "projected_completion_count": "61",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.626865671642",
-    "projected_completion_count": "67",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.378378378378",
-    "projected_completion_count": "37",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.826086956522",
-    "projected_completion_count": "69",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.510638297872",
-    "projected_completion_count": "94",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.318181818182",
-    "projected_completion_count": "22",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "35",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.78125",
-    "projected_completion_count": "96",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.315789473684",
-    "projected_completion_count": "19",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.635294117647",
-    "projected_completion_count": "85",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.517647058824",
-    "projected_completion_count": "85",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.5",
-    "projected_completion_count": "18",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.5",
-    "projected_completion_count": "18",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.390243902439",
-    "projected_completion_count": "41",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "1.0",
-    "projected_completion_count": "5",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.378787878788",
-    "projected_completion_count": "66",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.892307692308",
-    "projected_completion_count": "65",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.464285714286",
-    "projected_completion_count": "28",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.439024390244",
-    "projected_completion_count": "82",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "93",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.986842105263",
-    "projected_completion_count": "76",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.740740740741",
-    "projected_completion_count": "54",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.4",
-    "projected_completion_count": "30",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "62",
-    "success_rate": "0.953846153846",
-    "projected_completion_count": "65",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.789473684211",
-    "projected_completion_count": "95",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.521739130435",
-    "projected_completion_count": "23",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.479166666667",
-    "projected_completion_count": "48",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "68",
-    "success_rate": "0.8",
-    "projected_completion_count": "85",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "96",
-    "success_rate": "0.989690721649",
-    "projected_completion_count": "97",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "27",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.923076923077",
-    "projected_completion_count": "13",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.693548387097",
-    "projected_completion_count": "62",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "12",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.590163934426",
-    "projected_completion_count": "61",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.888888888889",
-    "projected_completion_count": "9",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.722891566265",
-    "projected_completion_count": "83",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.84126984127",
-    "projected_completion_count": "63",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.619047619048",
-    "projected_completion_count": "21",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "81",
-    "success_rate": "0.910112359551",
-    "projected_completion_count": "89",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "22",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.746478873239",
-    "projected_completion_count": "71",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.340659340659",
-    "projected_completion_count": "91",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.431578947368",
-    "projected_completion_count": "95",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.685185185185",
-    "projected_completion_count": "54",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.934782608696",
-    "projected_completion_count": "46",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.521739130435",
-    "projected_completion_count": "23",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.566265060241",
-    "projected_completion_count": "83",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "14",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.681818181818",
-    "projected_completion_count": "22",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.653333333333",
-    "projected_completion_count": "75",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.849056603774",
-    "projected_completion_count": "53",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.760869565217",
-    "projected_completion_count": "46",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.9",
-    "projected_completion_count": "20",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.684210526316",
-    "projected_completion_count": "57",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.965517241379",
-    "projected_completion_count": "29",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.294117647059",
-    "projected_completion_count": "17",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.888888888889",
-    "projected_completion_count": "45",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.39175257732",
-    "projected_completion_count": "97",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.641791044776",
-    "projected_completion_count": "67",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.583333333333",
-    "projected_completion_count": "96",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.894736842105",
-    "projected_completion_count": "38",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.554347826087",
-    "projected_completion_count": "92",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "95",
-    "success_rate": "0.959595959596",
-    "projected_completion_count": "99",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.25",
-    "projected_completion_count": "8",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.528301886792",
-    "projected_completion_count": "53",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "74",
-    "success_rate": "0.795698924731",
-    "projected_completion_count": "93",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.556962025316",
-    "projected_completion_count": "79",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.603174603175",
-    "projected_completion_count": "63",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "74",
-    "success_rate": "0.804347826087",
-    "projected_completion_count": "92",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "1.0",
-    "projected_completion_count": "83",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.720588235294",
-    "projected_completion_count": "68",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.465909090909",
     "projected_completion_count": "88",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.88",
-    "projected_completion_count": "25",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.344827586207",
-    "projected_completion_count": "29",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.597222222222",
-    "projected_completion_count": "72",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "13",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.432432432432",
-    "projected_completion_count": "37",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.8",
-    "projected_completion_count": "10",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "1.0",
-    "projected_completion_count": "4",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "75",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "1.0",
-    "projected_completion_count": "29",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.602409638554",
-    "projected_completion_count": "83",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "68",
-    "success_rate": "0.731182795699",
-    "projected_completion_count": "93",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.56976744186",
-    "projected_completion_count": "86",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.410256410256",
-    "projected_completion_count": "39",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "7",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "67",
-    "success_rate": "0.779069767442",
-    "projected_completion_count": "86",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.585106382979",
-    "projected_completion_count": "94",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.644736842105",
-    "projected_completion_count": "76",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.546875",
-    "projected_completion_count": "64",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.380952380952",
-    "projected_completion_count": "21",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "12",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.851063829787",
-    "projected_completion_count": "47",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.421052631579",
-    "projected_completion_count": "19",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "1.0",
-    "projected_completion_count": "25",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "12",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.595238095238",
-    "projected_completion_count": "84",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.545454545455",
-    "projected_completion_count": "88",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.791666666667",
-    "projected_completion_count": "24",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.923076923077",
-    "projected_completion_count": "13",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.46511627907",
-    "projected_completion_count": "86",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.458333333333",
-    "projected_completion_count": "24",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.884615384615",
-    "projected_completion_count": "52",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "66",
-    "success_rate": "1.0",
-    "projected_completion_count": "66",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.416666666667",
-    "projected_completion_count": "12",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "66",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.672413793103",
-    "projected_completion_count": "58",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.736842105263",
-    "projected_completion_count": "19",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.782608695652",
-    "projected_completion_count": "23",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.347826086957",
-    "projected_completion_count": "23",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.382352941176",
-    "projected_completion_count": "34",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.535714285714",
-    "projected_completion_count": "28",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.878048780488",
-    "projected_completion_count": "41",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.578313253012",
-    "projected_completion_count": "83",
     "projected_month": "2",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "8",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "15",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "62",
-    "success_rate": "0.953846153846",
-    "projected_completion_count": "65",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.574074074074",
-    "projected_completion_count": "54",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "77",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "12",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "89",
-    "success_rate": "1.0",
-    "projected_completion_count": "89",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "84",
-    "success_rate": "0.903225806452",
-    "projected_completion_count": "93",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "24",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.954545454545",
-    "projected_completion_count": "22",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.629032258065",
-    "projected_completion_count": "62",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.44776119403",
-    "projected_completion_count": "67",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.62962962963",
-    "projected_completion_count": "27",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.875",
-    "projected_completion_count": "32",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.5",
-    "projected_completion_count": "14",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.583333333333",
-    "projected_completion_count": "12",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.744897959184",
-    "projected_completion_count": "98",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "2",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.375",
-    "projected_completion_count": "96",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.555555555556",
-    "projected_completion_count": "18",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.5",
-    "projected_completion_count": "32",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.809523809524",
-    "projected_completion_count": "21",
+    "district": "6",
+    "successful_termination_count": "142",
+    "success_rate": "0.735751295337",
+    "projected_completion_count": "193",
     "projected_month": "5",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "33",
-    "success_rate": "0.6875",
-    "projected_completion_count": "48",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "9",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "82",
-    "success_rate": "0.987951807229",
-    "projected_completion_count": "83",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.5",
-    "projected_completion_count": "20",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "11",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.515625",
-    "projected_completion_count": "64",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.392857142857",
-    "projected_completion_count": "84",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.573770491803",
-    "projected_completion_count": "61",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.610526315789",
-    "projected_completion_count": "95",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.652173913043",
-    "projected_completion_count": "46",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.548387096774",
-    "projected_completion_count": "31",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "70",
-    "success_rate": "1.0",
-    "projected_completion_count": "70",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.691358024691",
-    "projected_completion_count": "81",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.423076923077",
-    "projected_completion_count": "26",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.521739130435",
-    "projected_completion_count": "23",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.755555555556",
-    "projected_completion_count": "45",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "18",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "79",
-    "success_rate": "0.887640449438",
-    "projected_completion_count": "89",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.561224489796",
-    "projected_completion_count": "98",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.697674418605",
-    "projected_completion_count": "86",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.655737704918",
-    "projected_completion_count": "61",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.681818181818",
-    "projected_completion_count": "66",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.652173913043",
-    "projected_completion_count": "23",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.923076923077",
-    "projected_completion_count": "26",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.947368421053",
-    "projected_completion_count": "57",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.568181818182",
-    "projected_completion_count": "88",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.405405405405",
-    "projected_completion_count": "74",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.661538461538",
-    "projected_completion_count": "65",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.717647058824",
-    "projected_completion_count": "85",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.866666666667",
-    "projected_completion_count": "15",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.515151515152",
-    "projected_completion_count": "99",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.35",
-    "projected_completion_count": "80",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.349397590361",
-    "projected_completion_count": "83",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.821428571429",
-    "projected_completion_count": "28",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.632653061224",
-    "projected_completion_count": "49",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.916666666667",
-    "projected_completion_count": "36",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.8125",
-    "projected_completion_count": "32",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.611111111111",
-    "projected_completion_count": "36",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.795918367347",
-    "projected_completion_count": "49",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.346153846154",
-    "projected_completion_count": "26",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "77",
-    "success_rate": "0.802083333333",
-    "projected_completion_count": "96",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.622641509434",
-    "projected_completion_count": "53",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "11",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "1.0",
-    "projected_completion_count": "28",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "42",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.652173913043",
-    "projected_completion_count": "92",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.384615384615",
-    "projected_completion_count": "39",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.816326530612",
-    "projected_completion_count": "49",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.431034482759",
-    "projected_completion_count": "58",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "33",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "30",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "6",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.373626373626",
-    "projected_completion_count": "91",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "13",
     "successful_termination_count": "76",
-    "success_rate": "0.974358974359",
-    "projected_completion_count": "78",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.684210526316",
-    "projected_completion_count": "19",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "1",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.4",
-    "projected_completion_count": "10",
+    "success_rate": "0.381909547739",
+    "projected_completion_count": "199",
     "projected_month": "7",
-    "projected_year": "2018",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "114",
+    "success_rate": "0.662790697674",
+    "projected_completion_count": "172",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "150",
+    "success_rate": "0.675675675676",
+    "projected_completion_count": "222",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "139",
+    "success_rate": "0.545098039216",
+    "projected_completion_count": "255",
+    "projected_month": "7",
+    "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "24",
-    "success_rate": "0.375",
-    "projected_completion_count": "64",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.388888888889",
-    "projected_completion_count": "36",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.357142857143",
-    "projected_completion_count": "14",
+    "district": "8",
+    "successful_termination_count": "102",
+    "success_rate": "0.395348837209",
+    "projected_completion_count": "258",
     "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.679012345679",
-    "projected_completion_count": "81",
-    "projected_month": "2",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "42",
-    "success_rate": "0.688524590164",
-    "projected_completion_count": "61",
-    "projected_month": "2",
+    "district": "11",
+    "successful_termination_count": "151",
+    "success_rate": "0.782383419689",
+    "projected_completion_count": "193",
+    "projected_month": "11",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "10",
-    "success_rate": "0.526315789474",
-    "projected_completion_count": "19",
+    "district": "13",
+    "successful_termination_count": "174",
+    "success_rate": "0.945652173913",
+    "projected_completion_count": "184",
     "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "7",
-    "success_rate": "0.466666666667",
-    "projected_completion_count": "15",
+    "district": "1",
+    "successful_termination_count": "249",
+    "success_rate": "0.867595818815",
+    "projected_completion_count": "287",
     "projected_month": "5",
-    "projected_year": "2019",
+    "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "3",
+    "district": "17",
+    "successful_termination_count": "186",
     "success_rate": "0.75",
-    "projected_completion_count": "4",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.652173913043",
-    "projected_completion_count": "23",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.621951219512",
-    "projected_completion_count": "82",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.7",
-    "projected_completion_count": "50",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.783783783784",
-    "projected_completion_count": "37",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.75",
-    "projected_completion_count": "12",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.941176470588",
-    "projected_completion_count": "17",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "1.0",
-    "projected_completion_count": "3",
-    "projected_month": "4",
+    "projected_completion_count": "248",
+    "projected_month": "5",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "9",
-    "success_rate": "0.9",
-    "projected_completion_count": "10",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.88",
-    "projected_completion_count": "50",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.541666666667",
-    "projected_completion_count": "72",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "72",
-    "success_rate": "0.765957446809",
-    "projected_completion_count": "94",
+    "district": "ALL",
+    "successful_termination_count": "120",
+    "success_rate": "0.478087649402",
+    "projected_completion_count": "251",
     "projected_month": "9",
     "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.5",
-    "projected_completion_count": "36",
-    "projected_month": "10",
-    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "20",
-    "success_rate": "0.416666666667",
-    "projected_completion_count": "48",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.646153846154",
-    "projected_completion_count": "65",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "78",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.632183908046",
-    "projected_completion_count": "87",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.542168674699",
-    "projected_completion_count": "83",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.307692307692",
-    "projected_completion_count": "26",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.347826086957",
-    "projected_completion_count": "46",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.40243902439",
-    "projected_completion_count": "82",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.6",
-    "projected_completion_count": "25",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "9",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.9375",
-    "projected_completion_count": "16",
+    "district": "ALL",
+    "successful_termination_count": "283",
+    "success_rate": "0.822674418605",
+    "projected_completion_count": "344",
     "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "30",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.6",
-    "projected_completion_count": "90",
-    "projected_month": "2",
-    "projected_year": "2020",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "42",
-    "success_rate": "0.494117647059",
-    "projected_completion_count": "85",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.510638297872",
-    "projected_completion_count": "47",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "4",
     "successful_termination_count": "35",
     "success_rate": "0.614035087719",
     "projected_completion_count": "57",
-    "projected_month": "9",
-    "projected_year": "2017",
+    "projected_month": "1",
+    "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "56",
-    "success_rate": "1.0",
-    "projected_completion_count": "56",
+    "district": "3",
+    "successful_termination_count": "157",
+    "success_rate": "0.588014981273",
+    "projected_completion_count": "267",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "63",
+    "success_rate": "0.338709677419",
+    "projected_completion_count": "186",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "95",
+    "success_rate": "0.539772727273",
+    "projected_completion_count": "176",
     "projected_month": "2",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "3",
-    "success_rate": "0.6",
-    "projected_completion_count": "5",
-    "projected_month": "3",
+    "district": "2",
+    "successful_termination_count": "46",
+    "success_rate": "0.80701754386",
+    "projected_completion_count": "57",
+    "projected_month": "4",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "56",
-    "success_rate": "0.717948717949",
-    "projected_completion_count": "78",
+    "district": "5",
+    "successful_termination_count": "192",
+    "success_rate": "0.817021276596",
+    "projected_completion_count": "235",
     "projected_month": "5",
     "projected_year": "2018",
-    "supervision_type": "PROBATION",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "75",
-    "success_rate": "0.824175824176",
-    "projected_completion_count": "91",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.344444444444",
-    "projected_completion_count": "90",
-    "projected_month": "10",
+    "district": "3",
+    "successful_termination_count": "54",
+    "success_rate": "0.52427184466",
+    "projected_completion_count": "103",
+    "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "29",
-    "success_rate": "0.420289855072",
-    "projected_completion_count": "69",
-    "projected_month": "12",
+    "district": "12",
+    "successful_termination_count": "97",
+    "success_rate": "0.356617647059",
+    "projected_completion_count": "272",
+    "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
+    "district": "2",
     "successful_termination_count": "30",
-    "success_rate": "0.340909090909",
-    "projected_completion_count": "88",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.35",
-    "projected_completion_count": "60",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.928571428571",
-    "projected_completion_count": "14",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.46",
-    "projected_completion_count": "50",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.74358974359",
-    "projected_completion_count": "78",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "78",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.342105263158",
-    "projected_completion_count": "76",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "35",
     "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "1.0",
-    "projected_completion_count": "58",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "55",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.48",
-    "projected_completion_count": "25",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "45",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.344827586207",
-    "projected_completion_count": "58",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.756756756757",
-    "projected_completion_count": "37",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.8125",
-    "projected_completion_count": "32",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.753246753247",
-    "projected_completion_count": "77",
-    "projected_month": "3",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "15",
-    "success_rate": "0.75",
-    "projected_completion_count": "20",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "15",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.75",
-    "projected_completion_count": "4",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.323529411765",
-    "projected_completion_count": "34",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.747126436782",
-    "projected_completion_count": "87",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.977528089888",
-    "projected_completion_count": "89",
+    "district": "15",
+    "successful_termination_count": "220",
+    "success_rate": "0.72131147541",
+    "projected_completion_count": "305",
     "projected_month": "8",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "59",
-    "success_rate": "0.766233766234",
-    "projected_completion_count": "77",
-    "projected_month": "10",
+    "district": "7",
+    "successful_termination_count": "103",
+    "success_rate": "0.872881355932",
+    "projected_completion_count": "118",
+    "projected_month": "9",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "8",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "15",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "district": "11",
+    "successful_termination_count": "42",
+    "success_rate": "0.65625",
+    "projected_completion_count": "64",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "59",
-    "success_rate": "0.7375",
-    "projected_completion_count": "80",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "district": "7",
+    "successful_termination_count": "146",
+    "success_rate": "0.593495934959",
+    "projected_completion_count": "246",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "47",
-    "success_rate": "0.5875",
-    "projected_completion_count": "80",
-    "projected_month": "7",
+    "district": "13",
+    "successful_termination_count": "53",
+    "success_rate": "0.688311688312",
+    "projected_completion_count": "77",
+    "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "3",
+    "successful_termination_count": "22",
+    "success_rate": "0.458333333333",
+    "projected_completion_count": "48",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "60",
+    "success_rate": "0.392156862745",
+    "projected_completion_count": "153",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "100",
+    "success_rate": "0.806451612903",
+    "projected_completion_count": "124",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
     "successful_termination_count": "4",
     "success_rate": "0.666666666667",
     "projected_completion_count": "6",
-    "projected_month": "11",
+    "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "51",
-    "success_rate": "0.784615384615",
-    "projected_completion_count": "65",
+    "district": "4",
+    "successful_termination_count": "234",
+    "success_rate": "0.92125984252",
+    "projected_completion_count": "254",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "183",
+    "success_rate": "0.905940594059",
+    "projected_completion_count": "202",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "227",
+    "success_rate": "0.700617283951",
+    "projected_completion_count": "324",
     "projected_month": "12",
     "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "57",
-    "success_rate": "0.6",
-    "projected_completion_count": "95",
+    "district": "8",
+    "successful_termination_count": "165",
+    "success_rate": "0.760368663594",
+    "projected_completion_count": "217",
     "projected_month": "1",
     "projected_year": "2020",
-    "supervision_type": "PROBATION",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "8",
-    "success_rate": "1.0",
-    "projected_completion_count": "8",
-    "projected_month": "4",
+    "district": "13",
+    "successful_termination_count": "98",
+    "success_rate": "0.601226993865",
+    "projected_completion_count": "163",
+    "projected_month": "5",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "41",
-    "success_rate": "0.5125",
-    "projected_completion_count": "80",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "1.0",
-    "projected_completion_count": "9",
+    "district": "13",
+    "successful_termination_count": "258",
+    "success_rate": "0.743515850144",
+    "projected_completion_count": "347",
     "projected_month": "6",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "21",
-    "success_rate": "0.45652173913",
-    "projected_completion_count": "46",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.45",
-    "projected_completion_count": "20",
-    "projected_month": "8",
+    "district": "13",
+    "successful_termination_count": "201",
+    "success_rate": "0.681355932203",
+    "projected_completion_count": "295",
+    "projected_month": "9",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "1",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "3",
-    "projected_month": "1",
+    "district": "5",
+    "successful_termination_count": "14",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "18",
+    "projected_month": "2",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "42",
-    "success_rate": "0.488372093023",
-    "projected_completion_count": "86",
+    "district": "9",
+    "successful_termination_count": "106",
+    "success_rate": "0.5",
+    "projected_completion_count": "212",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "154",
+    "success_rate": "0.465256797583",
+    "projected_completion_count": "331",
     "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "78",
-    "success_rate": "0.962962962963",
-    "projected_completion_count": "81",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.808510638298",
-    "projected_completion_count": "47",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.522222222222",
-    "projected_completion_count": "90",
+    "district": "10",
+    "successful_termination_count": "71",
+    "success_rate": "0.331775700935",
+    "projected_completion_count": "214",
     "projected_month": "9",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "8",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "24",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "5",
     "successful_termination_count": "41",
-    "success_rate": "0.488095238095",
-    "projected_completion_count": "84",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.96",
-    "projected_completion_count": "25",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.307692307692",
-    "projected_completion_count": "13",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.542168674699",
-    "projected_completion_count": "83",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.90625",
-    "projected_completion_count": "64",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.54347826087",
-    "projected_completion_count": "46",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.944444444444",
-    "projected_completion_count": "36",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.459183673469",
-    "projected_completion_count": "98",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.747126436782",
-    "projected_completion_count": "87",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.794117647059",
-    "projected_completion_count": "34",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "60",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.634615384615",
-    "projected_completion_count": "52",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.6875",
+    "success_rate": "0.854166666667",
     "projected_completion_count": "48",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "0.932584269663",
-    "projected_completion_count": "89",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.824561403509",
-    "projected_completion_count": "57",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.673076923077",
-    "projected_completion_count": "52",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.652173913043",
-    "projected_completion_count": "69",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.424242424242",
-    "projected_completion_count": "66",
-    "projected_month": "3",
+    "projected_month": "10",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "47",
-    "success_rate": "0.52808988764",
-    "projected_completion_count": "89",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "28",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.753846153846",
-    "projected_completion_count": "65",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.8",
-    "projected_completion_count": "25",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.538461538462",
-    "projected_completion_count": "13",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.534090909091",
-    "projected_completion_count": "88",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "21",
+    "district": "1",
+    "successful_termination_count": "181",
+    "success_rate": "0.546827794562",
+    "projected_completion_count": "331",
     "projected_month": "12",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "45",
-    "success_rate": "0.642857142857",
-    "projected_completion_count": "70",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.727272727273",
-    "projected_completion_count": "77",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.369565217391",
-    "projected_completion_count": "46",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "39",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.440476190476",
-    "projected_completion_count": "84",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.880952380952",
-    "projected_completion_count": "42",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.964285714286",
-    "projected_completion_count": "28",
+    "district": "8",
+    "successful_termination_count": "101",
+    "success_rate": "0.647435897436",
+    "projected_completion_count": "156",
     "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.352941176471",
-    "projected_completion_count": "51",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.5",
-    "projected_completion_count": "20",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.587628865979",
-    "projected_completion_count": "97",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "65",
-    "projected_month": "9",
-    "projected_year": "2017",
+    "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "10",
     "successful_termination_count": "33",
-    "success_rate": "0.846153846154",
-    "projected_completion_count": "39",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.6",
-    "projected_completion_count": "50",
-    "projected_month": "10",
-    "projected_year": "2017",
+    "success_rate": "0.916666666667",
+    "projected_completion_count": "36",
+    "projected_month": "2",
+    "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "37",
-    "success_rate": "1.0",
-    "projected_completion_count": "37",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.35",
-    "projected_completion_count": "60",
-    "projected_month": "1",
-    "projected_year": "2018",
+    "district": "17",
+    "successful_termination_count": "249",
+    "success_rate": "0.936090225564",
+    "projected_completion_count": "266",
+    "projected_month": "3",
+    "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "20",
-    "success_rate": "0.588235294118",
-    "projected_completion_count": "34",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "28",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.5",
-    "projected_completion_count": "8",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.696202531646",
+    "district": "5",
+    "successful_termination_count": "67",
+    "success_rate": "0.848101265823",
     "projected_completion_count": "79",
     "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.771428571429",
-    "projected_completion_count": "35",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.818181818182",
-    "projected_completion_count": "11",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.486486486486",
-    "projected_completion_count": "37",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.509090909091",
-    "projected_completion_count": "55",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "9",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.641791044776",
-    "projected_completion_count": "67",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.75",
-    "projected_completion_count": "100",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.402597402597",
-    "projected_completion_count": "77",
-    "projected_month": "4",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "37",
-    "success_rate": "0.770833333333",
-    "projected_completion_count": "48",
+    "district": "15",
+    "successful_termination_count": "84",
+    "success_rate": "0.661417322835",
+    "projected_completion_count": "127",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "165",
+    "success_rate": "0.726872246696",
+    "projected_completion_count": "227",
     "projected_month": "6",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "35",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "55",
-    "projected_month": "8",
+    "district": "13",
+    "successful_termination_count": "90",
+    "success_rate": "0.5625",
+    "projected_completion_count": "160",
+    "projected_month": "7",
     "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "3",
-    "success_rate": "0.272727272727",
-    "projected_completion_count": "11",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.483870967742",
-    "projected_completion_count": "93",
+    "district": "7",
+    "successful_termination_count": "293",
+    "success_rate": "0.98322147651",
+    "projected_completion_count": "298",
     "projected_month": "10",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "70",
-    "success_rate": "0.736842105263",
-    "projected_completion_count": "95",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.864864864865",
-    "projected_completion_count": "37",
+    "district": "8",
+    "successful_termination_count": "215",
+    "success_rate": "0.749128919861",
+    "projected_completion_count": "287",
     "projected_month": "3",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "13",
-    "success_rate": "1.0",
-    "projected_completion_count": "13",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.933333333333",
-    "projected_completion_count": "30",
+    "district": "1",
+    "successful_termination_count": "287",
+    "success_rate": "0.859281437126",
+    "projected_completion_count": "334",
     "projected_month": "5",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "4",
+    "successful_termination_count": "285",
+    "success_rate": "0.838235294118",
+    "projected_completion_count": "340",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
     "successful_termination_count": "46",
-    "success_rate": "0.730158730159",
-    "projected_completion_count": "63",
-    "projected_month": "6",
-    "projected_year": "2020",
+    "success_rate": "0.362204724409",
+    "projected_completion_count": "127",
+    "projected_month": "8",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "34",
-    "success_rate": "0.357894736842",
-    "projected_completion_count": "95",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.320754716981",
-    "projected_completion_count": "53",
+    "district": "10",
+    "successful_termination_count": "9",
+    "success_rate": "0.642857142857",
+    "projected_completion_count": "14",
     "projected_month": "10",
     "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.733333333333",
-    "projected_completion_count": "15",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.553191489362",
-    "projected_completion_count": "47",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.545454545455",
-    "projected_completion_count": "99",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.810344827586",
-    "projected_completion_count": "58",
-    "projected_month": "3",
-    "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "49",
-    "success_rate": "0.742424242424",
-    "projected_completion_count": "66",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.764705882353",
-    "projected_completion_count": "34",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.842105263158",
-    "projected_completion_count": "76",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.872340425532",
-    "projected_completion_count": "47",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.620689655172",
-    "projected_completion_count": "29",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "1.0",
-    "projected_completion_count": "6",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.860465116279",
-    "projected_completion_count": "43",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.612244897959",
-    "projected_completion_count": "49",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.434782608696",
-    "projected_completion_count": "23",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.625",
-    "projected_completion_count": "40",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.565217391304",
-    "projected_completion_count": "46",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.866666666667",
-    "projected_completion_count": "30",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.342857142857",
-    "projected_completion_count": "35",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.35632183908",
-    "projected_completion_count": "87",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "22",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.4",
-    "projected_completion_count": "5",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.692307692308",
-    "projected_completion_count": "65",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.573333333333",
-    "projected_completion_count": "75",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.484536082474",
-    "projected_completion_count": "97",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.466666666667",
-    "projected_completion_count": "15",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.44",
-    "projected_completion_count": "100",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.68",
-    "projected_completion_count": "75",
+    "district": "1",
+    "successful_termination_count": "65",
+    "success_rate": "0.40625",
+    "projected_completion_count": "160",
     "projected_month": "11",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "8",
-    "success_rate": "0.380952380952",
-    "projected_completion_count": "21",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.588235294118",
-    "projected_completion_count": "34",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.425",
-    "projected_completion_count": "40",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.545454545455",
-    "projected_completion_count": "22",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.672131147541",
-    "projected_completion_count": "61",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "75",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.794117647059",
-    "projected_completion_count": "34",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.322033898305",
-    "projected_completion_count": "59",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "80",
-    "success_rate": "0.93023255814",
-    "projected_completion_count": "86",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.384615384615",
-    "projected_completion_count": "39",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.34375",
-    "projected_completion_count": "96",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "31",
-    "success_rate": "0.794871794872",
-    "projected_completion_count": "39",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.318181818182",
-    "projected_completion_count": "22",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.627450980392",
-    "projected_completion_count": "51",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.947368421053",
-    "projected_completion_count": "19",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "28",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "1.0",
-    "projected_completion_count": "11",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.329268292683",
-    "projected_completion_count": "82",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "1",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "11",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "0.96511627907",
-    "projected_completion_count": "86",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.550561797753",
-    "projected_completion_count": "89",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.807692307692",
-    "projected_completion_count": "52",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.52808988764",
-    "projected_completion_count": "89",
+    "district": "17",
+    "successful_termination_count": "221",
+    "success_rate": "0.928571428571",
+    "projected_completion_count": "238",
     "projected_month": "11",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "24",
-    "success_rate": "0.342857142857",
-    "projected_completion_count": "70",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.820512820513",
-    "projected_completion_count": "39",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "63",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "81",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.643835616438",
-    "projected_completion_count": "73",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.7625",
+    "district": "2",
+    "successful_termination_count": "77",
+    "success_rate": "0.9625",
     "projected_completion_count": "80",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "38",
+    "success_rate": "0.372549019608",
+    "projected_completion_count": "102",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "66",
+    "success_rate": "0.573913043478",
+    "projected_completion_count": "115",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "34",
+    "success_rate": "0.523076923077",
+    "projected_completion_count": "65",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "20",
+    "success_rate": "0.740740740741",
+    "projected_completion_count": "27",
     "projected_month": "8",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "55",
-    "success_rate": "0.932203389831",
-    "projected_completion_count": "59",
+    "district": "5",
+    "successful_termination_count": "10",
+    "success_rate": "0.5",
+    "projected_completion_count": "20",
     "projected_month": "11",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "28",
-    "success_rate": "0.373333333333",
-    "projected_completion_count": "75",
+    "district": "11",
+    "successful_termination_count": "276",
+    "success_rate": "0.804664723032",
+    "projected_completion_count": "343",
     "projected_month": "12",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "19",
-    "success_rate": "0.904761904762",
-    "projected_completion_count": "21",
+    "district": "13",
+    "successful_termination_count": "203",
+    "success_rate": "0.685810810811",
+    "projected_completion_count": "296",
     "projected_month": "12",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "57",
-    "success_rate": "0.575757575758",
-    "projected_completion_count": "99",
+    "district": "3",
+    "successful_termination_count": "26",
+    "success_rate": "0.590909090909",
+    "projected_completion_count": "44",
     "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "14",
-    "success_rate": "0.388888888889",
-    "projected_completion_count": "36",
+    "district": "12",
+    "successful_termination_count": "231",
+    "success_rate": "0.888461538462",
+    "projected_completion_count": "260",
     "projected_month": "4",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "35",
-    "success_rate": "0.795454545455",
-    "projected_completion_count": "44",
+    "district": "ALL",
+    "successful_termination_count": "218",
+    "success_rate": "0.935622317597",
+    "projected_completion_count": "233",
     "projected_month": "6",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "33",
-    "success_rate": "0.485294117647",
-    "projected_completion_count": "68",
+    "district": "6",
+    "successful_termination_count": "103",
+    "success_rate": "0.786259541985",
+    "projected_completion_count": "131",
     "projected_month": "7",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "6",
-    "success_rate": "0.461538461538",
-    "projected_completion_count": "13",
+    "district": "1",
+    "successful_termination_count": "101",
+    "success_rate": "0.381132075472",
+    "projected_completion_count": "265",
     "projected_month": "7",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "40",
-    "success_rate": "0.8",
-    "projected_completion_count": "50",
+    "district": "11",
+    "successful_termination_count": "284",
+    "success_rate": "0.962711864407",
+    "projected_completion_count": "295",
     "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "7",
-    "success_rate": "0.875",
+    "district": "2",
+    "successful_termination_count": "3",
+    "success_rate": "0.375",
     "projected_completion_count": "8",
     "projected_month": "8",
     "projected_year": "2019",
@@ -6552,773 +880,3759 @@
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "48",
-    "success_rate": "0.533333333333",
-    "projected_completion_count": "90",
+    "district": "3",
+    "successful_termination_count": "106",
+    "success_rate": "0.598870056497",
+    "projected_completion_count": "177",
     "projected_month": "9",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "49",
-    "success_rate": "0.830508474576",
-    "projected_completion_count": "59",
+    "district": "11",
+    "successful_termination_count": "178",
+    "success_rate": "0.735537190083",
+    "projected_completion_count": "242",
     "projected_month": "9",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "10",
-    "success_rate": "0.588235294118",
-    "projected_completion_count": "17",
+    "district": "1",
+    "successful_termination_count": "129",
+    "success_rate": "0.661538461538",
+    "projected_completion_count": "195",
     "projected_month": "10",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "23",
-    "success_rate": "0.741935483871",
-    "projected_completion_count": "31",
+    "district": "12",
+    "successful_termination_count": "294",
+    "success_rate": "0.983277591973",
+    "projected_completion_count": "299",
     "projected_month": "10",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "3",
-    "success_rate": "0.6",
-    "projected_completion_count": "5",
+    "district": "18",
+    "successful_termination_count": "56",
+    "success_rate": "0.861538461538",
+    "projected_completion_count": "65",
     "projected_month": "11",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "40",
-    "success_rate": "0.816326530612",
-    "projected_completion_count": "49",
+    "district": "2",
+    "successful_termination_count": "43",
+    "success_rate": "0.767857142857",
+    "projected_completion_count": "56",
     "projected_month": "1",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "3",
+    "successful_termination_count": "130",
+    "success_rate": "0.471014492754",
+    "projected_completion_count": "276",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "98",
+    "success_rate": "0.56976744186",
+    "projected_completion_count": "172",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "39",
+    "success_rate": "0.975",
+    "projected_completion_count": "40",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "167",
+    "success_rate": "0.509146341463",
+    "projected_completion_count": "328",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "59",
+    "success_rate": "0.37106918239",
+    "projected_completion_count": "159",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
     "successful_termination_count": "49",
     "success_rate": "0.777777777778",
     "projected_completion_count": "63",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.782051282051",
-    "projected_completion_count": "78",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "40",
-    "success_rate": "0.459770114943",
-    "projected_completion_count": "87",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.862068965517",
-    "projected_completion_count": "87",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.469135802469",
-    "projected_completion_count": "81",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.55",
-    "projected_completion_count": "40",
     "projected_month": "7",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "7",
-    "success_rate": "0.7",
-    "projected_completion_count": "10",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.457627118644",
-    "projected_completion_count": "59",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.611111111111",
-    "projected_completion_count": "36",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.506666666667",
-    "projected_completion_count": "75",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.768115942029",
-    "projected_completion_count": "69",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "9",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "4",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "7",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.491525423729",
-    "projected_completion_count": "59",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.888888888889",
-    "projected_completion_count": "18",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "70",
-    "success_rate": "0.958904109589",
-    "projected_completion_count": "73",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.928571428571",
-    "projected_completion_count": "14",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "30",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.9",
-    "projected_completion_count": "20",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.708333333333",
-    "projected_completion_count": "48",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.4",
-    "projected_completion_count": "40",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.602272727273",
-    "projected_completion_count": "88",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "69",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.779661016949",
-    "projected_completion_count": "59",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "78",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.452830188679",
-    "projected_completion_count": "53",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.4",
-    "projected_completion_count": "15",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.5",
-    "projected_completion_count": "24",
+    "district": "13",
+    "successful_termination_count": "122",
+    "success_rate": "0.953125",
+    "projected_completion_count": "128",
     "projected_month": "8",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "32",
-    "success_rate": "0.492307692308",
-    "projected_completion_count": "65",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "1.0",
-    "projected_completion_count": "5",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.452830188679",
-    "projected_completion_count": "53",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "1.0",
-    "projected_completion_count": "5",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.415094339623",
-    "projected_completion_count": "53",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.47",
-    "projected_completion_count": "100",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.5625",
-    "projected_completion_count": "32",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.454545454545",
-    "projected_completion_count": "66",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.466666666667",
-    "projected_completion_count": "60",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "2",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.871794871795",
-    "projected_completion_count": "39",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.58064516129",
-    "projected_completion_count": "31",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.393939393939",
-    "projected_completion_count": "33",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.623188405797",
-    "projected_completion_count": "69",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.326923076923",
-    "projected_completion_count": "52",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.75",
-    "projected_completion_count": "56",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.741935483871",
-    "projected_completion_count": "62",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "80",
-    "success_rate": "0.842105263158",
-    "projected_completion_count": "95",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "83",
-    "success_rate": "0.954022988506",
-    "projected_completion_count": "87",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.416666666667",
-    "projected_completion_count": "84",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "33",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.890909090909",
+    "district": "6",
+    "successful_termination_count": "33",
+    "success_rate": "0.6",
     "projected_completion_count": "55",
-    "projected_month": "2",
-    "projected_year": "2018",
+    "projected_month": "8",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "53",
-    "success_rate": "0.53",
-    "projected_completion_count": "100",
+    "district": "7",
+    "successful_termination_count": "147",
+    "success_rate": "0.633620689655",
+    "projected_completion_count": "232",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "14",
+    "success_rate": "0.4",
+    "projected_completion_count": "35",
     "projected_month": "5",
     "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "30",
+    "success_rate": "0.75",
+    "projected_completion_count": "40",
+    "projected_month": "6",
+    "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "56",
-    "success_rate": "0.756756756757",
-    "projected_completion_count": "74",
-    "projected_month": "8",
+    "district": "13",
+    "successful_termination_count": "187",
+    "success_rate": "0.907766990291",
+    "projected_completion_count": "206",
+    "projected_month": "7",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "24",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "42",
-    "projected_month": "11",
+    "district": "16",
+    "successful_termination_count": "4",
+    "success_rate": "1.0",
+    "projected_completion_count": "4",
+    "projected_month": "9",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "28",
-    "success_rate": "0.373333333333",
-    "projected_completion_count": "75",
-    "projected_month": "12",
+    "district": "15",
+    "successful_termination_count": "79",
+    "success_rate": "0.711711711712",
+    "projected_completion_count": "111",
+    "projected_month": "10",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "35",
-    "success_rate": "0.460526315789",
-    "projected_completion_count": "76",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "10",
     "successful_termination_count": "23",
     "success_rate": "0.433962264151",
     "projected_completion_count": "53",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.75",
-    "projected_completion_count": "28",
-    "projected_month": "5",
-    "projected_year": "2019",
+    "projected_month": "11",
+    "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "55",
-    "success_rate": "0.901639344262",
-    "projected_completion_count": "61",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.402777777778",
-    "projected_completion_count": "72",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "10",
     "successful_termination_count": "17",
-    "success_rate": "1.0",
-    "projected_completion_count": "17",
-    "projected_month": "7",
+    "success_rate": "0.34",
+    "projected_completion_count": "50",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "252",
+    "success_rate": "0.893617021277",
+    "projected_completion_count": "282",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "252",
+    "success_rate": "0.842809364548",
+    "projected_completion_count": "299",
+    "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "41",
-    "success_rate": "0.476744186047",
-    "projected_completion_count": "86",
-    "projected_month": "7",
+    "district": "8",
+    "successful_termination_count": "29",
+    "success_rate": "0.408450704225",
+    "projected_completion_count": "71",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "24",
+    "success_rate": "0.489795918367",
+    "projected_completion_count": "49",
+    "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "62",
-    "success_rate": "0.62",
-    "projected_completion_count": "100",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.468085106383",
-    "projected_completion_count": "47",
+    "district": "3",
+    "successful_termination_count": "14",
+    "success_rate": "0.875",
+    "projected_completion_count": "16",
     "projected_month": "11",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "12",
-    "success_rate": "0.363636363636",
-    "projected_completion_count": "33",
+    "district": "10",
+    "successful_termination_count": "164",
+    "success_rate": "0.762790697674",
+    "projected_completion_count": "215",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "24",
+    "success_rate": "0.48",
+    "projected_completion_count": "50",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "92",
+    "success_rate": "0.634482758621",
+    "projected_completion_count": "145",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "89",
+    "success_rate": "0.566878980892",
+    "projected_completion_count": "157",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "203",
+    "success_rate": "0.805555555556",
+    "projected_completion_count": "252",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "7",
+    "success_rate": "0.583333333333",
+    "projected_completion_count": "12",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "134",
+    "success_rate": "0.414860681115",
+    "projected_completion_count": "323",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "92",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "138",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "88",
+    "success_rate": "0.704",
+    "projected_completion_count": "125",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "115",
+    "success_rate": "0.741935483871",
+    "projected_completion_count": "155",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "244",
+    "success_rate": "0.890510948905",
+    "projected_completion_count": "274",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "27",
+    "success_rate": "0.964285714286",
+    "projected_completion_count": "28",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "87",
+    "success_rate": "0.925531914894",
+    "projected_completion_count": "94",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "109",
+    "success_rate": "0.973214285714",
+    "projected_completion_count": "112",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "10",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "22",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "97",
+    "success_rate": "0.342756183746",
+    "projected_completion_count": "283",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "5",
+    "success_rate": "0.357142857143",
+    "projected_completion_count": "14",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "161",
+    "success_rate": "0.493865030675",
+    "projected_completion_count": "326",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "130",
+    "success_rate": "0.977443609023",
+    "projected_completion_count": "133",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "171",
+    "success_rate": "0.568106312292",
+    "projected_completion_count": "301",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "264",
+    "success_rate": "0.96",
+    "projected_completion_count": "275",
     "projected_month": "2",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "54",
-    "success_rate": "0.830769230769",
-    "projected_completion_count": "65",
+    "district": "7",
+    "successful_termination_count": "166",
+    "success_rate": "0.56462585034",
+    "projected_completion_count": "294",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "91",
+    "success_rate": "0.522988505747",
+    "projected_completion_count": "174",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "104",
+    "success_rate": "0.481481481481",
+    "projected_completion_count": "216",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "184",
+    "success_rate": "0.603278688525",
+    "projected_completion_count": "305",
     "projected_month": "8",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "16",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "24",
+    "district": "10",
+    "successful_termination_count": "153",
+    "success_rate": "0.437142857143",
+    "projected_completion_count": "350",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "126",
+    "success_rate": "0.409090909091",
+    "projected_completion_count": "308",
     "projected_month": "9",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "4",
-    "success_rate": "0.5",
-    "projected_completion_count": "8",
+    "district": "16",
+    "successful_termination_count": "179",
+    "success_rate": "0.724696356275",
+    "projected_completion_count": "247",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "296",
+    "success_rate": "0.922118380062",
+    "projected_completion_count": "321",
     "projected_month": "10",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "76",
-    "success_rate": "0.95",
-    "projected_completion_count": "80",
-    "projected_month": "10",
-    "projected_year": "2017",
+    "district": "17",
+    "successful_termination_count": "270",
+    "success_rate": "0.780346820809",
+    "projected_completion_count": "346",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "124",
+    "success_rate": "0.409240924092",
+    "projected_completion_count": "303",
+    "projected_month": "3",
+    "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "9",
-    "success_rate": "0.375",
-    "projected_completion_count": "24",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "71",
-    "success_rate": "0.934210526316",
-    "projected_completion_count": "76",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.790322580645",
-    "projected_completion_count": "62",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.632183908046",
-    "projected_completion_count": "87",
+    "district": "2",
+    "successful_termination_count": "226",
+    "success_rate": "0.893280632411",
+    "projected_completion_count": "253",
     "projected_month": "5",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "94",
-    "success_rate": "0.979166666667",
-    "projected_completion_count": "96",
+    "district": "12",
+    "successful_termination_count": "53",
+    "success_rate": "0.646341463415",
+    "projected_completion_count": "82",
     "projected_month": "6",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "28",
-    "success_rate": "0.430769230769",
-    "projected_completion_count": "65",
+    "district": "1",
+    "successful_termination_count": "124",
+    "success_rate": "0.729411764706",
+    "projected_completion_count": "170",
     "projected_month": "7",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "74",
-    "success_rate": "0.762886597938",
-    "projected_completion_count": "97",
+    "district": "8",
+    "successful_termination_count": "61",
+    "success_rate": "0.580952380952",
+    "projected_completion_count": "105",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "119",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "189",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "18",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "42",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "146",
+    "success_rate": "0.843930635838",
+    "projected_completion_count": "173",
     "projected_month": "9",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "16",
-    "success_rate": "0.941176470588",
-    "projected_completion_count": "17",
-    "projected_month": "12",
+    "district": "6",
+    "successful_termination_count": "130",
+    "success_rate": "0.593607305936",
+    "projected_completion_count": "219",
+    "projected_month": "9",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "23",
-    "success_rate": "0.884615384615",
-    "projected_completion_count": "26",
+    "district": "1",
+    "successful_termination_count": "249",
+    "success_rate": "0.800643086817",
+    "projected_completion_count": "311",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "158",
+    "success_rate": "0.54295532646",
+    "projected_completion_count": "291",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "227",
+    "success_rate": "0.652298850575",
+    "projected_completion_count": "348",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "136",
+    "success_rate": "0.877419354839",
+    "projected_completion_count": "155",
     "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "68",
-    "success_rate": "0.739130434783",
-    "projected_completion_count": "92",
+    "district": "16",
+    "successful_termination_count": "72",
+    "success_rate": "0.4",
+    "projected_completion_count": "180",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "131",
+    "success_rate": "0.528225806452",
+    "projected_completion_count": "248",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "153",
+    "success_rate": "0.518644067797",
+    "projected_completion_count": "295",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "20",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "30",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "84",
+    "success_rate": "0.965517241379",
+    "projected_completion_count": "87",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "158",
+    "success_rate": "0.610038610039",
+    "projected_completion_count": "259",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "86",
+    "success_rate": "0.521212121212",
+    "projected_completion_count": "165",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "58",
+    "success_rate": "0.345238095238",
+    "projected_completion_count": "168",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "214",
+    "success_rate": "0.629411764706",
+    "projected_completion_count": "340",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "146",
+    "success_rate": "0.660633484163",
+    "projected_completion_count": "221",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "169",
+    "success_rate": "0.665354330709",
+    "projected_completion_count": "254",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "308",
+    "success_rate": "0.980891719745",
+    "projected_completion_count": "314",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "170",
+    "success_rate": "0.988372093023",
+    "projected_completion_count": "172",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "214",
+    "success_rate": "0.884297520661",
+    "projected_completion_count": "242",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "121",
+    "success_rate": "0.443223443223",
+    "projected_completion_count": "273",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "193",
+    "success_rate": "0.57100591716",
+    "projected_completion_count": "338",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "25",
+    "success_rate": "1.0",
+    "projected_completion_count": "25",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "159",
+    "success_rate": "0.646341463415",
+    "projected_completion_count": "246",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "117",
+    "success_rate": "0.400684931507",
+    "projected_completion_count": "292",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "23",
+    "success_rate": "0.92",
+    "projected_completion_count": "25",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "65",
+    "success_rate": "0.52",
+    "projected_completion_count": "125",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "149",
+    "success_rate": "0.980263157895",
+    "projected_completion_count": "152",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "204",
+    "success_rate": "0.864406779661",
+    "projected_completion_count": "236",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "103",
+    "success_rate": "0.476851851852",
+    "projected_completion_count": "216",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "193",
+    "success_rate": "0.850220264317",
+    "projected_completion_count": "227",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "146",
+    "success_rate": "0.722772277228",
+    "projected_completion_count": "202",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "98",
+    "success_rate": "0.604938271605",
+    "projected_completion_count": "162",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "98",
+    "success_rate": "0.420600858369",
+    "projected_completion_count": "233",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "46",
+    "success_rate": "0.884615384615",
+    "projected_completion_count": "52",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "127",
+    "success_rate": "0.437931034483",
+    "projected_completion_count": "290",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "118",
+    "success_rate": "0.374603174603",
+    "projected_completion_count": "315",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "139",
+    "success_rate": "0.401734104046",
+    "projected_completion_count": "346",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "84",
+    "success_rate": "0.388888888889",
+    "projected_completion_count": "216",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "166",
+    "success_rate": "0.477011494253",
+    "projected_completion_count": "348",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "35",
+    "success_rate": "0.388888888889",
+    "projected_completion_count": "90",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "132",
+    "success_rate": "0.992481203008",
+    "projected_completion_count": "133",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "123",
+    "success_rate": "0.414141414141",
+    "projected_completion_count": "297",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "136",
+    "success_rate": "0.559670781893",
+    "projected_completion_count": "243",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "127",
+    "success_rate": "0.907142857143",
+    "projected_completion_count": "140",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "59",
+    "success_rate": "0.357575757576",
+    "projected_completion_count": "165",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "164",
+    "success_rate": "0.752293577982",
+    "projected_completion_count": "218",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "155",
+    "success_rate": "0.513245033113",
+    "projected_completion_count": "302",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "304",
+    "success_rate": "0.935384615385",
+    "projected_completion_count": "325",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "213",
+    "success_rate": "0.950892857143",
+    "projected_completion_count": "224",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "14",
+    "success_rate": "0.933333333333",
+    "projected_completion_count": "15",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "124",
+    "success_rate": "0.733727810651",
+    "projected_completion_count": "169",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "286",
+    "success_rate": "0.899371069182",
+    "projected_completion_count": "318",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "98",
+    "success_rate": "0.563218390805",
+    "projected_completion_count": "174",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "56",
+    "success_rate": "0.402877697842",
+    "projected_completion_count": "139",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "49",
+    "success_rate": "0.494949494949",
+    "projected_completion_count": "99",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "42",
+    "success_rate": "0.893617021277",
+    "projected_completion_count": "47",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "64",
+    "success_rate": "0.646464646465",
+    "projected_completion_count": "99",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "97",
+    "success_rate": "0.92380952381",
+    "projected_completion_count": "105",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "316",
+    "success_rate": "0.993710691824",
+    "projected_completion_count": "318",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "216",
+    "success_rate": "0.658536585366",
+    "projected_completion_count": "328",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "148",
+    "success_rate": "0.490066225166",
+    "projected_completion_count": "302",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "258",
+    "success_rate": "0.752186588921",
+    "projected_completion_count": "343",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "161",
+    "success_rate": "0.596296296296",
+    "projected_completion_count": "270",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "79",
+    "success_rate": "0.774509803922",
+    "projected_completion_count": "102",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "116",
+    "success_rate": "0.446153846154",
+    "projected_completion_count": "260",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "94",
+    "success_rate": "0.959183673469",
+    "projected_completion_count": "98",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "59",
+    "success_rate": "0.495798319328",
+    "projected_completion_count": "119",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "73",
+    "success_rate": "0.9125",
+    "projected_completion_count": "80",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "23",
+    "success_rate": "0.92",
+    "projected_completion_count": "25",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "84",
+    "success_rate": "0.477272727273",
+    "projected_completion_count": "176",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "6",
+    "success_rate": "0.461538461538",
+    "projected_completion_count": "13",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "15",
+    "success_rate": "0.681818181818",
+    "projected_completion_count": "22",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "69",
+    "success_rate": "0.621621621622",
+    "projected_completion_count": "111",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "167",
+    "success_rate": "0.897849462366",
+    "projected_completion_count": "186",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "259",
+    "success_rate": "0.74212034384",
+    "projected_completion_count": "349",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "21",
+    "success_rate": "0.567567567568",
+    "projected_completion_count": "37",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "184",
+    "success_rate": "0.609271523179",
+    "projected_completion_count": "302",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "29",
+    "success_rate": "1.0",
+    "projected_completion_count": "29",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "145",
+    "success_rate": "0.966666666667",
+    "projected_completion_count": "150",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "127",
+    "success_rate": "0.610576923077",
+    "projected_completion_count": "208",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "168",
+    "success_rate": "0.721030042918",
+    "projected_completion_count": "233",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "243",
+    "success_rate": "0.934615384615",
+    "projected_completion_count": "260",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "29",
+    "success_rate": "0.391891891892",
+    "projected_completion_count": "74",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "119",
+    "success_rate": "0.60101010101",
+    "projected_completion_count": "198",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "128",
+    "success_rate": "0.438356164384",
+    "projected_completion_count": "292",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "17",
+    "success_rate": "0.772727272727",
+    "projected_completion_count": "22",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "65",
+    "success_rate": "0.427631578947",
+    "projected_completion_count": "152",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "118",
+    "success_rate": "0.347058823529",
+    "projected_completion_count": "340",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "150",
+    "success_rate": "0.438596491228",
+    "projected_completion_count": "342",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "36",
+    "success_rate": "0.8",
+    "projected_completion_count": "45",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "115",
+    "success_rate": "0.332369942197",
+    "projected_completion_count": "346",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "308",
+    "success_rate": "0.887608069164",
+    "projected_completion_count": "347",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "220",
+    "success_rate": "0.658682634731",
+    "projected_completion_count": "334",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "143",
+    "success_rate": "0.572",
+    "projected_completion_count": "250",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "1",
+    "success_rate": "0.2",
+    "projected_completion_count": "5",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "139",
+    "success_rate": "0.434375",
+    "projected_completion_count": "320",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "27",
+    "success_rate": "0.457627118644",
+    "projected_completion_count": "59",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "23",
+    "success_rate": "0.489361702128",
+    "projected_completion_count": "47",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "87",
+    "success_rate": "0.358024691358",
+    "projected_completion_count": "243",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "30",
+    "success_rate": "0.731707317073",
+    "projected_completion_count": "41",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "137",
+    "success_rate": "0.477351916376",
+    "projected_completion_count": "287",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "232",
+    "success_rate": "0.711656441718",
+    "projected_completion_count": "326",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "23",
+    "success_rate": "0.479166666667",
+    "projected_completion_count": "48",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "23",
+    "success_rate": "0.547619047619",
+    "projected_completion_count": "42",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "6",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "7",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "321",
+    "success_rate": "0.941348973607",
+    "projected_completion_count": "341",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "23",
+    "success_rate": "0.766666666667",
+    "projected_completion_count": "30",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "231",
+    "success_rate": "0.970588235294",
+    "projected_completion_count": "238",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "63",
+    "success_rate": "0.940298507463",
+    "projected_completion_count": "67",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "136",
+    "success_rate": "0.906666666667",
+    "projected_completion_count": "150",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "220",
+    "success_rate": "0.728476821192",
+    "projected_completion_count": "302",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "109",
+    "success_rate": "0.608938547486",
+    "projected_completion_count": "179",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "161",
+    "success_rate": "0.585454545455",
+    "projected_completion_count": "275",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "209",
+    "success_rate": "0.639143730887",
+    "projected_completion_count": "327",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "20",
+    "success_rate": "0.512820512821",
+    "projected_completion_count": "39",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "126",
+    "success_rate": "0.422818791946",
+    "projected_completion_count": "298",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "109",
+    "success_rate": "0.807407407407",
+    "projected_completion_count": "135",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "62",
+    "success_rate": "0.645833333333",
+    "projected_completion_count": "96",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "144",
+    "success_rate": "0.5625",
+    "projected_completion_count": "256",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "54",
+    "success_rate": "0.885245901639",
+    "projected_completion_count": "61",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "21",
+    "success_rate": "1.0",
+    "projected_completion_count": "21",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "175",
+    "success_rate": "0.897435897436",
+    "projected_completion_count": "195",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "141",
+    "success_rate": "0.42987804878",
+    "projected_completion_count": "328",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "234",
+    "success_rate": "0.787878787879",
+    "projected_completion_count": "297",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "114",
+    "success_rate": "0.814285714286",
+    "projected_completion_count": "140",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "104",
+    "success_rate": "0.662420382166",
+    "projected_completion_count": "157",
     "projected_month": "1",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "4",
+    "successful_termination_count": "148",
+    "success_rate": "0.840909090909",
+    "projected_completion_count": "176",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "115",
+    "success_rate": "0.723270440252",
+    "projected_completion_count": "159",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "108",
+    "success_rate": "0.377622377622",
+    "projected_completion_count": "286",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "11",
+    "success_rate": "0.458333333333",
+    "projected_completion_count": "24",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "177",
+    "success_rate": "0.602040816327",
+    "projected_completion_count": "294",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "69",
+    "success_rate": "0.418181818182",
+    "projected_completion_count": "165",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "146",
+    "success_rate": "0.485049833887",
+    "projected_completion_count": "301",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "32",
+    "success_rate": "0.524590163934",
+    "projected_completion_count": "61",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "157",
+    "success_rate": "0.805128205128",
+    "projected_completion_count": "195",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "143",
+    "success_rate": "0.846153846154",
+    "projected_completion_count": "169",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "36",
+    "success_rate": "0.423529411765",
+    "projected_completion_count": "85",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "92",
+    "success_rate": "0.393162393162",
+    "projected_completion_count": "234",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "4",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "9",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "331",
+    "success_rate": "1.0",
+    "projected_completion_count": "331",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "37",
+    "success_rate": "0.381443298969",
+    "projected_completion_count": "97",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "66",
+    "success_rate": "0.458333333333",
+    "projected_completion_count": "144",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "41",
+    "success_rate": "0.532467532468",
+    "projected_completion_count": "77",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "68",
+    "success_rate": "0.723404255319",
+    "projected_completion_count": "94",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "65",
+    "success_rate": "0.970149253731",
+    "projected_completion_count": "67",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "203",
+    "success_rate": "0.676666666667",
+    "projected_completion_count": "300",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "56",
+    "success_rate": "0.33734939759",
+    "projected_completion_count": "166",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "181",
+    "success_rate": "0.529239766082",
+    "projected_completion_count": "342",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "2",
+    "success_rate": "0.285714285714",
+    "projected_completion_count": "7",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "113",
+    "success_rate": "0.862595419847",
+    "projected_completion_count": "131",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "7",
+    "success_rate": "0.318181818182",
+    "projected_completion_count": "22",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "123",
+    "success_rate": "0.611940298507",
+    "projected_completion_count": "201",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "147",
+    "success_rate": "0.665158371041",
+    "projected_completion_count": "221",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "145",
+    "success_rate": "0.828571428571",
+    "projected_completion_count": "175",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "6",
+    "success_rate": "1.0",
+    "projected_completion_count": "6",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "117",
+    "success_rate": "0.36",
+    "projected_completion_count": "325",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "108",
+    "success_rate": "0.650602409639",
+    "projected_completion_count": "166",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "27",
+    "success_rate": "0.341772151899",
+    "projected_completion_count": "79",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "79",
+    "success_rate": "0.348017621145",
+    "projected_completion_count": "227",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "51",
+    "success_rate": "0.621951219512",
+    "projected_completion_count": "82",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "87",
+    "success_rate": "0.54375",
+    "projected_completion_count": "160",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "23",
+    "success_rate": "0.547619047619",
+    "projected_completion_count": "42",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "45",
+    "success_rate": "0.865384615385",
+    "projected_completion_count": "52",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "65",
+    "success_rate": "0.855263157895",
+    "projected_completion_count": "76",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "166",
+    "success_rate": "0.603636363636",
+    "projected_completion_count": "275",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "45",
+    "success_rate": "0.412844036697",
+    "projected_completion_count": "109",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "14",
+    "success_rate": "0.424242424242",
+    "projected_completion_count": "33",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "115",
+    "success_rate": "0.463709677419",
+    "projected_completion_count": "248",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "11",
+    "success_rate": "0.733333333333",
+    "projected_completion_count": "15",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "154",
+    "success_rate": "0.836956521739",
+    "projected_completion_count": "184",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "116",
+    "success_rate": "0.644444444444",
+    "projected_completion_count": "180",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "101",
+    "success_rate": "0.643312101911",
+    "projected_completion_count": "157",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "166",
+    "success_rate": "0.507645259939",
+    "projected_completion_count": "327",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "33",
+    "success_rate": "0.970588235294",
+    "projected_completion_count": "34",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "6",
+    "success_rate": "1.0",
+    "projected_completion_count": "6",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "197",
+    "success_rate": "0.641693811075",
+    "projected_completion_count": "307",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "28",
+    "success_rate": "0.8",
+    "projected_completion_count": "35",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "132",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "143",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "117",
+    "success_rate": "0.436567164179",
+    "projected_completion_count": "268",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "30",
+    "success_rate": "0.588235294118",
+    "projected_completion_count": "51",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "197",
+    "success_rate": "0.879464285714",
+    "projected_completion_count": "224",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "108",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "136",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "108",
+    "success_rate": "0.972972972973",
+    "projected_completion_count": "111",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "69",
+    "success_rate": "0.370967741935",
+    "projected_completion_count": "186",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "130",
+    "success_rate": "0.896551724138",
+    "projected_completion_count": "145",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "277",
+    "success_rate": "0.849693251534",
+    "projected_completion_count": "326",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "88",
+    "success_rate": "0.682170542636",
+    "projected_completion_count": "129",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "12",
+    "success_rate": "0.413793103448",
+    "projected_completion_count": "29",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "23",
+    "success_rate": "0.92",
+    "projected_completion_count": "25",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "54",
+    "success_rate": "0.568421052632",
+    "projected_completion_count": "95",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "56",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "72",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "34",
+    "success_rate": "0.69387755102",
+    "projected_completion_count": "49",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "47",
+    "success_rate": "0.618421052632",
+    "projected_completion_count": "76",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "54",
+    "success_rate": "0.710526315789",
+    "projected_completion_count": "76",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "51",
+    "success_rate": "0.344594594595",
+    "projected_completion_count": "148",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "81",
+    "success_rate": "0.349137931034",
+    "projected_completion_count": "232",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "22",
+    "success_rate": "0.647058823529",
+    "projected_completion_count": "34",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "24",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "27",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "227",
+    "success_rate": "0.66568914956",
+    "projected_completion_count": "341",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "148",
+    "success_rate": "0.493333333333",
+    "projected_completion_count": "300",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "125",
+    "success_rate": "0.618811881188",
+    "projected_completion_count": "202",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "75",
+    "success_rate": "0.604838709677",
+    "projected_completion_count": "124",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "83",
+    "success_rate": "0.334677419355",
+    "projected_completion_count": "248",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "83",
+    "success_rate": "0.790476190476",
+    "projected_completion_count": "105",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "188",
+    "success_rate": "0.908212560386",
+    "projected_completion_count": "207",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "46",
+    "success_rate": "0.793103448276",
+    "projected_completion_count": "58",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "98",
+    "success_rate": "0.538461538462",
+    "projected_completion_count": "182",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "237",
+    "success_rate": "0.861818181818",
+    "projected_completion_count": "275",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "66",
+    "success_rate": "0.474820143885",
+    "projected_completion_count": "139",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "124",
+    "success_rate": "0.435087719298",
+    "projected_completion_count": "285",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "59",
+    "success_rate": "0.526785714286",
+    "projected_completion_count": "112",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "239",
+    "success_rate": "0.835664335664",
+    "projected_completion_count": "286",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "260",
+    "success_rate": "0.962962962963",
+    "projected_completion_count": "270",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "267",
+    "success_rate": "0.963898916968",
+    "projected_completion_count": "277",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "16",
+    "success_rate": "0.484848484848",
+    "projected_completion_count": "33",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "189",
+    "success_rate": "0.682310469314",
+    "projected_completion_count": "277",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "105",
+    "success_rate": "0.433884297521",
+    "projected_completion_count": "242",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "60",
+    "success_rate": "0.521739130435",
+    "projected_completion_count": "115",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "114",
+    "success_rate": "0.942148760331",
+    "projected_completion_count": "121",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "53",
+    "success_rate": "0.398496240602",
+    "projected_completion_count": "133",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "71",
+    "success_rate": "0.581967213115",
+    "projected_completion_count": "122",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "102",
+    "success_rate": "0.69387755102",
+    "projected_completion_count": "147",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "295",
+    "success_rate": "0.93949044586",
+    "projected_completion_count": "314",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "77",
+    "success_rate": "0.342222222222",
+    "projected_completion_count": "225",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "226",
+    "success_rate": "0.869230769231",
+    "projected_completion_count": "260",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "29",
+    "success_rate": "0.557692307692",
+    "projected_completion_count": "52",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "62",
+    "success_rate": "0.389937106918",
+    "projected_completion_count": "159",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "24",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "224",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "336",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "35",
+    "success_rate": "0.945945945946",
+    "projected_completion_count": "37",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "47",
+    "success_rate": "0.712121212121",
+    "projected_completion_count": "66",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
     "successful_termination_count": "48",
-    "success_rate": "0.75",
+    "success_rate": "0.64",
+    "projected_completion_count": "75",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "296",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "333",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "101",
+    "success_rate": "0.517948717949",
+    "projected_completion_count": "195",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "245",
+    "success_rate": "0.795454545455",
+    "projected_completion_count": "308",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "54",
+    "success_rate": "0.885245901639",
+    "projected_completion_count": "61",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "48",
+    "success_rate": "0.872727272727",
+    "projected_completion_count": "55",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "266",
+    "success_rate": "0.813455657492",
+    "projected_completion_count": "327",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "92",
+    "success_rate": "0.87619047619",
+    "projected_completion_count": "105",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "49",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "63",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "5",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "11",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "45",
+    "success_rate": "0.5625",
+    "projected_completion_count": "80",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "182",
+    "success_rate": "0.538461538462",
+    "projected_completion_count": "338",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "182",
+    "success_rate": "0.54328358209",
+    "projected_completion_count": "335",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "21",
+    "success_rate": "0.913043478261",
+    "projected_completion_count": "23",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "87",
+    "success_rate": "0.561290322581",
+    "projected_completion_count": "155",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "76",
+    "success_rate": "0.449704142012",
+    "projected_completion_count": "169",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "207",
+    "success_rate": "0.69",
+    "projected_completion_count": "300",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "87",
+    "success_rate": "0.386666666667",
+    "projected_completion_count": "225",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "187",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "297",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "12",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "21",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "26",
+    "success_rate": "0.722222222222",
+    "projected_completion_count": "36",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "92",
+    "success_rate": "0.821428571429",
+    "projected_completion_count": "112",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "41",
+    "success_rate": "0.344537815126",
+    "projected_completion_count": "119",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "67",
+    "success_rate": "1.0",
+    "projected_completion_count": "67",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "135",
+    "success_rate": "0.489130434783",
+    "projected_completion_count": "276",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "74",
+    "success_rate": "0.60162601626",
+    "projected_completion_count": "123",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "156",
+    "success_rate": "0.513157894737",
+    "projected_completion_count": "304",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "92",
+    "success_rate": "0.867924528302",
+    "projected_completion_count": "106",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "79",
+    "success_rate": "0.782178217822",
+    "projected_completion_count": "101",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "313",
+    "success_rate": "0.960122699387",
+    "projected_completion_count": "326",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "131",
+    "success_rate": "0.379710144928",
+    "projected_completion_count": "345",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "150",
+    "success_rate": "0.828729281768",
+    "projected_completion_count": "181",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "177",
+    "success_rate": "0.580327868852",
+    "projected_completion_count": "305",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "48",
+    "success_rate": "0.979591836735",
+    "projected_completion_count": "49",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "316",
+    "success_rate": "0.969325153374",
+    "projected_completion_count": "326",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "41",
+    "success_rate": "0.341666666667",
+    "projected_completion_count": "120",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "212",
+    "success_rate": "0.713804713805",
+    "projected_completion_count": "297",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "162",
+    "success_rate": "0.826530612245",
+    "projected_completion_count": "196",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "245",
+    "success_rate": "0.960784313725",
+    "projected_completion_count": "255",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "118",
+    "success_rate": "0.830985915493",
+    "projected_completion_count": "142",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "5",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "7",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "255",
+    "success_rate": "0.91726618705",
+    "projected_completion_count": "278",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "122",
+    "success_rate": "0.802631578947",
+    "projected_completion_count": "152",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "179",
+    "success_rate": "0.817351598174",
+    "projected_completion_count": "219",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "31",
+    "success_rate": "0.911764705882",
+    "projected_completion_count": "34",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "46",
+    "success_rate": "0.938775510204",
+    "projected_completion_count": "49",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "77",
+    "success_rate": "0.827956989247",
+    "projected_completion_count": "93",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "95",
+    "success_rate": "0.558823529412",
+    "projected_completion_count": "170",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "71",
+    "success_rate": "0.816091954023",
+    "projected_completion_count": "87",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "132",
+    "success_rate": "0.498113207547",
+    "projected_completion_count": "265",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "202",
+    "success_rate": "0.59587020649",
+    "projected_completion_count": "339",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "283",
+    "success_rate": "0.904153354633",
+    "projected_completion_count": "313",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "13",
+    "success_rate": "0.764705882353",
+    "projected_completion_count": "17",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "46",
+    "success_rate": "0.741935483871",
+    "projected_completion_count": "62",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "58",
+    "success_rate": "0.690476190476",
+    "projected_completion_count": "84",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "194",
+    "success_rate": "0.984771573604",
+    "projected_completion_count": "197",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "88",
+    "success_rate": "0.567741935484",
+    "projected_completion_count": "155",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "80",
+    "success_rate": "0.695652173913",
+    "projected_completion_count": "115",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "68",
+    "success_rate": "0.819277108434",
+    "projected_completion_count": "83",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "10",
+    "success_rate": "0.47619047619",
+    "projected_completion_count": "21",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "25",
+    "success_rate": "0.568181818182",
+    "projected_completion_count": "44",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "40",
+    "success_rate": "0.975609756098",
+    "projected_completion_count": "41",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "327",
+    "success_rate": "0.993920972644",
+    "projected_completion_count": "329",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "8",
+    "success_rate": "0.8",
+    "projected_completion_count": "10",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "180",
+    "success_rate": "0.989010989011",
+    "projected_completion_count": "182",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "48",
+    "success_rate": "0.5",
+    "projected_completion_count": "96",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "30",
+    "success_rate": "0.375",
+    "projected_completion_count": "80",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "216",
+    "success_rate": "0.79704797048",
+    "projected_completion_count": "271",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "72",
+    "success_rate": "0.409090909091",
+    "projected_completion_count": "176",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "17",
+    "success_rate": "0.894736842105",
+    "projected_completion_count": "19",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "133",
+    "success_rate": "0.93661971831",
+    "projected_completion_count": "142",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "100",
+    "success_rate": "0.469483568075",
+    "projected_completion_count": "213",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "147",
+    "success_rate": "0.57421875",
+    "projected_completion_count": "256",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "94",
+    "success_rate": "0.648275862069",
+    "projected_completion_count": "145",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "159",
+    "success_rate": "0.550173010381",
+    "projected_completion_count": "289",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "39",
+    "success_rate": "0.573529411765",
+    "projected_completion_count": "68",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "161",
+    "success_rate": "0.93063583815",
+    "projected_completion_count": "173",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "142",
+    "success_rate": "0.959459459459",
+    "projected_completion_count": "148",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "148",
+    "success_rate": "0.8",
+    "projected_completion_count": "185",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "62",
+    "success_rate": "0.96875",
     "projected_completion_count": "64",
     "projected_month": "2",
     "projected_year": "2019",
@@ -7326,341 +4640,2337 @@
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "27",
-    "success_rate": "0.586956521739",
-    "projected_completion_count": "46",
+    "district": "5",
+    "successful_termination_count": "179",
+    "success_rate": "0.526470588235",
+    "projected_completion_count": "340",
     "projected_month": "2",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "17",
-    "success_rate": "0.369565217391",
-    "projected_completion_count": "46",
+    "district": "2",
+    "successful_termination_count": "150",
+    "success_rate": "0.837988826816",
+    "projected_completion_count": "179",
     "projected_month": "3",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "54",
-    "success_rate": "0.794117647059",
-    "projected_completion_count": "68",
+    "district": "12",
+    "successful_termination_count": "109",
+    "success_rate": "0.502304147465",
+    "projected_completion_count": "217",
     "projected_month": "3",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "25",
-    "success_rate": "0.5",
-    "projected_completion_count": "50",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.924528301887",
-    "projected_completion_count": "53",
+    "district": "17",
+    "successful_termination_count": "171",
+    "success_rate": "0.521341463415",
+    "projected_completion_count": "328",
     "projected_month": "3",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "4",
-    "success_rate": "0.8",
-    "projected_completion_count": "5",
+    "district": "11",
+    "successful_termination_count": "132",
+    "success_rate": "0.591928251121",
+    "projected_completion_count": "223",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "214",
+    "success_rate": "0.981651376147",
+    "projected_completion_count": "218",
     "projected_month": "5",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "95",
-    "success_rate": "0.979381443299",
-    "projected_completion_count": "97",
+    "district": "8",
+    "successful_termination_count": "183",
+    "success_rate": "0.948186528497",
+    "projected_completion_count": "193",
     "projected_month": "5",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "61",
-    "success_rate": "0.67032967033",
-    "projected_completion_count": "91",
+    "district": "15",
+    "successful_termination_count": "260",
+    "success_rate": "0.838709677419",
+    "projected_completion_count": "310",
     "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "5",
-    "success_rate": "0.625",
-    "projected_completion_count": "8",
+    "district": "4",
+    "successful_termination_count": "125",
+    "success_rate": "0.374251497006",
+    "projected_completion_count": "334",
     "projected_month": "9",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "59",
-    "success_rate": "0.59595959596",
-    "projected_completion_count": "99",
+    "district": "12",
+    "successful_termination_count": "43",
+    "success_rate": "0.614285714286",
+    "projected_completion_count": "70",
     "projected_month": "10",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "67",
-    "success_rate": "0.690721649485",
-    "projected_completion_count": "97",
+    "district": "12",
+    "successful_termination_count": "136",
+    "success_rate": "0.396501457726",
+    "projected_completion_count": "343",
     "projected_month": "11",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "9",
-    "success_rate": "0.346153846154",
-    "projected_completion_count": "26",
+    "district": "9",
+    "successful_termination_count": "112",
+    "success_rate": "0.925619834711",
+    "projected_completion_count": "121",
     "projected_month": "2",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "24",
-    "success_rate": "0.358208955224",
-    "projected_completion_count": "67",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "61",
-    "success_rate": "0.663043478261",
-    "projected_completion_count": "92",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "81",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.5",
-    "projected_completion_count": "10",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "1.0",
-    "projected_completion_count": "3",
+    "district": "7",
+    "successful_termination_count": "20",
+    "success_rate": "0.4",
+    "projected_completion_count": "50",
     "projected_month": "11",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "25",
-    "success_rate": "0.675675675676",
-    "projected_completion_count": "37",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.80487804878",
-    "projected_completion_count": "41",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "72",
-    "success_rate": "0.757894736842",
-    "projected_completion_count": "95",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "77",
-    "success_rate": "0.895348837209",
-    "projected_completion_count": "86",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.507936507937",
-    "projected_completion_count": "63",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.9375",
-    "projected_completion_count": "16",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "85",
-    "success_rate": "0.934065934066",
-    "projected_completion_count": "91",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.463414634146",
-    "projected_completion_count": "41",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.48275862069",
-    "projected_completion_count": "29",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.607142857143",
-    "projected_completion_count": "28",
+    "district": "10",
+    "successful_termination_count": "4",
+    "success_rate": "0.8",
+    "projected_completion_count": "5",
     "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "104",
+    "success_rate": "0.604651162791",
+    "projected_completion_count": "172",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "164",
+    "success_rate": "0.677685950413",
+    "projected_completion_count": "242",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "189",
+    "success_rate": "0.613636363636",
+    "projected_completion_count": "308",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "136",
+    "success_rate": "0.457912457912",
+    "projected_completion_count": "297",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "62",
+    "success_rate": "0.607843137255",
+    "projected_completion_count": "102",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "119",
+    "success_rate": "0.734567901235",
+    "projected_completion_count": "162",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "232",
+    "success_rate": "0.73417721519",
+    "projected_completion_count": "316",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "150",
+    "success_rate": "0.773195876289",
+    "projected_completion_count": "194",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "189",
+    "success_rate": "0.979274611399",
+    "projected_completion_count": "193",
+    "projected_month": "2",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "10",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "14",
+    "district": "12",
+    "successful_termination_count": "300",
+    "success_rate": "0.900900900901",
+    "projected_completion_count": "333",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "84",
+    "success_rate": "0.407766990291",
+    "projected_completion_count": "206",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "46",
+    "success_rate": "0.511111111111",
+    "projected_completion_count": "90",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "50",
+    "success_rate": "0.632911392405",
+    "projected_completion_count": "79",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "254",
+    "success_rate": "0.824675324675",
+    "projected_completion_count": "308",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "20",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "24",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "71",
+    "success_rate": "0.5546875",
+    "projected_completion_count": "128",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "14",
+    "success_rate": "0.933333333333",
+    "projected_completion_count": "15",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "197",
+    "success_rate": "0.84188034188",
+    "projected_completion_count": "234",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "141",
+    "success_rate": "0.88679245283",
+    "projected_completion_count": "159",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "173",
+    "success_rate": "0.835748792271",
+    "projected_completion_count": "207",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "18",
+    "success_rate": "0.6",
+    "projected_completion_count": "30",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "168",
+    "success_rate": "0.893617021277",
+    "projected_completion_count": "188",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "226",
+    "success_rate": "0.804270462633",
+    "projected_completion_count": "281",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "11",
+    "success_rate": "0.846153846154",
+    "projected_completion_count": "13",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "60",
+    "success_rate": "0.451127819549",
+    "projected_completion_count": "133",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "201",
+    "success_rate": "0.830578512397",
+    "projected_completion_count": "242",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "237",
+    "success_rate": "0.709580838323",
+    "projected_completion_count": "334",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "57",
+    "success_rate": "0.4453125",
+    "projected_completion_count": "128",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "84",
+    "success_rate": "0.903225806452",
+    "projected_completion_count": "93",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "182",
+    "success_rate": "0.748971193416",
+    "projected_completion_count": "243",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "166",
+    "success_rate": "0.617100371747",
+    "projected_completion_count": "269",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "62",
+    "success_rate": "0.746987951807",
+    "projected_completion_count": "83",
     "projected_month": "1",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "14",
-    "success_rate": "0.7",
-    "projected_completion_count": "20",
-    "projected_month": "2",
+    "district": "15",
+    "successful_termination_count": "199",
+    "success_rate": "0.601208459215",
+    "projected_completion_count": "331",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "194",
+    "success_rate": "0.766798418972",
+    "projected_completion_count": "253",
+    "projected_month": "3",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "46",
-    "success_rate": "0.730158730159",
-    "projected_completion_count": "63",
+    "district": "10",
+    "successful_termination_count": "112",
+    "success_rate": "0.777777777778",
+    "projected_completion_count": "144",
     "projected_month": "4",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "10",
-    "success_rate": "0.47619047619",
-    "projected_completion_count": "21",
+    "district": "ALL",
+    "successful_termination_count": "54",
+    "success_rate": "0.870967741935",
+    "projected_completion_count": "62",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "131",
+    "success_rate": "0.935714285714",
+    "projected_completion_count": "140",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "58",
+    "success_rate": "0.5",
+    "projected_completion_count": "116",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "68",
+    "success_rate": "0.459459459459",
+    "projected_completion_count": "148",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "152",
+    "success_rate": "0.487179487179",
+    "projected_completion_count": "312",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "42",
+    "success_rate": "0.875",
+    "projected_completion_count": "48",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "163",
+    "success_rate": "0.747706422018",
+    "projected_completion_count": "218",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "62",
+    "success_rate": "0.369047619048",
+    "projected_completion_count": "168",
     "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "101",
+    "success_rate": "0.716312056738",
+    "projected_completion_count": "141",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "69",
+    "success_rate": "0.605263157895",
+    "projected_completion_count": "114",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "213",
+    "success_rate": "0.714765100671",
+    "projected_completion_count": "298",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "249",
+    "success_rate": "0.821782178218",
+    "projected_completion_count": "303",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "126",
+    "success_rate": "0.633165829146",
+    "projected_completion_count": "199",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "38",
+    "success_rate": "0.493506493506",
+    "projected_completion_count": "77",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "215",
+    "success_rate": "0.796296296296",
+    "projected_completion_count": "270",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "95",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "133",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "43",
+    "success_rate": "0.352459016393",
+    "projected_completion_count": "122",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "83",
+    "success_rate": "0.432291666667",
+    "projected_completion_count": "192",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "19",
+    "success_rate": "0.475",
+    "projected_completion_count": "40",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "76",
+    "success_rate": "0.426966292135",
+    "projected_completion_count": "178",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "23",
+    "success_rate": "0.71875",
+    "projected_completion_count": "32",
+    "projected_month": "7",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "29",
-    "success_rate": "0.604166666667",
-    "projected_completion_count": "48",
+    "district": "1",
+    "successful_termination_count": "137",
+    "success_rate": "0.410179640719",
+    "projected_completion_count": "334",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "107",
+    "success_rate": "0.946902654867",
+    "projected_completion_count": "113",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "190",
+    "success_rate": "0.954773869347",
+    "projected_completion_count": "199",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "152",
+    "success_rate": "0.605577689243",
+    "projected_completion_count": "251",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "111",
+    "success_rate": "0.735099337748",
+    "projected_completion_count": "151",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "51",
+    "success_rate": "0.439655172414",
+    "projected_completion_count": "116",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "131",
+    "success_rate": "0.766081871345",
+    "projected_completion_count": "171",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "17",
+    "success_rate": "0.85",
+    "projected_completion_count": "20",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "165",
+    "success_rate": "0.504587155963",
+    "projected_completion_count": "327",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "61",
+    "success_rate": "0.743902439024",
+    "projected_completion_count": "82",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "131",
+    "success_rate": "0.569565217391",
+    "projected_completion_count": "230",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "190",
+    "success_rate": "0.641891891892",
+    "projected_completion_count": "296",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "31",
+    "success_rate": "0.402597402597",
+    "projected_completion_count": "77",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "57",
+    "success_rate": "0.730769230769",
+    "projected_completion_count": "78",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "101",
+    "success_rate": "0.587209302326",
+    "projected_completion_count": "172",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "224",
+    "success_rate": "0.868217054264",
+    "projected_completion_count": "258",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "92",
+    "success_rate": "0.491978609626",
+    "projected_completion_count": "187",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "168",
+    "success_rate": "0.71186440678",
+    "projected_completion_count": "236",
     "projected_month": "9",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "57",
-    "success_rate": "1.0",
-    "projected_completion_count": "57",
+    "district": "12",
+    "successful_termination_count": "38",
+    "success_rate": "0.387755102041",
+    "projected_completion_count": "98",
     "projected_month": "10",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "13",
-    "success_rate": "0.722222222222",
-    "projected_completion_count": "18",
-    "projected_month": "10",
+    "district": "17",
+    "successful_termination_count": "166",
+    "success_rate": "0.907103825137",
+    "projected_completion_count": "183",
+    "projected_month": "11",
     "projected_year": "2017",
-    "supervision_type": "PROBATION",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "9",
-    "success_rate": "0.346153846154",
-    "projected_completion_count": "26",
+    "district": "4",
+    "successful_termination_count": "70",
+    "success_rate": "0.707070707071",
+    "projected_completion_count": "99",
     "projected_month": "12",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "64",
-    "success_rate": "0.780487804878",
-    "projected_completion_count": "82",
+    "district": "1",
+    "successful_termination_count": "133",
+    "success_rate": "0.610091743119",
+    "projected_completion_count": "218",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "80",
+    "success_rate": "0.353982300885",
+    "projected_completion_count": "226",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "2",
+    "success_rate": "0.25",
+    "projected_completion_count": "8",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "65",
+    "success_rate": "0.747126436782",
+    "projected_completion_count": "87",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "290",
+    "success_rate": "0.863095238095",
+    "projected_completion_count": "336",
     "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "30",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "42",
+    "district": "4",
+    "successful_termination_count": "53",
+    "success_rate": "0.427419354839",
+    "projected_completion_count": "124",
     "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "49",
-    "success_rate": "0.644736842105",
+    "district": "16",
+    "successful_termination_count": "7",
+    "success_rate": "0.5",
+    "projected_completion_count": "14",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "67",
+    "success_rate": "0.360215053763",
+    "projected_completion_count": "186",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "135",
+    "success_rate": "0.509433962264",
+    "projected_completion_count": "265",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "189",
+    "success_rate": "0.9",
+    "projected_completion_count": "210",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "15",
+    "success_rate": "0.6",
+    "projected_completion_count": "25",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "243",
+    "success_rate": "0.87725631769",
+    "projected_completion_count": "277",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "96",
+    "success_rate": "0.786885245902",
+    "projected_completion_count": "122",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "111",
+    "success_rate": "0.575129533679",
+    "projected_completion_count": "193",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "207",
+    "success_rate": "0.623493975904",
+    "projected_completion_count": "332",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "65",
+    "success_rate": "0.65",
+    "projected_completion_count": "100",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "87",
+    "success_rate": "0.674418604651",
+    "projected_completion_count": "129",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "294",
+    "success_rate": "0.921630094044",
+    "projected_completion_count": "319",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "147",
+    "success_rate": "0.521276595745",
+    "projected_completion_count": "282",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "4",
+    "success_rate": "0.285714285714",
+    "projected_completion_count": "14",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "117",
+    "success_rate": "0.928571428571",
+    "projected_completion_count": "126",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "7",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "11",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "13",
+    "success_rate": "0.361111111111",
+    "projected_completion_count": "36",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "120",
+    "success_rate": "0.377358490566",
+    "projected_completion_count": "318",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "145",
+    "success_rate": "0.884146341463",
+    "projected_completion_count": "164",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "149",
+    "success_rate": "0.702830188679",
+    "projected_completion_count": "212",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "96",
+    "success_rate": "0.466019417476",
+    "projected_completion_count": "206",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "34",
+    "success_rate": "0.607142857143",
+    "projected_completion_count": "56",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "98",
+    "success_rate": "0.464454976303",
+    "projected_completion_count": "211",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "269",
+    "success_rate": "0.853968253968",
+    "projected_completion_count": "315",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "151",
+    "success_rate": "0.613821138211",
+    "projected_completion_count": "246",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "101",
+    "success_rate": "0.770992366412",
+    "projected_completion_count": "131",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "82",
+    "success_rate": "0.625954198473",
+    "projected_completion_count": "131",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "130",
+    "success_rate": "0.456140350877",
+    "projected_completion_count": "285",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "97",
+    "success_rate": "0.889908256881",
+    "projected_completion_count": "109",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "91",
+    "success_rate": "0.502762430939",
+    "projected_completion_count": "181",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "303",
+    "success_rate": "0.918181818182",
+    "projected_completion_count": "330",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "5",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "12",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "92",
+    "success_rate": "0.396551724138",
+    "projected_completion_count": "232",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "74",
+    "success_rate": "0.564885496183",
+    "projected_completion_count": "131",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "200",
+    "success_rate": "0.660066006601",
+    "projected_completion_count": "303",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "165",
+    "success_rate": "0.559322033898",
+    "projected_completion_count": "295",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "3",
+    "success_rate": "0.5",
+    "projected_completion_count": "6",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "141",
+    "success_rate": "0.432515337423",
+    "projected_completion_count": "326",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "108",
+    "success_rate": "0.606741573034",
+    "projected_completion_count": "178",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "42",
+    "success_rate": "0.432989690722",
+    "projected_completion_count": "97",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "89",
+    "success_rate": "0.956989247312",
+    "projected_completion_count": "93",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "107",
+    "success_rate": "0.629411764706",
+    "projected_completion_count": "170",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "29",
+    "success_rate": "0.966666666667",
+    "projected_completion_count": "30",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "277",
+    "success_rate": "0.890675241158",
+    "projected_completion_count": "311",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "48",
+    "success_rate": "0.331034482759",
+    "projected_completion_count": "145",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "312",
+    "success_rate": "0.936936936937",
+    "projected_completion_count": "333",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "210",
+    "success_rate": "0.972222222222",
+    "projected_completion_count": "216",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "14",
+    "success_rate": "0.411764705882",
+    "projected_completion_count": "34",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "102",
+    "success_rate": "0.62962962963",
+    "projected_completion_count": "162",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "55",
+    "success_rate": "0.948275862069",
+    "projected_completion_count": "58",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "119",
+    "success_rate": "0.85",
+    "projected_completion_count": "140",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "85",
+    "success_rate": "0.594405594406",
+    "projected_completion_count": "143",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "34",
+    "success_rate": "0.85",
+    "projected_completion_count": "40",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "79",
+    "success_rate": "0.385365853659",
+    "projected_completion_count": "205",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "52",
+    "success_rate": "0.452173913043",
+    "projected_completion_count": "115",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "187",
+    "success_rate": "0.722007722008",
+    "projected_completion_count": "259",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "172",
+    "success_rate": "0.751091703057",
+    "projected_completion_count": "229",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "48",
+    "success_rate": "0.979591836735",
+    "projected_completion_count": "49",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "48",
+    "success_rate": "0.372093023256",
+    "projected_completion_count": "129",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "111",
+    "success_rate": "0.822222222222",
+    "projected_completion_count": "135",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "127",
+    "success_rate": "0.535864978903",
+    "projected_completion_count": "237",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "315",
+    "success_rate": "0.975232198142",
+    "projected_completion_count": "323",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "148",
+    "success_rate": "0.663677130045",
+    "projected_completion_count": "223",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "80",
+    "success_rate": "0.470588235294",
+    "projected_completion_count": "170",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "28",
+    "success_rate": "1.0",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "231",
+    "success_rate": "0.715170278638",
+    "projected_completion_count": "323",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "15",
+    "success_rate": "0.535714285714",
+    "projected_completion_count": "28",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "37",
+    "success_rate": "0.349056603774",
+    "projected_completion_count": "106",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "63",
+    "success_rate": "0.525",
+    "projected_completion_count": "120",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "66",
+    "success_rate": "0.44",
+    "projected_completion_count": "150",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "99",
+    "success_rate": "0.46261682243",
+    "projected_completion_count": "214",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "222",
+    "success_rate": "0.755102040816",
+    "projected_completion_count": "294",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "17",
+    "success_rate": "0.53125",
+    "projected_completion_count": "32",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "10",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "30",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "111",
+    "success_rate": "0.620111731844",
+    "projected_completion_count": "179",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "134",
+    "success_rate": "0.475177304965",
+    "projected_completion_count": "282",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "114",
+    "success_rate": "0.77027027027",
+    "projected_completion_count": "148",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "205",
+    "success_rate": "0.80078125",
+    "projected_completion_count": "256",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "51",
+    "success_rate": "0.662337662338",
+    "projected_completion_count": "77",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "124",
+    "success_rate": "0.454212454212",
+    "projected_completion_count": "273",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "80",
+    "success_rate": "0.720720720721",
+    "projected_completion_count": "111",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "78",
+    "success_rate": "0.655462184874",
+    "projected_completion_count": "119",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "16",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "24",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "8",
+    "success_rate": "0.727272727273",
+    "projected_completion_count": "11",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "4",
+    "success_rate": "1.0",
+    "projected_completion_count": "4",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "17",
+    "success_rate": "0.894736842105",
+    "projected_completion_count": "19",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "269",
+    "success_rate": "0.770773638968",
+    "projected_completion_count": "349",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "59",
+    "success_rate": "0.5",
+    "projected_completion_count": "118",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "260",
+    "success_rate": "0.844155844156",
+    "projected_completion_count": "308",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "21",
+    "success_rate": "0.35",
+    "projected_completion_count": "60",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "212",
+    "success_rate": "0.9592760181",
+    "projected_completion_count": "221",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "169",
+    "success_rate": "0.65503875969",
+    "projected_completion_count": "258",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "116",
+    "success_rate": "0.42962962963",
+    "projected_completion_count": "270",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "104",
+    "success_rate": "0.608187134503",
+    "projected_completion_count": "171",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "33",
+    "success_rate": "0.540983606557",
+    "projected_completion_count": "61",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "149",
+    "success_rate": "0.65350877193",
+    "projected_completion_count": "228",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "205",
+    "success_rate": "0.590778097983",
+    "projected_completion_count": "347",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "23",
+    "success_rate": "0.605263157895",
+    "projected_completion_count": "38",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "131",
+    "success_rate": "0.620853080569",
+    "projected_completion_count": "211",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "8",
+    "success_rate": "1.0",
+    "projected_completion_count": "8",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "76",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "171",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "29",
+    "success_rate": "0.341176470588",
+    "projected_completion_count": "85",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "158",
+    "success_rate": "0.724770642202",
+    "projected_completion_count": "218",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "109",
+    "success_rate": "0.368243243243",
+    "projected_completion_count": "296",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "183",
+    "success_rate": "0.607973421927",
+    "projected_completion_count": "301",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "303",
+    "success_rate": "0.929447852761",
+    "projected_completion_count": "326",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "154",
+    "success_rate": "0.487341772152",
+    "projected_completion_count": "316",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "121",
+    "success_rate": "0.636842105263",
+    "projected_completion_count": "190",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "231",
+    "success_rate": "0.905882352941",
+    "projected_completion_count": "255",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "111",
+    "success_rate": "0.74",
+    "projected_completion_count": "150",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "145",
+    "success_rate": "0.687203791469",
+    "projected_completion_count": "211",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "35",
+    "success_rate": "0.673076923077",
+    "projected_completion_count": "52",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "18",
+    "success_rate": "0.36",
+    "projected_completion_count": "50",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "156",
+    "success_rate": "0.619047619048",
+    "projected_completion_count": "252",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "37",
+    "success_rate": "0.345794392523",
+    "projected_completion_count": "107",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "231",
+    "success_rate": "0.691616766467",
+    "projected_completion_count": "334",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "41",
+    "success_rate": "0.706896551724",
+    "projected_completion_count": "58",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "106",
+    "success_rate": "0.746478873239",
+    "projected_completion_count": "142",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "82",
+    "success_rate": "0.780952380952",
+    "projected_completion_count": "105",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "1",
+    "success_rate": "0.25",
+    "projected_completion_count": "4",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "218",
+    "success_rate": "0.703225806452",
+    "projected_completion_count": "310",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "84",
+    "success_rate": "0.988235294118",
+    "projected_completion_count": "85",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "65",
+    "success_rate": "0.902777777778",
+    "projected_completion_count": "72",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "39",
+    "success_rate": "0.351351351351",
+    "projected_completion_count": "111",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "149",
+    "success_rate": "0.434402332362",
+    "projected_completion_count": "343",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "64",
+    "success_rate": "0.340425531915",
+    "projected_completion_count": "188",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "260",
+    "success_rate": "0.760233918129",
+    "projected_completion_count": "342",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "86",
+    "success_rate": "0.623188405797",
+    "projected_completion_count": "138",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "210",
+    "success_rate": "0.995260663507",
+    "projected_completion_count": "211",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "23",
+    "success_rate": "0.40350877193",
+    "projected_completion_count": "57",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "19",
+    "success_rate": "0.826086956522",
+    "projected_completion_count": "23",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "215",
+    "success_rate": "0.695792880259",
+    "projected_completion_count": "309",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "151",
+    "success_rate": "0.692660550459",
+    "projected_completion_count": "218",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "28",
+    "success_rate": "0.411764705882",
+    "projected_completion_count": "68",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "85",
+    "success_rate": "0.582191780822",
+    "projected_completion_count": "146",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "73",
+    "success_rate": "0.960526315789",
     "projected_completion_count": "76",
     "projected_month": "12",
     "projected_year": "2018",
@@ -7668,2475 +6978,4289 @@
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "52",
-    "success_rate": "0.776119402985",
-    "projected_completion_count": "67",
+    "district": "10",
+    "successful_termination_count": "257",
+    "success_rate": "0.927797833935",
+    "projected_completion_count": "277",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "62",
+    "success_rate": "0.815789473684",
+    "projected_completion_count": "76",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "35",
+    "success_rate": "0.406976744186",
+    "projected_completion_count": "86",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "298",
+    "success_rate": "0.946031746032",
+    "projected_completion_count": "315",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "243",
+    "success_rate": "0.712609970674",
+    "projected_completion_count": "341",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "276",
+    "success_rate": "0.938775510204",
+    "projected_completion_count": "294",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "108",
+    "success_rate": "0.371134020619",
+    "projected_completion_count": "291",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "183",
+    "success_rate": "0.855140186916",
+    "projected_completion_count": "214",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "212",
+    "success_rate": "0.80303030303",
+    "projected_completion_count": "264",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "117",
+    "success_rate": "0.541666666667",
+    "projected_completion_count": "216",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "75",
+    "success_rate": "0.619834710744",
+    "projected_completion_count": "121",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "88",
+    "success_rate": "0.586666666667",
+    "projected_completion_count": "150",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "95",
+    "success_rate": "0.703703703704",
+    "projected_completion_count": "135",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "4",
+    "success_rate": "0.571428571429",
+    "projected_completion_count": "7",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "90",
+    "success_rate": "0.418604651163",
+    "projected_completion_count": "215",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "110",
+    "success_rate": "0.502283105023",
+    "projected_completion_count": "219",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "228",
+    "success_rate": "0.912",
+    "projected_completion_count": "250",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "62",
+    "success_rate": "0.41059602649",
+    "projected_completion_count": "151",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "177",
+    "success_rate": "0.804545454545",
+    "projected_completion_count": "220",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "147",
+    "success_rate": "0.724137931034",
+    "projected_completion_count": "203",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "55",
+    "success_rate": "0.350318471338",
+    "projected_completion_count": "157",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "16",
+    "success_rate": "0.516129032258",
+    "projected_completion_count": "31",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "36",
+    "success_rate": "0.382978723404",
+    "projected_completion_count": "94",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "91",
+    "success_rate": "0.40625",
+    "projected_completion_count": "224",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "33",
+    "success_rate": "0.647058823529",
+    "projected_completion_count": "51",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "118",
+    "success_rate": "0.402730375427",
+    "projected_completion_count": "293",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "253",
+    "success_rate": "0.783281733746",
+    "projected_completion_count": "323",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "195",
+    "success_rate": "0.609375",
+    "projected_completion_count": "320",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "279",
+    "success_rate": "0.996428571429",
+    "projected_completion_count": "280",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "110",
+    "success_rate": "0.509259259259",
+    "projected_completion_count": "216",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "59",
+    "success_rate": "0.504273504274",
+    "projected_completion_count": "117",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "29",
+    "success_rate": "0.3625",
+    "projected_completion_count": "80",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "28",
+    "success_rate": "0.354430379747",
+    "projected_completion_count": "79",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "138",
+    "success_rate": "0.541176470588",
+    "projected_completion_count": "255",
     "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "54",
-    "success_rate": "0.75",
-    "projected_completion_count": "72",
+    "district": "2",
+    "successful_termination_count": "184",
+    "success_rate": "0.757201646091",
+    "projected_completion_count": "243",
     "projected_month": "9",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "17",
+    "successful_termination_count": "26",
+    "success_rate": "0.684210526316",
+    "projected_completion_count": "38",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "166",
+    "success_rate": "0.677551020408",
+    "projected_completion_count": "245",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "250",
+    "success_rate": "0.798722044728",
+    "projected_completion_count": "313",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "65",
+    "success_rate": "0.942028985507",
+    "projected_completion_count": "69",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "21",
+    "success_rate": "0.7",
+    "projected_completion_count": "30",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "29",
+    "success_rate": "0.460317460317",
+    "projected_completion_count": "63",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "139",
+    "success_rate": "0.879746835443",
+    "projected_completion_count": "158",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "72",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "198",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "158",
+    "success_rate": "0.6171875",
+    "projected_completion_count": "256",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "91",
+    "success_rate": "0.572327044025",
+    "projected_completion_count": "159",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "36",
+    "success_rate": "0.553846153846",
+    "projected_completion_count": "65",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "175",
+    "success_rate": "0.806451612903",
+    "projected_completion_count": "217",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "150",
+    "success_rate": "0.511945392491",
+    "projected_completion_count": "293",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "87",
+    "success_rate": "0.783783783784",
+    "projected_completion_count": "111",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "7",
+    "success_rate": "0.466666666667",
+    "projected_completion_count": "15",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "5",
+    "success_rate": "1.0",
+    "projected_completion_count": "5",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "60",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "140",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "118",
+    "success_rate": "0.475806451613",
+    "projected_completion_count": "248",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "48",
+    "success_rate": "0.377952755906",
+    "projected_completion_count": "127",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "91",
+    "success_rate": "0.875",
+    "projected_completion_count": "104",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "23",
+    "success_rate": "0.589743589744",
+    "projected_completion_count": "39",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "101",
+    "success_rate": "0.507537688442",
+    "projected_completion_count": "199",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "78",
+    "success_rate": "0.604651162791",
+    "projected_completion_count": "129",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "29",
+    "success_rate": "0.805555555556",
+    "projected_completion_count": "36",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "22",
+    "success_rate": "0.733333333333",
+    "projected_completion_count": "30",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "112",
+    "success_rate": "0.551724137931",
+    "projected_completion_count": "203",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "77",
+    "success_rate": "0.334782608696",
+    "projected_completion_count": "230",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "46",
+    "success_rate": "0.422018348624",
+    "projected_completion_count": "109",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "276",
+    "success_rate": "0.923076923077",
+    "projected_completion_count": "299",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "158",
+    "success_rate": "0.530201342282",
+    "projected_completion_count": "298",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "62",
+    "success_rate": "0.394904458599",
+    "projected_completion_count": "157",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "17",
+    "success_rate": "0.68",
+    "projected_completion_count": "25",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "44",
+    "success_rate": "0.846153846154",
+    "projected_completion_count": "52",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "143",
+    "success_rate": "0.420588235294",
+    "projected_completion_count": "340",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "295",
+    "success_rate": "0.921875",
+    "projected_completion_count": "320",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "78",
+    "success_rate": "1.0",
+    "projected_completion_count": "78",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "89",
+    "success_rate": "0.361788617886",
+    "projected_completion_count": "246",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "19",
+    "success_rate": "0.527777777778",
+    "projected_completion_count": "36",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "128",
+    "success_rate": "0.677248677249",
+    "projected_completion_count": "189",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "13",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "39",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "137",
+    "success_rate": "0.655502392344",
+    "projected_completion_count": "209",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "112",
+    "success_rate": "0.546341463415",
+    "projected_completion_count": "205",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "112",
+    "success_rate": "0.377104377104",
+    "projected_completion_count": "297",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "74",
+    "success_rate": "0.660714285714",
+    "projected_completion_count": "112",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "55",
+    "success_rate": "0.932203389831",
+    "projected_completion_count": "59",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "100",
+    "success_rate": "0.862068965517",
+    "projected_completion_count": "116",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "114",
+    "success_rate": "0.417582417582",
+    "projected_completion_count": "273",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "138",
+    "success_rate": "0.945205479452",
+    "projected_completion_count": "146",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "120",
+    "success_rate": "0.46511627907",
+    "projected_completion_count": "258",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "156",
+    "success_rate": "0.652719665272",
+    "projected_completion_count": "239",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "192",
+    "success_rate": "0.662068965517",
+    "projected_completion_count": "290",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "99",
+    "success_rate": "0.397590361446",
+    "projected_completion_count": "249",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "8",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "18",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "104",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "312",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "262",
+    "success_rate": "0.973977695167",
+    "projected_completion_count": "269",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "171",
+    "success_rate": "0.542857142857",
+    "projected_completion_count": "315",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "35",
+    "success_rate": "0.686274509804",
+    "projected_completion_count": "51",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "6",
+    "success_rate": "0.461538461538",
+    "projected_completion_count": "13",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "73",
+    "success_rate": "0.598360655738",
+    "projected_completion_count": "122",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "65",
+    "success_rate": "0.349462365591",
+    "projected_completion_count": "186",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "53",
+    "success_rate": "1.0",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "158",
+    "success_rate": "0.658333333333",
+    "projected_completion_count": "240",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "155",
+    "success_rate": "0.842391304348",
+    "projected_completion_count": "184",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "87",
+    "success_rate": "0.75",
+    "projected_completion_count": "116",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "215",
+    "success_rate": "0.686900958466",
+    "projected_completion_count": "313",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "95",
+    "success_rate": "0.855855855856",
+    "projected_completion_count": "111",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "180",
+    "success_rate": "0.731707317073",
+    "projected_completion_count": "246",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "8",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "24",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "22",
+    "success_rate": "0.611111111111",
+    "projected_completion_count": "36",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "133",
+    "success_rate": "0.751412429379",
+    "projected_completion_count": "177",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "56",
+    "success_rate": "0.451612903226",
+    "projected_completion_count": "124",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "78",
+    "success_rate": "0.393939393939",
+    "projected_completion_count": "198",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "89",
+    "success_rate": "0.706349206349",
+    "projected_completion_count": "126",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "284",
+    "success_rate": "0.982698961938",
+    "projected_completion_count": "289",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "56",
+    "success_rate": "0.4",
+    "projected_completion_count": "140",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "78",
+    "success_rate": "0.629032258065",
+    "projected_completion_count": "124",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "70",
+    "success_rate": "0.334928229665",
+    "projected_completion_count": "209",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "7",
+    "success_rate": "0.368421052632",
+    "projected_completion_count": "19",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "155",
+    "success_rate": "0.962732919255",
+    "projected_completion_count": "161",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "16",
+    "success_rate": "0.666666666667",
+    "projected_completion_count": "24",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "73",
+    "success_rate": "0.44512195122",
+    "projected_completion_count": "164",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "176",
+    "success_rate": "0.635379061372",
+    "projected_completion_count": "277",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "246",
+    "success_rate": "0.836734693878",
+    "projected_completion_count": "294",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "9",
+    "success_rate": "0.6",
+    "projected_completion_count": "15",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "89",
+    "success_rate": "0.358870967742",
+    "projected_completion_count": "248",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "37",
+    "success_rate": "0.860465116279",
+    "projected_completion_count": "43",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "215",
+    "success_rate": "0.938864628821",
+    "projected_completion_count": "229",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "33",
+    "success_rate": "0.507692307692",
+    "projected_completion_count": "65",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "58",
+    "success_rate": "0.508771929825",
+    "projected_completion_count": "114",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "14",
+    "success_rate": "0.4",
+    "projected_completion_count": "35",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "213",
+    "success_rate": "0.902542372881",
+    "projected_completion_count": "236",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "257",
+    "success_rate": "0.958955223881",
+    "projected_completion_count": "268",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "106",
+    "success_rate": "0.354515050167",
+    "projected_completion_count": "299",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "102",
+    "success_rate": "0.684563758389",
+    "projected_completion_count": "149",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "94",
+    "success_rate": "0.537142857143",
+    "projected_completion_count": "175",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "114",
+    "success_rate": "0.98275862069",
+    "projected_completion_count": "116",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "101",
+    "success_rate": "0.660130718954",
+    "projected_completion_count": "153",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "91",
+    "success_rate": "0.65",
+    "projected_completion_count": "140",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "4",
+    "success_rate": "0.363636363636",
+    "projected_completion_count": "11",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "169",
+    "success_rate": "0.889473684211",
+    "projected_completion_count": "190",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "145",
+    "success_rate": "0.917721518987",
+    "projected_completion_count": "158",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "51",
+    "success_rate": "0.689189189189",
+    "projected_completion_count": "74",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "188",
+    "success_rate": "0.793248945148",
+    "projected_completion_count": "237",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "116",
+    "success_rate": "0.449612403101",
+    "projected_completion_count": "258",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "300",
+    "success_rate": "0.9375",
+    "projected_completion_count": "320",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "46",
+    "success_rate": "0.377049180328",
+    "projected_completion_count": "122",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "200",
+    "success_rate": "0.836820083682",
+    "projected_completion_count": "239",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "3",
+    "success_rate": "0.3",
+    "projected_completion_count": "10",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "250",
+    "success_rate": "0.984251968504",
+    "projected_completion_count": "254",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "12",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "14",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "284",
+    "success_rate": "1.0",
+    "projected_completion_count": "284",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "69",
+    "success_rate": "0.489361702128",
+    "projected_completion_count": "141",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "118",
+    "success_rate": "0.475806451613",
+    "projected_completion_count": "248",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "177",
+    "success_rate": "1.0",
+    "projected_completion_count": "177",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "57",
+    "success_rate": "0.890625",
+    "projected_completion_count": "64",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "33",
+    "success_rate": "0.407407407407",
+    "projected_completion_count": "81",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "96",
+    "success_rate": "0.65306122449",
+    "projected_completion_count": "147",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "184",
+    "success_rate": "0.786324786325",
+    "projected_completion_count": "234",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "61",
+    "success_rate": "0.859154929577",
+    "projected_completion_count": "71",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "113",
+    "success_rate": "1.0",
+    "projected_completion_count": "113",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "241",
+    "success_rate": "0.831034482759",
+    "projected_completion_count": "290",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "133",
+    "success_rate": "0.382183908046",
+    "projected_completion_count": "348",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "157",
+    "success_rate": "0.835106382979",
+    "projected_completion_count": "188",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "99",
+    "success_rate": "0.535135135135",
+    "projected_completion_count": "185",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "21",
+    "success_rate": "0.807692307692",
+    "projected_completion_count": "26",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "69",
+    "success_rate": "0.436708860759",
+    "projected_completion_count": "158",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "207",
+    "success_rate": "0.958333333333",
+    "projected_completion_count": "216",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "77",
+    "success_rate": "0.81914893617",
+    "projected_completion_count": "94",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "132",
+    "success_rate": "0.725274725275",
+    "projected_completion_count": "182",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "150",
+    "success_rate": "0.461538461538",
+    "projected_completion_count": "325",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "176",
+    "success_rate": "0.690196078431",
+    "projected_completion_count": "255",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "142",
+    "success_rate": "0.699507389163",
+    "projected_completion_count": "203",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "129",
+    "success_rate": "0.511904761905",
+    "projected_completion_count": "252",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "62",
+    "success_rate": "0.521008403361",
+    "projected_completion_count": "119",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "54",
+    "success_rate": "0.794117647059",
+    "projected_completion_count": "68",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "277",
+    "success_rate": "0.814705882353",
+    "projected_completion_count": "340",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "70",
+    "success_rate": "0.374331550802",
+    "projected_completion_count": "187",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "214",
+    "success_rate": "0.715719063545",
+    "projected_completion_count": "299",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "166",
+    "success_rate": "0.994011976048",
+    "projected_completion_count": "167",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "228",
+    "success_rate": "0.658959537572",
+    "projected_completion_count": "346",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "82",
+    "success_rate": "0.546666666667",
+    "projected_completion_count": "150",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "106",
+    "success_rate": "0.430894308943",
+    "projected_completion_count": "246",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "117",
+    "success_rate": "0.603092783505",
+    "projected_completion_count": "194",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "145",
+    "success_rate": "0.671296296296",
+    "projected_completion_count": "216",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "128",
+    "success_rate": "0.365714285714",
+    "projected_completion_count": "350",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "219",
+    "success_rate": "0.718032786885",
+    "projected_completion_count": "305",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "5",
+    "success_rate": "0.555555555556",
+    "projected_completion_count": "9",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
     "successful_termination_count": "59",
     "success_rate": "0.627659574468",
     "projected_completion_count": "94",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "230",
+    "success_rate": "0.8984375",
+    "projected_completion_count": "256",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "91",
+    "success_rate": "0.395652173913",
+    "projected_completion_count": "230",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "1",
+    "success_rate": "0.25",
+    "projected_completion_count": "4",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "110",
+    "success_rate": "0.564102564103",
+    "projected_completion_count": "195",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "273",
+    "success_rate": "1.0",
+    "projected_completion_count": "273",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "144",
+    "success_rate": "0.505263157895",
+    "projected_completion_count": "285",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "154",
+    "success_rate": "0.684444444444",
+    "projected_completion_count": "225",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "241",
+    "success_rate": "0.991769547325",
+    "projected_completion_count": "243",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "10",
+    "success_rate": "0.357142857143",
+    "projected_completion_count": "28",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "37",
+    "success_rate": "0.406593406593",
+    "projected_completion_count": "91",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "89",
+    "success_rate": "0.674242424242",
+    "projected_completion_count": "132",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "97",
+    "success_rate": "0.374517374517",
+    "projected_completion_count": "259",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "72",
+    "success_rate": "0.367346938776",
+    "projected_completion_count": "196",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "12",
+    "success_rate": "0.4",
+    "projected_completion_count": "30",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "133",
+    "success_rate": "0.95",
+    "projected_completion_count": "140",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "232",
+    "success_rate": "0.983050847458",
+    "projected_completion_count": "236",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "131",
+    "success_rate": "0.557446808511",
+    "projected_completion_count": "235",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "101",
+    "success_rate": "0.682432432432",
+    "projected_completion_count": "148",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "48",
+    "success_rate": "0.827586206897",
+    "projected_completion_count": "58",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "61",
+    "success_rate": "0.598039215686",
+    "projected_completion_count": "102",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "51",
+    "success_rate": "0.6",
+    "projected_completion_count": "85",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "9",
+    "success_rate": "0.9",
+    "projected_completion_count": "10",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "30",
+    "success_rate": "0.416666666667",
+    "projected_completion_count": "72",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "241",
+    "success_rate": "0.698550724638",
+    "projected_completion_count": "345",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "89",
+    "success_rate": "0.373949579832",
+    "projected_completion_count": "238",
     "projected_month": "1",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "39",
-    "success_rate": "0.565217391304",
-    "projected_completion_count": "69",
+    "district": "5",
+    "successful_termination_count": "73",
+    "success_rate": "0.675925925926",
+    "projected_completion_count": "108",
     "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.425",
-    "projected_completion_count": "40",
-    "projected_month": "4",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "17",
-    "success_rate": "0.944444444444",
-    "projected_completion_count": "18",
-    "projected_month": "4",
+    "district": "8",
+    "successful_termination_count": "128",
+    "success_rate": "0.87074829932",
+    "projected_completion_count": "147",
+    "projected_month": "2",
     "projected_year": "2020",
-    "supervision_type": "PROBATION",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "10",
-    "success_rate": "0.322580645161",
-    "projected_completion_count": "31",
+    "district": "3",
+    "successful_termination_count": "93",
+    "success_rate": "0.837837837838",
+    "projected_completion_count": "111",
     "projected_month": "6",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "26",
-    "success_rate": "0.838709677419",
-    "projected_completion_count": "31",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.896551724138",
-    "projected_completion_count": "58",
+    "district": "13",
+    "successful_termination_count": "97",
+    "success_rate": "0.451162790698",
+    "projected_completion_count": "215",
     "projected_month": "7",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "59",
-    "success_rate": "0.655555555556",
-    "projected_completion_count": "90",
+    "district": "5",
+    "successful_termination_count": "309",
+    "success_rate": "0.939209726444",
+    "projected_completion_count": "329",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "252",
+    "success_rate": "0.794952681388",
+    "projected_completion_count": "317",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "52",
+    "success_rate": "0.353741496599",
+    "projected_completion_count": "147",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "150",
+    "success_rate": "0.717703349282",
+    "projected_completion_count": "209",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "91",
+    "success_rate": "0.587096774194",
+    "projected_completion_count": "155",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "79",
+    "success_rate": "0.731481481481",
+    "projected_completion_count": "108",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "157",
+    "success_rate": "0.765853658537",
+    "projected_completion_count": "205",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "340",
+    "success_rate": "1.0",
+    "projected_completion_count": "340",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "58",
+    "success_rate": "0.37908496732",
+    "projected_completion_count": "153",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "128",
+    "success_rate": "0.540084388186",
+    "projected_completion_count": "237",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "22",
+    "success_rate": "0.488888888889",
+    "projected_completion_count": "45",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "160",
+    "success_rate": "0.462427745665",
+    "projected_completion_count": "346",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "43",
+    "success_rate": "0.394495412844",
+    "projected_completion_count": "109",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "185",
+    "success_rate": "0.915841584158",
+    "projected_completion_count": "202",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "73",
+    "success_rate": "0.640350877193",
+    "projected_completion_count": "114",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "12",
+    "success_rate": "0.8",
+    "projected_completion_count": "15",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "181",
+    "success_rate": "0.967914438503",
+    "projected_completion_count": "187",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "143",
+    "success_rate": "0.547892720307",
+    "projected_completion_count": "261",
+    "projected_month": "7",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "110",
+    "success_rate": "0.738255033557",
+    "projected_completion_count": "149",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "331",
+    "success_rate": "0.96783625731",
+    "projected_completion_count": "342",
     "projected_month": "10",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "22",
-    "success_rate": "0.709677419355",
-    "projected_completion_count": "31",
+    "district": "7",
+    "successful_termination_count": "35",
+    "success_rate": "0.492957746479",
+    "projected_completion_count": "71",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "31",
+    "success_rate": "0.455882352941",
+    "projected_completion_count": "68",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "70",
+    "success_rate": "0.388888888889",
+    "projected_completion_count": "180",
     "projected_month": "11",
     "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "35",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "45",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.560606060606",
-    "projected_completion_count": "66",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.833333333333",
-    "projected_completion_count": "12",
+    "district": "13",
+    "successful_termination_count": "4",
+    "success_rate": "0.444444444444",
+    "projected_completion_count": "9",
     "projected_month": "3",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "52",
-    "success_rate": "0.896551724138",
-    "projected_completion_count": "58",
-    "projected_month": "6",
+    "district": "8",
+    "successful_termination_count": "156",
+    "success_rate": "0.518272425249",
+    "projected_completion_count": "301",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "176",
+    "success_rate": "0.606896551724",
+    "projected_completion_count": "290",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "139",
+    "success_rate": "0.972027972028",
+    "projected_completion_count": "143",
+    "projected_month": "5",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "21",
-    "success_rate": "0.381818181818",
-    "projected_completion_count": "55",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.432835820896",
-    "projected_completion_count": "67",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.955882352941",
-    "projected_completion_count": "68",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.842105263158",
-    "projected_completion_count": "19",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "79",
-    "success_rate": "0.877777777778",
-    "projected_completion_count": "90",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "59",
-    "success_rate": "0.855072463768",
-    "projected_completion_count": "69",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.868421052632",
-    "projected_completion_count": "38",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "13",
     "successful_termination_count": "45",
-    "success_rate": "0.576923076923",
-    "projected_completion_count": "78",
+    "success_rate": "0.9375",
+    "projected_completion_count": "48",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "329",
+    "success_rate": "0.967647058824",
+    "projected_completion_count": "340",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "202",
+    "success_rate": "0.838174273859",
+    "projected_completion_count": "241",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "69",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "161",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "89",
+    "success_rate": "0.824074074074",
+    "projected_completion_count": "108",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "221",
+    "success_rate": "0.924686192469",
+    "projected_completion_count": "239",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "3",
+    "success_rate": "0.428571428571",
+    "projected_completion_count": "7",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "25",
+    "success_rate": "1.0",
+    "projected_completion_count": "25",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "71",
+    "success_rate": "0.383783783784",
+    "projected_completion_count": "185",
     "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "42",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "66",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "42",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.648648648649",
-    "projected_completion_count": "37",
-    "projected_month": "11",
+    "district": "7",
+    "successful_termination_count": "139",
+    "success_rate": "0.576763485477",
+    "projected_completion_count": "241",
+    "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "28",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "36",
+    "district": "1",
+    "successful_termination_count": "225",
+    "success_rate": "0.78125",
+    "projected_completion_count": "288",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "230",
+    "success_rate": "0.71875",
+    "projected_completion_count": "320",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "152",
+    "success_rate": "0.649572649573",
+    "projected_completion_count": "234",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "57",
+    "success_rate": "0.876923076923",
+    "projected_completion_count": "65",
     "projected_month": "1",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "5",
-    "success_rate": "0.384615384615",
-    "projected_completion_count": "13",
+    "district": "12",
+    "successful_termination_count": "33",
+    "success_rate": "0.702127659574",
+    "projected_completion_count": "47",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "61",
+    "success_rate": "0.983870967742",
+    "projected_completion_count": "62",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "206",
+    "success_rate": "0.656050955414",
+    "projected_completion_count": "314",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "165",
+    "success_rate": "0.585106382979",
+    "projected_completion_count": "282",
     "projected_month": "3",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "4",
+    "successful_termination_count": "132",
+    "success_rate": "0.717391304348",
+    "projected_completion_count": "184",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "119",
+    "success_rate": "0.657458563536",
+    "projected_completion_count": "181",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "58",
+    "success_rate": "0.840579710145",
+    "projected_completion_count": "69",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "196",
+    "success_rate": "0.915887850467",
+    "projected_completion_count": "214",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "42",
+    "success_rate": "0.677419354839",
+    "projected_completion_count": "62",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "93",
+    "success_rate": "0.861111111111",
+    "projected_completion_count": "108",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "114",
+    "success_rate": "0.545454545455",
+    "projected_completion_count": "209",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "46",
+    "success_rate": "0.455445544554",
+    "projected_completion_count": "101",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "70",
+    "success_rate": "0.886075949367",
+    "projected_completion_count": "79",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "90",
+    "success_rate": "0.833333333333",
+    "projected_completion_count": "108",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "40",
+    "success_rate": "0.5",
+    "projected_completion_count": "80",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
     "successful_termination_count": "82",
-    "success_rate": "0.82",
-    "projected_completion_count": "100",
+    "success_rate": "0.725663716814",
+    "projected_completion_count": "113",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "139",
+    "success_rate": "0.952054794521",
+    "projected_completion_count": "146",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "10",
+    "success_rate": "0.454545454545",
+    "projected_completion_count": "22",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "259",
+    "success_rate": "0.770833333333",
+    "projected_completion_count": "336",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "117",
+    "success_rate": "0.740506329114",
+    "projected_completion_count": "158",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "337",
+    "success_rate": "0.979651162791",
+    "projected_completion_count": "344",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "119",
+    "success_rate": "0.915384615385",
+    "projected_completion_count": "130",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "35",
+    "success_rate": "0.507246376812",
+    "projected_completion_count": "69",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "248",
+    "success_rate": "0.87323943662",
+    "projected_completion_count": "284",
     "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "28",
+    "success_rate": "0.595744680851",
+    "projected_completion_count": "47",
+    "projected_month": "6",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "60",
-    "success_rate": "0.618556701031",
-    "projected_completion_count": "97",
+    "district": "ALL",
+    "successful_termination_count": "260",
+    "success_rate": "0.887372013652",
+    "projected_completion_count": "293",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "145",
+    "success_rate": "0.625",
+    "projected_completion_count": "232",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "223",
+    "success_rate": "0.884920634921",
+    "projected_completion_count": "252",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "successful_termination_count": "237",
+    "success_rate": "0.771986970684",
+    "projected_completion_count": "307",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "111",
+    "success_rate": "0.707006369427",
+    "projected_completion_count": "157",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "192",
+    "success_rate": "0.75",
+    "projected_completion_count": "256",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "20",
+    "success_rate": "1.0",
+    "projected_completion_count": "20",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "294",
+    "success_rate": "0.877611940299",
+    "projected_completion_count": "335",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "133",
+    "success_rate": "0.5859030837",
+    "projected_completion_count": "227",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "161",
+    "success_rate": "0.551369863014",
+    "projected_completion_count": "292",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "211",
+    "success_rate": "0.68064516129",
+    "projected_completion_count": "310",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "83",
+    "success_rate": "0.538961038961",
+    "projected_completion_count": "154",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "43",
+    "success_rate": "0.632352941176",
+    "projected_completion_count": "68",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "34",
+    "success_rate": "0.641509433962",
+    "projected_completion_count": "53",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "100",
+    "success_rate": "0.602409638554",
+    "projected_completion_count": "166",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "304",
+    "success_rate": "0.894117647059",
+    "projected_completion_count": "340",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "252",
+    "success_rate": "0.958174904943",
+    "projected_completion_count": "263",
     "projected_month": "5",
     "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "126",
+    "success_rate": "0.552631578947",
+    "projected_completion_count": "228",
+    "projected_month": "8",
+    "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "75",
-    "success_rate": "0.892857142857",
-    "projected_completion_count": "84",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
+    "district": "11",
+    "successful_termination_count": "122",
+    "success_rate": "0.412162162162",
+    "projected_completion_count": "296",
+    "projected_month": "8",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "33",
-    "success_rate": "0.351063829787",
-    "projected_completion_count": "94",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
+    "district": "5",
+    "successful_termination_count": "181",
+    "success_rate": "0.635087719298",
+    "projected_completion_count": "285",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "23",
-    "success_rate": "0.338235294118",
-    "projected_completion_count": "68",
+    "district": "8",
+    "successful_termination_count": "1",
+    "success_rate": "0.25",
+    "projected_completion_count": "4",
     "projected_month": "11",
     "projected_year": "2017",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "69",
-    "success_rate": "0.793103448276",
-    "projected_completion_count": "87",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
+    "district": "15",
+    "successful_termination_count": "249",
+    "success_rate": "0.713467048711",
+    "projected_completion_count": "349",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "49",
-    "success_rate": "0.924528301887",
-    "projected_completion_count": "53",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.733333333333",
-    "projected_completion_count": "45",
+    "district": "3",
+    "successful_termination_count": "135",
+    "success_rate": "0.567226890756",
+    "projected_completion_count": "238",
     "projected_month": "3",
     "projected_year": "2018",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "16",
-    "success_rate": "0.571428571429",
-    "projected_completion_count": "28",
+    "district": "5",
+    "successful_termination_count": "181",
+    "success_rate": "0.952631578947",
+    "projected_completion_count": "190",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "67",
+    "success_rate": "0.943661971831",
+    "projected_completion_count": "71",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "25",
+    "success_rate": "0.438596491228",
+    "projected_completion_count": "57",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "200",
+    "success_rate": "0.943396226415",
+    "projected_completion_count": "212",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "235",
+    "success_rate": "0.741324921136",
+    "projected_completion_count": "317",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "294",
+    "success_rate": "0.910216718266",
+    "projected_completion_count": "323",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "129",
+    "success_rate": "0.754385964912",
+    "projected_completion_count": "171",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "96",
+    "success_rate": "0.542372881356",
+    "projected_completion_count": "177",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "53",
+    "success_rate": "0.337579617834",
+    "projected_completion_count": "157",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "161",
+    "success_rate": "0.829896907216",
+    "projected_completion_count": "194",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "14",
+    "success_rate": "1.0",
+    "projected_completion_count": "14",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "112",
+    "success_rate": "0.7",
+    "projected_completion_count": "160",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "170",
+    "success_rate": "0.837438423645",
+    "projected_completion_count": "203",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "121",
+    "success_rate": "0.668508287293",
+    "projected_completion_count": "181",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "198",
+    "success_rate": "0.60736196319",
+    "projected_completion_count": "326",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "104",
+    "success_rate": "0.679738562092",
+    "projected_completion_count": "153",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "252",
+    "success_rate": "0.828947368421",
+    "projected_completion_count": "304",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "299",
+    "success_rate": "0.946202531646",
+    "projected_completion_count": "316",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "294",
+    "success_rate": "0.899082568807",
+    "projected_completion_count": "327",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "22",
+    "success_rate": "0.415094339623",
+    "projected_completion_count": "53",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "62",
+    "success_rate": "0.402597402597",
+    "projected_completion_count": "154",
     "projected_month": "4",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
+    "district": "1",
+    "successful_termination_count": "119",
+    "success_rate": "0.725609756098",
+    "projected_completion_count": "164",
+    "projected_month": "6",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "40",
+    "success_rate": "0.769230769231",
+    "projected_completion_count": "52",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "138",
+    "success_rate": "0.53488372093",
+    "projected_completion_count": "258",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "83",
+    "success_rate": "0.38785046729",
+    "projected_completion_count": "214",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "102",
+    "success_rate": "0.75",
+    "projected_completion_count": "136",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "245",
+    "success_rate": "0.782747603834",
+    "projected_completion_count": "313",
+    "projected_month": "10",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "99",
+    "success_rate": "0.692307692308",
+    "projected_completion_count": "143",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "48",
+    "success_rate": "0.657534246575",
+    "projected_completion_count": "73",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "101",
+    "success_rate": "0.952830188679",
+    "projected_completion_count": "106",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "106",
+    "success_rate": "0.549222797927",
+    "projected_completion_count": "193",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "136",
+    "success_rate": "0.609865470852",
+    "projected_completion_count": "223",
+    "projected_month": "3",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "192",
+    "success_rate": "0.603773584906",
+    "projected_completion_count": "318",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "107",
+    "success_rate": "0.963963963964",
+    "projected_completion_count": "111",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "50",
+    "success_rate": "0.588235294118",
+    "projected_completion_count": "85",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "14",
+    "success_rate": "0.333333333333",
+    "projected_completion_count": "42",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "149",
+    "success_rate": "0.579766536965",
+    "projected_completion_count": "257",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "40",
+    "success_rate": "0.754716981132",
+    "projected_completion_count": "53",
+    "projected_month": "12",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "257",
+    "success_rate": "1.0",
+    "projected_completion_count": "257",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "107",
+    "success_rate": "0.618497109827",
+    "projected_completion_count": "173",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "135",
+    "success_rate": "0.714285714286",
+    "projected_completion_count": "189",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "176",
+    "success_rate": "0.664150943396",
+    "projected_completion_count": "265",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "138",
+    "success_rate": "0.734042553191",
+    "projected_completion_count": "188",
+    "projected_month": "3",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "147",
+    "success_rate": "0.761658031088",
+    "projected_completion_count": "193",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "109",
+    "success_rate": "0.448559670782",
+    "projected_completion_count": "243",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "91",
+    "success_rate": "0.491891891892",
+    "projected_completion_count": "185",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "123",
+    "success_rate": "0.572093023256",
+    "projected_completion_count": "215",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "43",
+    "success_rate": "0.877551020408",
+    "projected_completion_count": "49",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "127",
+    "success_rate": "0.788819875776",
+    "projected_completion_count": "161",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "168",
+    "success_rate": "0.736842105263",
+    "projected_completion_count": "228",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "101",
+    "success_rate": "0.901785714286",
+    "projected_completion_count": "112",
+    "projected_month": "1",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "149",
+    "success_rate": "0.588932806324",
+    "projected_completion_count": "253",
+    "projected_month": "2",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "88",
+    "success_rate": "0.586666666667",
+    "projected_completion_count": "150",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "49",
+    "success_rate": "0.636363636364",
+    "projected_completion_count": "77",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "62",
+    "success_rate": "0.521008403361",
+    "projected_completion_count": "119",
+    "projected_month": "6",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "18",
+    "success_rate": "0.75",
+    "projected_completion_count": "24",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "235",
+    "success_rate": "0.78073089701",
+    "projected_completion_count": "301",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "27",
+    "success_rate": "0.551020408163",
+    "projected_completion_count": "49",
+    "projected_month": "4",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "187",
+    "success_rate": "0.670250896057",
+    "projected_completion_count": "279",
+    "projected_month": "5",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "2",
+    "success_rate": "0.4",
+    "projected_completion_count": "5",
+    "projected_month": "9",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "75",
+    "success_rate": "0.681818181818",
+    "projected_completion_count": "110",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "109",
+    "success_rate": "0.652694610778",
+    "projected_completion_count": "167",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "13",
+    "successful_termination_count": "121",
+    "success_rate": "0.960317460317",
+    "projected_completion_count": "126",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "249",
+    "success_rate": "0.813725490196",
+    "projected_completion_count": "306",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "308",
+    "success_rate": "0.903225806452",
+    "projected_completion_count": "341",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "45",
+    "success_rate": "0.9",
+    "projected_completion_count": "50",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "51",
+    "success_rate": "0.980769230769",
+    "projected_completion_count": "52",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "169",
+    "success_rate": "0.853535353535",
+    "projected_completion_count": "198",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "291",
+    "success_rate": "0.976510067114",
+    "projected_completion_count": "298",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "139",
+    "success_rate": "0.822485207101",
+    "projected_completion_count": "169",
+    "projected_month": "5",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "43",
+    "success_rate": "0.955555555556",
+    "projected_completion_count": "45",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "76",
+    "success_rate": "0.419889502762",
+    "projected_completion_count": "181",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "18",
+    "successful_termination_count": "184",
+    "success_rate": "0.94358974359",
+    "projected_completion_count": "195",
+    "projected_month": "7",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "40",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "45",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "83",
+    "success_rate": "0.542483660131",
+    "projected_completion_count": "153",
+    "projected_month": "11",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "216",
+    "success_rate": "0.734693877551",
+    "projected_completion_count": "294",
+    "projected_month": "2",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "5",
+    "successful_termination_count": "83",
+    "success_rate": "0.370535714286",
+    "projected_completion_count": "224",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "168",
+    "success_rate": "0.8",
+    "projected_completion_count": "210",
+    "projected_month": "12",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "231",
+    "success_rate": "0.80487804878",
+    "projected_completion_count": "287",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "80",
+    "success_rate": "0.860215053763",
+    "projected_completion_count": "93",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "189",
+    "success_rate": "0.557522123894",
+    "projected_completion_count": "339",
+    "projected_month": "3",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "45",
+    "success_rate": "0.394736842105",
+    "projected_completion_count": "114",
+    "projected_month": "5",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
     "successful_termination_count": "56",
     "success_rate": "0.848484848485",
     "projected_completion_count": "66",
     "projected_month": "7",
     "projected_year": "2018",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "12",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "28",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.545454545455",
-    "projected_completion_count": "11",
-    "projected_month": "11",
+    "district": "16",
+    "successful_termination_count": "249",
+    "success_rate": "0.841216216216",
+    "projected_completion_count": "296",
+    "projected_month": "7",
     "projected_year": "2018",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "61",
-    "success_rate": "0.7625",
-    "projected_completion_count": "80",
+    "district": "12",
+    "successful_termination_count": "22",
+    "success_rate": "0.468085106383",
+    "projected_completion_count": "47",
+    "projected_month": "8",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "43",
+    "success_rate": "0.895833333333",
+    "projected_completion_count": "48",
     "projected_month": "1",
     "projected_year": "2019",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "22",
-    "success_rate": "0.488888888889",
-    "projected_completion_count": "45",
+    "district": "2",
+    "successful_termination_count": "6",
+    "success_rate": "0.315789473684",
+    "projected_completion_count": "19",
     "projected_month": "2",
     "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.321428571429",
-    "projected_completion_count": "28",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "13",
-    "projected_month": "5",
-    "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "7",
+    "district": "1",
+    "successful_termination_count": "149",
+    "success_rate": "0.706161137441",
+    "projected_completion_count": "211",
+    "projected_month": "6",
     "projected_year": "2019",
-    "supervision_type": "PROBATION",
+    "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
+    "district": "1",
     "successful_termination_count": "44",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "99",
+    "success_rate": "0.328358208955",
+    "projected_completion_count": "134",
     "projected_month": "8",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "59",
-    "success_rate": "1.0",
-    "projected_completion_count": "59",
+    "district": "3",
+    "successful_termination_count": "100",
+    "success_rate": "0.502512562814",
+    "projected_completion_count": "199",
+    "projected_month": "8",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "6",
+    "successful_termination_count": "165",
+    "success_rate": "0.64453125",
+    "projected_completion_count": "256",
+    "projected_month": "9",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "83",
+    "success_rate": "0.768518518519",
+    "projected_completion_count": "108",
+    "projected_month": "10",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "120",
+    "success_rate": "0.888888888889",
+    "projected_completion_count": "135",
     "projected_month": "12",
     "projected_year": "2019",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "45",
-    "success_rate": "0.454545454545",
-    "projected_completion_count": "99",
+    "district": "3",
+    "successful_termination_count": "119",
+    "success_rate": "0.9296875",
+    "projected_completion_count": "128",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "59",
+    "success_rate": "0.341040462428",
+    "projected_completion_count": "173",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "116",
+    "success_rate": "0.822695035461",
+    "projected_completion_count": "141",
+    "projected_month": "1",
+    "projected_year": "2020",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "133",
+    "success_rate": "0.419558359621",
+    "projected_completion_count": "317",
     "projected_month": "2",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "30",
-    "success_rate": "0.4",
-    "projected_completion_count": "75",
+    "district": "1",
+    "successful_termination_count": "225",
+    "success_rate": "0.824175824176",
+    "projected_completion_count": "273",
     "projected_month": "3",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "82",
-    "success_rate": "0.828282828283",
-    "projected_completion_count": "99",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.5625",
-    "projected_completion_count": "16",
+    "district": "ALL",
+    "successful_termination_count": "32",
+    "success_rate": "0.761904761905",
+    "projected_completion_count": "42",
     "projected_month": "5",
     "projected_year": "2020",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "23",
-    "success_rate": "0.589743589744",
-    "projected_completion_count": "39",
+    "district": "15",
+    "successful_termination_count": "142",
+    "success_rate": "0.965986394558",
+    "projected_completion_count": "147",
     "projected_month": "5",
     "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "11",
+    "successful_termination_count": "50",
+    "success_rate": "0.406504065041",
+    "projected_completion_count": "123",
+    "projected_month": "6",
+    "projected_year": "2020",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "8",
+    "successful_termination_count": "309",
+    "success_rate": "0.916913946588",
+    "projected_completion_count": "337",
+    "projected_month": "9",
+    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "30",
-    "success_rate": "0.44776119403",
+    "district": "11",
+    "successful_termination_count": "68",
+    "success_rate": "0.422360248447",
+    "projected_completion_count": "161",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "240",
+    "success_rate": "0.919540229885",
+    "projected_completion_count": "261",
+    "projected_month": "10",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "72",
+    "success_rate": "0.857142857143",
+    "projected_completion_count": "84",
+    "projected_month": "11",
+    "projected_year": "2017",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "3",
+    "successful_termination_count": "124",
+    "success_rate": "0.639175257732",
+    "projected_completion_count": "194",
+    "projected_month": "1",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "102",
+    "success_rate": "0.653846153846",
+    "projected_completion_count": "156",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "69",
+    "success_rate": "0.711340206186",
+    "projected_completion_count": "97",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "2",
+    "successful_termination_count": "39",
+    "success_rate": "0.327731092437",
+    "projected_completion_count": "119",
+    "projected_month": "2",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "ALL",
+    "successful_termination_count": "256",
+    "success_rate": "0.744186046512",
+    "projected_completion_count": "344",
+    "projected_month": "4",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "7",
+    "successful_termination_count": "49",
+    "success_rate": "0.4375",
+    "projected_completion_count": "112",
+    "projected_month": "7",
+    "projected_year": "2018",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "4",
+    "successful_termination_count": "140",
+    "success_rate": "0.693069306931",
+    "projected_completion_count": "202",
+    "projected_month": "9",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "16",
+    "successful_termination_count": "99",
+    "success_rate": "0.388235294118",
+    "projected_completion_count": "255",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "12",
+    "successful_termination_count": "93",
+    "success_rate": "0.958762886598",
+    "projected_completion_count": "97",
+    "projected_month": "11",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "171",
+    "success_rate": "0.488571428571",
+    "projected_completion_count": "350",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "9",
+    "successful_termination_count": "253",
+    "success_rate": "0.884615384615",
+    "projected_completion_count": "286",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "15",
+    "successful_termination_count": "139",
+    "success_rate": "0.553784860558",
+    "projected_completion_count": "251",
+    "projected_month": "12",
+    "projected_year": "2018",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "1",
+    "successful_termination_count": "123",
+    "success_rate": "0.486166007905",
+    "projected_completion_count": "253",
+    "projected_month": "4",
+    "projected_year": "2019",
+    "supervision_type": "PAROLE",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "17",
+    "successful_termination_count": "29",
+    "success_rate": "0.432835820896",
     "projected_completion_count": "67",
     "projected_month": "6",
-    "projected_year": "2020",
+    "projected_year": "2019",
+    "supervision_type": "PROBATION",
+    "state_code": "US_ND"
+  },
+  {
+    "district": "10",
+    "successful_termination_count": "187",
+    "success_rate": "0.722007722008",
+    "projected_completion_count": "259",
+    "projected_month": "8",
+    "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "67",
-    "success_rate": "0.87012987013",
-    "projected_completion_count": "77",
+    "district": "2",
+    "successful_termination_count": "120",
+    "success_rate": "0.528634361233",
+    "projected_completion_count": "227",
     "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.454545454545",
-    "projected_completion_count": "44",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.444444444444",
-    "projected_completion_count": "63",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.357142857143",
-    "projected_completion_count": "14",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "21",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.535714285714",
-    "projected_completion_count": "84",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.75",
-    "projected_completion_count": "20",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.609756097561",
-    "projected_completion_count": "82",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.695652173913",
-    "projected_completion_count": "46",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.95652173913",
-    "projected_completion_count": "23",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.513888888889",
-    "projected_completion_count": "72",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "1.0",
-    "projected_completion_count": "2",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.351063829787",
-    "projected_completion_count": "94",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.640449438202",
-    "projected_completion_count": "89",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.825",
-    "projected_completion_count": "40",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "84",
-    "success_rate": "0.943820224719",
-    "projected_completion_count": "89",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.905660377358",
-    "projected_completion_count": "53",
-    "projected_month": "2",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "29",
-    "success_rate": "0.783783783784",
-    "projected_completion_count": "37",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.604651162791",
-    "projected_completion_count": "43",
-    "projected_month": "7",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "1.0",
-    "projected_completion_count": "17",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "47",
-    "success_rate": "0.635135135135",
-    "projected_completion_count": "74",
+    "district": "11",
+    "successful_termination_count": "248",
+    "success_rate": "0.864111498258",
+    "projected_completion_count": "287",
     "projected_month": "10",
     "projected_year": "2019",
     "supervision_type": "PAROLE",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "5",
-    "success_rate": "0.416666666667",
-    "projected_completion_count": "12",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "1.0",
-    "projected_completion_count": "3",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "72",
-    "success_rate": "0.727272727273",
-    "projected_completion_count": "99",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.272727272727",
-    "projected_completion_count": "11",
-    "projected_month": "5",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "1.0",
-    "projected_completion_count": "28",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.8",
-    "projected_completion_count": "80",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.55",
-    "projected_completion_count": "40",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.523076923077",
-    "projected_completion_count": "65",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.977528089888",
-    "projected_completion_count": "89",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.389830508475",
-    "projected_completion_count": "59",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.452054794521",
-    "projected_completion_count": "73",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "91",
-    "success_rate": "0.978494623656",
-    "projected_completion_count": "93",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.384615384615",
-    "projected_completion_count": "78",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.307692307692",
-    "projected_completion_count": "26",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.691358024691",
-    "projected_completion_count": "81",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.352941176471",
-    "projected_completion_count": "34",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.426229508197",
-    "projected_completion_count": "61",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "63",
-    "success_rate": "0.692307692308",
-    "projected_completion_count": "91",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.967741935484",
-    "projected_completion_count": "31",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.322033898305",
-    "projected_completion_count": "59",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.863636363636",
-    "projected_completion_count": "44",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "1.0",
-    "projected_completion_count": "10",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.2",
-    "projected_completion_count": "5",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "14",
-    "success_rate": "0.5",
-    "projected_completion_count": "28",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "67",
-    "success_rate": "0.917808219178",
-    "projected_completion_count": "73",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "1.0",
-    "projected_completion_count": "1",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.69387755102",
-    "projected_completion_count": "49",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.405063291139",
-    "projected_completion_count": "79",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "25",
-    "success_rate": "0.390625",
-    "projected_completion_count": "64",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.46875",
-    "projected_completion_count": "96",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.75",
-    "projected_completion_count": "36",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.397058823529",
-    "projected_completion_count": "68",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.733333333333",
-    "projected_completion_count": "30",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.679012345679",
-    "projected_completion_count": "81",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "49",
-    "success_rate": "0.636363636364",
-    "projected_completion_count": "77",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "5",
-    "success_rate": "0.454545454545",
-    "projected_completion_count": "11",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "39",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "93",
-    "success_rate": "0.939393939394",
-    "projected_completion_count": "99",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.359375",
-    "projected_completion_count": "64",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.478260869565",
-    "projected_completion_count": "46",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.920634920635",
-    "projected_completion_count": "63",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.472727272727",
-    "projected_completion_count": "55",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.714285714286",
-    "projected_completion_count": "21",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.867924528302",
-    "projected_completion_count": "53",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.825396825397",
-    "projected_completion_count": "63",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "41",
-    "success_rate": "0.77358490566",
-    "projected_completion_count": "53",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "14",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "1.0",
-    "projected_completion_count": "3",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.923076923077",
-    "projected_completion_count": "52",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.351351351351",
-    "projected_completion_count": "37",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.491803278689",
-    "projected_completion_count": "61",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "66",
-    "success_rate": "0.66",
-    "projected_completion_count": "100",
-    "projected_month": "3",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "44",
-    "success_rate": "0.448979591837",
-    "projected_completion_count": "98",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "2",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "2",
     "successful_termination_count": "59",
-    "success_rate": "0.655555555556",
-    "projected_completion_count": "90",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "1.0",
-    "projected_completion_count": "1",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.53125",
-    "projected_completion_count": "32",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.4",
-    "projected_completion_count": "15",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.86",
-    "projected_completion_count": "50",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.547619047619",
-    "projected_completion_count": "42",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.825",
-    "projected_completion_count": "40",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.758620689655",
-    "projected_completion_count": "29",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.555555555556",
-    "projected_completion_count": "27",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.66265060241",
-    "projected_completion_count": "83",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.630136986301",
-    "projected_completion_count": "73",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "43",
-    "success_rate": "0.796296296296",
-    "projected_completion_count": "54",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.625",
-    "projected_completion_count": "56",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "36",
-    "success_rate": "0.521739130435",
-    "projected_completion_count": "69",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "26",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "39",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.875",
-    "projected_completion_count": "24",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.988636363636",
-    "projected_completion_count": "88",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "70",
-    "success_rate": "0.909090909091",
-    "projected_completion_count": "77",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.753623188406",
-    "projected_completion_count": "69",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.621621621622",
-    "projected_completion_count": "37",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.547619047619",
-    "projected_completion_count": "42",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "27",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.806451612903",
-    "projected_completion_count": "62",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.631578947368",
-    "projected_completion_count": "38",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "70",
-    "success_rate": "0.897435897436",
-    "projected_completion_count": "78",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.638554216867",
-    "projected_completion_count": "83",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "35",
-    "success_rate": "0.686274509804",
-    "projected_completion_count": "51",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.389830508475",
-    "projected_completion_count": "59",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "74",
-    "success_rate": "0.795698924731",
-    "projected_completion_count": "93",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.657142857143",
-    "projected_completion_count": "35",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.969696969697",
-    "projected_completion_count": "66",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.802197802198",
-    "projected_completion_count": "91",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "45",
-    "success_rate": "0.473684210526",
-    "projected_completion_count": "95",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "57",
-    "success_rate": "0.76",
-    "projected_completion_count": "75",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.372549019608",
-    "projected_completion_count": "51",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.887096774194",
-    "projected_completion_count": "62",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "82",
-    "success_rate": "0.845360824742",
-    "projected_completion_count": "97",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.25",
-    "projected_completion_count": "4",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.4375",
-    "projected_completion_count": "64",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.961538461538",
-    "projected_completion_count": "52",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.545454545455",
-    "projected_completion_count": "33",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.5",
-    "projected_completion_count": "56",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.947368421053",
-    "projected_completion_count": "19",
-    "projected_month": "3",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "0",
-    "success_rate": "0.0",
-    "projected_completion_count": "1",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.585365853659",
-    "projected_completion_count": "41",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.333333333333",
-    "projected_completion_count": "18",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "15",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "18",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "42",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "9",
-    "success_rate": "0.310344827586",
-    "projected_completion_count": "29",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "1.0",
-    "projected_completion_count": "17",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "16",
-    "success_rate": "0.457142857143",
-    "projected_completion_count": "35",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.623376623377",
-    "projected_completion_count": "77",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "20",
-    "success_rate": "0.689655172414",
-    "projected_completion_count": "29",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.659090909091",
-    "projected_completion_count": "44",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "29",
-    "success_rate": "0.783783783784",
-    "projected_completion_count": "37",
-    "projected_month": "6",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "75",
-    "success_rate": "0.925925925926",
-    "projected_completion_count": "81",
-    "projected_month": "8",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "56",
-    "success_rate": "0.602150537634",
-    "projected_completion_count": "93",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "68",
-    "success_rate": "0.83950617284",
-    "projected_completion_count": "81",
-    "projected_month": "10",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.62962962963",
-    "projected_completion_count": "27",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.569892473118",
-    "projected_completion_count": "93",
-    "projected_month": "1",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "13",
-    "success_rate": "0.764705882353",
-    "projected_completion_count": "17",
-    "projected_month": "3",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "66",
-    "success_rate": "0.758620689655",
-    "projected_completion_count": "87",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.362637362637",
-    "projected_completion_count": "91",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.548387096774",
-    "projected_completion_count": "31",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "52",
-    "success_rate": "0.881355932203",
-    "projected_completion_count": "59",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.492307692308",
-    "projected_completion_count": "65",
-    "projected_month": "12",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.410714285714",
-    "projected_completion_count": "56",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "7",
-    "success_rate": "0.538461538462",
-    "projected_completion_count": "13",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "19",
-    "success_rate": "0.487179487179",
-    "projected_completion_count": "39",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "42",
-    "success_rate": "0.42",
-    "projected_completion_count": "100",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "53",
-    "success_rate": "0.569892473118",
-    "projected_completion_count": "93",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "6",
-    "success_rate": "0.375",
-    "projected_completion_count": "16",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "21",
-    "success_rate": "1.0",
-    "projected_completion_count": "21",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.528735632184",
-    "projected_completion_count": "87",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "81",
-    "success_rate": "0.910112359551",
+    "success_rate": "0.662921348315",
     "projected_completion_count": "89",
-    "projected_month": "6",
+    "projected_month": "2",
     "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.74",
-    "projected_completion_count": "50",
-    "projected_month": "8",
-    "projected_year": "2017",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "61",
-    "success_rate": "0.734939759036",
-    "projected_completion_count": "83",
-    "projected_month": "8",
-    "projected_year": "2017",
+    "district": "6",
+    "successful_termination_count": "51",
+    "success_rate": "0.822580645161",
+    "projected_completion_count": "62",
+    "projected_month": "3",
+    "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "4",
-    "success_rate": "0.307692307692",
-    "projected_completion_count": "13",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "78",
-    "success_rate": "0.876404494382",
-    "projected_completion_count": "89",
-    "projected_month": "9",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.674418604651",
-    "projected_completion_count": "86",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
+    "district": "10",
     "successful_termination_count": "71",
-    "success_rate": "0.845238095238",
-    "projected_completion_count": "84",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.894736842105",
-    "projected_completion_count": "38",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.475609756098",
-    "projected_completion_count": "82",
-    "projected_month": "7",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "86",
-    "success_rate": "0.977272727273",
-    "projected_completion_count": "88",
-    "projected_month": "8",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "50",
-    "success_rate": "0.892857142857",
-    "projected_completion_count": "56",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "46",
-    "success_rate": "0.901960784314",
-    "projected_completion_count": "51",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.52380952381",
-    "projected_completion_count": "21",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "60",
-    "success_rate": "0.625",
-    "projected_completion_count": "96",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "76",
-    "success_rate": "0.767676767677",
-    "projected_completion_count": "99",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.566666666667",
-    "projected_completion_count": "30",
-    "projected_month": "1",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
     "success_rate": "0.333333333333",
-    "projected_completion_count": "3",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "74",
-    "success_rate": "0.74",
-    "projected_completion_count": "100",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.769230769231",
-    "projected_completion_count": "39",
-    "projected_month": "4",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.58064516129",
-    "projected_completion_count": "93",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.628571428571",
-    "projected_completion_count": "35",
-    "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "65",
-    "success_rate": "0.677083333333",
-    "projected_completion_count": "96",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "10",
-    "success_rate": "0.625",
-    "projected_completion_count": "16",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "70",
-    "success_rate": "0.864197530864",
-    "projected_completion_count": "81",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "32",
-    "success_rate": "0.864864864865",
-    "projected_completion_count": "37",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "33",
-    "success_rate": "0.375",
-    "projected_completion_count": "88",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "39",
-    "success_rate": "0.4875",
-    "projected_completion_count": "80",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "87",
-    "success_rate": "0.915789473684",
-    "projected_completion_count": "95",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.653846153846",
-    "projected_completion_count": "52",
+    "projected_completion_count": "213",
     "projected_month": "3",
     "projected_year": "2020",
-    "supervision_type": "PAROLE",
+    "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "51",
-    "success_rate": "0.980769230769",
-    "projected_completion_count": "52",
-    "projected_month": "4",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "1",
-    "success_rate": "0.5",
-    "projected_completion_count": "2",
-    "projected_month": "7",
+    "district": "8",
+    "successful_termination_count": "238",
+    "success_rate": "0.71686746988",
+    "projected_completion_count": "332",
+    "projected_month": "5",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "41",
-    "success_rate": "0.532467532468",
-    "projected_completion_count": "77",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "11",
-    "success_rate": "0.6875",
-    "projected_completion_count": "16",
-    "projected_month": "11",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "77",
-    "success_rate": "0.777777777778",
-    "projected_completion_count": "99",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "28",
-    "success_rate": "0.549019607843",
-    "projected_completion_count": "51",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.770833333333",
-    "projected_completion_count": "48",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.421052631579",
-    "projected_completion_count": "57",
-    "projected_month": "12",
-    "projected_year": "2017",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "37",
-    "success_rate": "0.637931034483",
-    "projected_completion_count": "58",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "51",
-    "success_rate": "0.796875",
-    "projected_completion_count": "64",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "30",
-    "success_rate": "0.37037037037",
-    "projected_completion_count": "81",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "15",
-    "success_rate": "0.46875",
-    "projected_completion_count": "32",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "17",
-    "success_rate": "0.548387096774",
-    "projected_completion_count": "31",
-    "projected_month": "11",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "2",
-    "success_rate": "0.666666666667",
-    "projected_completion_count": "3",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.888888888889",
-    "projected_completion_count": "27",
+    "district": "8",
+    "successful_termination_count": "153",
+    "success_rate": "0.944444444444",
+    "projected_completion_count": "162",
     "projected_month": "6",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.876712328767",
-    "projected_completion_count": "73",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "27",
-    "success_rate": "0.658536585366",
-    "projected_completion_count": "41",
-    "projected_month": "11",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "58",
-    "success_rate": "0.716049382716",
-    "projected_completion_count": "81",
-    "projected_month": "2",
     "projected_year": "2020",
     "supervision_type": "PROBATION",
     "state_code": "US_ND"
   },
   {
-    "successful_termination_count": "55",
-    "success_rate": "0.948275862069",
-    "projected_completion_count": "58",
-    "projected_month": "7",
-    "projected_year": "2020",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "24",
-    "success_rate": "0.8",
-    "projected_completion_count": "30",
-    "projected_month": "2",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "38",
-    "success_rate": "0.904761904762",
-    "projected_completion_count": "42",
-    "projected_month": "4",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.447368421053",
-    "projected_completion_count": "76",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "23",
-    "success_rate": "0.851851851852",
-    "projected_completion_count": "27",
-    "projected_month": "5",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.68",
-    "projected_completion_count": "50",
-    "projected_month": "6",
-    "projected_year": "2018",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "0.66265060241",
-    "projected_completion_count": "83",
-    "projected_month": "9",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.428571428571",
-    "projected_completion_count": "7",
-    "projected_month": "10",
-    "projected_year": "2018",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "34",
-    "success_rate": "0.607142857143",
-    "projected_completion_count": "56",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "22",
-    "success_rate": "0.52380952381",
-    "projected_completion_count": "42",
-    "projected_month": "2",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "8",
-    "success_rate": "0.32",
-    "projected_completion_count": "25",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "55",
-    "success_rate": "1.0",
-    "projected_completion_count": "55",
-    "projected_month": "5",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "73",
-    "success_rate": "0.935897435897",
-    "projected_completion_count": "78",
-    "projected_month": "8",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "54",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "63",
-    "projected_month": "9",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "64",
-    "success_rate": "0.831168831169",
-    "projected_completion_count": "77",
-    "projected_month": "10",
-    "projected_year": "2019",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "48",
-    "success_rate": "0.857142857143",
-    "projected_completion_count": "56",
-    "projected_month": "12",
-    "projected_year": "2019",
-    "supervision_type": "PROBATION",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.272727272727",
-    "projected_completion_count": "11",
-    "projected_month": "1",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "3",
-    "success_rate": "0.75",
-    "projected_completion_count": "4",
-    "projected_month": "2",
-    "projected_year": "2020",
-    "supervision_type": "PAROLE",
-    "state_code": "US_ND"
-  },
-  {
-    "successful_termination_count": "12",
-    "success_rate": "0.413793103448",
-    "projected_completion_count": "29",
+    "district": "7",
+    "successful_termination_count": "174",
+    "success_rate": "0.632727272727",
+    "projected_completion_count": "275",
     "projected_month": "7",
     "projected_year": "2020",
     "supervision_type": "PROBATION",

--- a/src/constants.js
+++ b/src/constants.js
@@ -131,7 +131,9 @@ const darkGreen = "#005450";
 const darkerGreen = "#00413E";
 const darkGray = "#5A6575";
 const lightGray = "#ECEDEF";
+const medGray = "#707F96";
 const white = "#fff";
+const medGreen = "#7EA8A6";
 
 export const THEME = {
   colors: {
@@ -139,8 +141,9 @@ export const THEME = {
     blue: "#3e8df7",
     darkGreen,
     // functional
+    chartAxis: medGray,
     background: "#FCFCFC",
-    body: "#707F96",
+    body: medGray,
     bodyLight: white,
     controlBackground: lightGray,
     controlLabel: "#3D4045",
@@ -152,6 +155,7 @@ export const THEME = {
     highlight: brightGreen,
     pillBackground: lightGray,
     pillValue: darkGray,
+    monthlyTimeseriesBar: medGreen,
     tooltipBackground: "#132c52",
     violationReasons: {
       [VIOLATION_TYPES.abscond]: "#327672",

--- a/src/constants.js
+++ b/src/constants.js
@@ -145,7 +145,6 @@ const darkGray = "#5A6575";
 const lightGray = "#ECEDEF";
 const medGray = "#707F96";
 const white = "#fff";
-const medGreen = "#7EA8A6";
 
 export const THEME = {
   colors: {
@@ -178,7 +177,7 @@ export const THEME = {
     highlight: brightGreen,
     pillBackground: lightGray,
     pillValue: darkGray,
-    monthlyTimeseriesBar: medGreen,
+    monthlyTimeseriesBar: darkGreen5,
     race: {
       AMERICAN_INDIAN_ALASKAN_NATIVE: darkGreen,
       ASIAN: darkGreen9,

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -94,7 +94,6 @@ function DetailSection({
           {showMonthControl && monthList && (
             <MonthControl months={monthList} onChange={setMonth} />
           )}
-          {showDimensionControl && <DimensionControl onChange={setDimension} />}
           {
             // we need both a flag and data to enable district control
             showDistrictControl && districtList && (
@@ -105,6 +104,7 @@ function DetailSection({
               />
             )
           }
+          {showDimensionControl && <DimensionControl onChange={setDimension} />}
         </DetailSectionControls>
       </DetailSectionHeader>
       <DetailSectionDescription>{description}</DetailSectionDescription>

--- a/src/monthly-timeseries/MonthlyTimeseries.js
+++ b/src/monthly-timeseries/MonthlyTimeseries.js
@@ -56,13 +56,13 @@ export default function MonthlyTimeseries({ data }) {
         data={data}
         margin={chartMargins}
         oAccessor="month"
-        oLabel={(labelText) =>
-          labelText.startsWith("1-") ? (
-            <TimeLabel>{labelText.split("-")[1]}</TimeLabel>
-          ) : null
-        }
+        oLabel={(labelText) => {
+          const [year, month] = labelText.split("-");
+          return month === "1" ? <TimeLabel>{year}</TimeLabel> : null;
+        }}
         rAccessor="value"
         rExtent={[0, 1]}
+        renderKey="month"
         responsiveHeight
         responsiveWidth
         style={{ fill: THEME.colors.monthlyTimeseriesBar }}

--- a/src/monthly-timeseries/MonthlyTimeseries.js
+++ b/src/monthly-timeseries/MonthlyTimeseries.js
@@ -1,0 +1,82 @@
+import PropTypes from "prop-types";
+import React from "react";
+import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
+import styled from "styled-components";
+import { THEME } from "../constants";
+import { formatAsPct } from "../utils";
+
+const MonthlyTimeseriesWrapper = styled.div`
+  height: 350px;
+  width: 100%;
+
+  /* classes provided by Semiotic */
+  .frame {
+    .axis-baseline {
+      stroke: ${(props) => props.theme.colors.chartAxis};
+    }
+
+    .axis-label,
+    .ordinal-labels {
+      fill: ${(props) => props.theme.colors.chartAxis};
+      font: ${(props) => props.theme.fonts.body};
+      font-size: 12px;
+    }
+
+    .background-graphics,
+    .visualization-layer {
+      shape-rendering: crispEdges;
+    }
+  }
+`;
+
+const chartMargins = {
+  top: 10,
+  bottom: 20,
+  left: 50,
+  right: 0,
+};
+
+const TimeLabel = styled.text`
+  text-anchor: middle;
+`;
+
+export default function MonthlyTimeseries({ data }) {
+  return (
+    <MonthlyTimeseriesWrapper>
+      <ResponsiveOrdinalFrame
+        axes={[
+          {
+            baseline: false,
+            orient: "left",
+            tickFormat: formatAsPct,
+            tickLineGenerator: () => null,
+            ticks: 3,
+          },
+        ]}
+        data={data}
+        margin={chartMargins}
+        oAccessor="month"
+        oLabel={(labelText) =>
+          labelText.startsWith("1-") ? (
+            <TimeLabel>{labelText.split("-")[1]}</TimeLabel>
+          ) : null
+        }
+        rAccessor="value"
+        rExtent={[0, 1]}
+        responsiveHeight
+        responsiveWidth
+        style={{ fill: THEME.colors.monthlyTimeseriesBar }}
+        type="bar"
+      />
+    </MonthlyTimeseriesWrapper>
+  );
+}
+
+MonthlyTimeseries.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      month: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+};

--- a/src/monthly-timeseries/index.js
+++ b/src/monthly-timeseries/index.js
@@ -1,0 +1,1 @@
+export { default } from "./MonthlyTimeseries";

--- a/src/page-parole/PageParole.js
+++ b/src/page-parole/PageParole.js
@@ -1,15 +1,17 @@
 import React from "react";
 import DetailPage from "../detail-page";
-// once the backend is in place, stop using these untracked test files
-// eslint-disable-next-line import/no-unresolved
+// once the backend is in place, stop using these test files
 import parolePopulationData from "../assets/test_data/US_ND_parole_population_by_district_by_demographics.json";
-// eslint-disable-next-line import/no-unresolved
 import paroleDistrictOffices from "../assets/test_data/US_ND_site_offices.json";
-// eslint-disable-next-line import/no-unresolved
 import supervisionRevocationByMonth from "../assets/test_data/US_ND_supervision_revocations_by_month_by_type_by_demographics.json";
+import supervisionSuccessByMonth from "../assets/test_data/US_ND_supervision_success_by_month.json";
 import VizParolePopulation from "../viz-parole-population";
 import VizParoleRevocation from "../viz-parole-revocation";
+import VizParoleSuccess from "../viz-parole-success";
 import { SUPERVISION_TYPES } from "../constants";
+
+const recordIsParole = (record) =>
+  record.supervision_type === SUPERVISION_TYPES.parole;
 
 const TITLE = "Parole";
 const DESCRIPTION = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -37,8 +39,12 @@ const SECTIONS = [
     tortor vitae iaculis egestas. Donec dictum, nunc nec tincidunt cursus,
     ipsum dui gravida.`,
     showDimensionControl: true,
-    VizComponent: () => null,
-    vizData: {},
+    showDistrictControl: true,
+    VizComponent: VizParoleSuccess,
+    vizData: {
+      districtOffices: paroleDistrictOffices,
+      successByMonth: supervisionSuccessByMonth.filter(recordIsParole),
+    },
   },
   {
     title: "Why do revocations happen?",
@@ -51,7 +57,7 @@ const SECTIONS = [
     VizComponent: VizParoleRevocation,
     vizData: {
       paroleRevocationByMonth: supervisionRevocationByMonth.filter(
-        (record) => record.supervision_type === SUPERVISION_TYPES.parole
+        recordIsParole
       ),
     },
   },

--- a/src/utils/addEmptyMonthsToData.js
+++ b/src/utils/addEmptyMonthsToData.js
@@ -1,0 +1,41 @@
+import { subMonths, eachMonthOfInterval } from "date-fns";
+/**
+ * Returns a new list of data points consisting of the given data points and new
+ * data points appended for any month in the last `monthCount` number of months
+ * that is missing data, where the value for the `valueKey` property is `emptyValue`.
+ * NOTE: copied and lightly adapted from pulse-dashboard
+ */
+export default function addEmptyMonthsToData({
+  dataPoints,
+  monthCount,
+  valueKey,
+  emptyValue,
+}) {
+  const representedMonths = {};
+  dataPoints.forEach(({ year, month }) => {
+    if (!representedMonths[year]) {
+      representedMonths[year] = {};
+    }
+    representedMonths[year][month] = true;
+  });
+
+  const newDataPoints = [...dataPoints];
+
+  const end = new Date();
+  const start = subMonths(end, monthCount);
+  eachMonthOfInterval({ start, end }).forEach((monthDate) => {
+    const year = monthDate.getFullYear();
+    // months are 1-indexed in our data source
+    const month = monthDate.getMonth() + 1;
+    if (!representedMonths[year] || !representedMonths[year][month]) {
+      const monthData = {
+        year: year.toString(),
+        month: month.toString(),
+      };
+      monthData[valueKey] = emptyValue;
+      newDataPoints.push(monthData);
+    }
+  });
+
+  return newDataPoints;
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,3 +3,4 @@ export { default as formatAsPct } from "./formatAsPct";
 export { default as formatDemographicValue } from "./formatDemographicValue";
 export { default as getDataWithPct } from "./getDataWithPct";
 export { default as recordIsTotal } from "./recordIsTotal";
+export { default as addEmptyMonthsToData } from "./addEmptyMonthsToData";

--- a/src/viz-parole-success/VizParoleSuccess.js
+++ b/src/viz-parole-success/VizParoleSuccess.js
@@ -1,0 +1,42 @@
+import { ascending } from "d3-array";
+import PropTypes from "prop-types";
+import React from "react";
+import MonthlyTimeseries from "../monthly-timeseries";
+
+function makeTimeseriesRecord(record) {
+  return {
+    month: `${record.projected_year}-${record.projected_month}`,
+    value: parseFloat(record.success_rate),
+  };
+}
+
+export default function VizParoleSuccess({
+  data: { successByMonth },
+  districtId,
+}) {
+  return (
+    <MonthlyTimeseries
+      data={successByMonth
+        .filter((record) => record.district === districtId)
+        .map(makeTimeseriesRecord)
+        .sort((a, b) => ascending(a.month, b.month))}
+    />
+  );
+}
+
+VizParoleSuccess.propTypes = {
+  data: PropTypes.shape({
+    successByMonth: PropTypes.arrayOf(
+      PropTypes.shape({
+        projected_month: PropTypes.string.isRequired,
+        projected_year: PropTypes.string.isRequired,
+        success_rate: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+  districtId: PropTypes.string,
+};
+
+VizParoleSuccess.defaultProps = {
+  districtId: undefined,
+};

--- a/src/viz-parole-success/VizParoleSuccess.js
+++ b/src/viz-parole-success/VizParoleSuccess.js
@@ -2,11 +2,22 @@ import { ascending } from "d3-array";
 import PropTypes from "prop-types";
 import React from "react";
 import MonthlyTimeseries from "../monthly-timeseries";
+import { addEmptyMonthsToData } from "../utils";
 
 function makeTimeseriesRecord(record) {
   return {
-    month: `${record.projected_year}-${record.projected_month}`,
+    month: `${record.year}-${record.month}`,
     value: parseFloat(record.success_rate),
+  };
+}
+
+// consistently using `year` and `month` in all monthly data structures
+// makes it easier to generalize for common transformations
+function normalizeMonth(record) {
+  return {
+    ...record,
+    year: record.projected_year,
+    month: record.projected_month,
   };
 }
 
@@ -14,14 +25,18 @@ export default function VizParoleSuccess({
   data: { successByMonth },
   districtId,
 }) {
-  return (
-    <MonthlyTimeseries
-      data={successByMonth
-        .filter((record) => record.district === districtId)
-        .map(makeTimeseriesRecord)
-        .sort((a, b) => ascending(a.month, b.month))}
-    />
-  );
+  const chartData = addEmptyMonthsToData({
+    dataPoints: successByMonth
+      .filter((record) => record.district === districtId)
+      .map(normalizeMonth),
+    monthCount: 36,
+    valueKey: "success_rate",
+    emptyValue: 0,
+  })
+    .map(makeTimeseriesRecord)
+    .sort((a, b) => ascending(a.month, b.month));
+
+  return <MonthlyTimeseries data={chartData} />;
 }
 
 VizParoleSuccess.propTypes = {

--- a/src/viz-parole-success/index.js
+++ b/src/viz-parole-success/index.js
@@ -1,0 +1,1 @@
+export { default } from "./VizParoleSuccess";


### PR DESCRIPTION
## Description of the change

Adds a new chart type and test data file (with randomized fake values) for month-over-month supervision success rates.

![Screen Shot 2020-07-15 at 11 35 35 AM](https://user-images.githubusercontent.com/5385319/87582710-a63f2300-c68f-11ea-9a73-ce79a71d6204.png)

This chart supports filtering by district but not by demographics.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #33 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
