### PR TITLE
Proportional bar takes explicit height

### DIFF
--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useState } from "react";
-import Measure from "react-measure";
+import React from "react";
 import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
 import styled from "styled-components";
 import ColorLegend from "../color-legend";
@@ -11,7 +10,6 @@ import formatAsPct from "../utils/formatAsPct";
 const ProportionalBarContainer = styled.figure`
   height: 100%;
   margin: 0;
-  position: relative;
   width: 100%;
 `;
 
@@ -23,11 +21,9 @@ const ProportionalBarChartWrapper = styled.div`
 
 const ProportionalBarMetadata = styled.figcaption`
   align-items: baseline;
-  bottom: 0;
   display: flex;
   justify-content: space-between;
   padding-top: 4px;
-  position: absolute;
   width: 100%;
   z-index: ${(props) => props.theme.zIndex.base};
 `;
@@ -45,16 +41,7 @@ const ProportionalBarTooltipText = styled.p`
   white-space: nowrap;
 `;
 
-// if the legend doesn't wrap it should be roughly this size;
-// the chart height will adjust as necessary
-const INITIAL_METADATA_HEIGHT = 28;
-
-export default function ProportionalBar({ data, showLegend, title }) {
-  // to both avoid janky chart animations and avoid height overflows
-  // when the legend wraps to multiple lines, we need to measure its height
-  // explicitly to determine the chart height
-  const [metadataHeight, setMetadataHeight] = useState(INITIAL_METADATA_HEIGHT);
-
+export default function ProportionalBar({ data, height, showLegend, title }) {
   const TOOLTIP_PADDING = 3;
 
   const dataWithPct = getDataWithPct(data);
@@ -64,15 +51,15 @@ export default function ProportionalBar({ data, showLegend, title }) {
       <ProportionalBarChartWrapper>
         <ResponsiveOrdinalFrame
           data={dataWithPct}
-          // bottom margin leaves room for the title and legend
-          margin={{ top: 0, left: 0, right: 0, bottom: metadataHeight }}
+          margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
           oAccessor={() => title}
           pieceHoverAnnotation
           projection="horizontal"
           rAccessor="value"
           renderKey="label"
-          responsiveHeight
           responsiveWidth
+          // the width value is just a placeholder, it will be 100% per responsiveWidth
+          size={[0, height]}
           style={(d) => ({ fill: d.color })}
           tooltipContent={(d) => {
             return (
@@ -98,17 +85,10 @@ export default function ProportionalBar({ data, showLegend, title }) {
           type="bar"
         />
       </ProportionalBarChartWrapper>
-      <Measure
-        bounds
-        onResize={(contentRect) => setMetadataHeight(contentRect.bounds.height)}
-      >
-        {({ measureRef }) => (
-          <ProportionalBarMetadata ref={measureRef}>
-            <ProportionalBarTitle>{title}</ProportionalBarTitle>
-            {showLegend && <ColorLegend items={data} />}
-          </ProportionalBarMetadata>
-        )}
-      </Measure>
+      <ProportionalBarMetadata>
+        <ProportionalBarTitle>{title}</ProportionalBarTitle>
+        {showLegend && <ColorLegend items={data} />}
+      </ProportionalBarMetadata>
     </ProportionalBarContainer>
   );
 }
@@ -121,6 +101,7 @@ ProportionalBar.propTypes = {
       color: PropTypes.string.isRequired,
     })
   ).isRequired,
+  height: PropTypes.number.isRequired,
   showLegend: PropTypes.bool,
   title: PropTypes.string.isRequired,
 };

--- a/src/viz-parole-population/VizParolePopulation.js
+++ b/src/viz-parole-population/VizParolePopulation.js
@@ -25,6 +25,8 @@ const BAR_CHART_VISUALIZATION_COLORS = {
   [DIMENSION_KEYS.race]: THEME.colors.race,
 };
 
+const BAR_CHART_HEIGHT = 43;
+
 const VizParolePopulationContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -50,6 +52,7 @@ const Gutter = styled.div`
 
 const MapWrapper = styled.figure`
   margin: 0;
+  padding-top: 24px;
   width: 100%;
 `;
 
@@ -70,7 +73,6 @@ const ParoleDemographicsDistrictCountWrapper = styled.div`
 `;
 
 const ParoleDemographicsBarChartWrapper = styled.div`
-  height: 64px;
   margin-bottom: 16px;
   position: relative;
   width: 100%;
@@ -121,6 +123,7 @@ function ParoleDemographicBarChart({ data, dimension, stackOrder }) {
     <ParoleDemographicsBarChartWrapper stackOrder={stackOrder}>
       <ProportionalBar
         data={dimensionData}
+        height={BAR_CHART_HEIGHT}
         title={DIMENSION_LABELS[dimension]}
       />
     </ParoleDemographicsBarChartWrapper>

--- a/src/viz-parole-revocation/VizParoleRevocation.js
+++ b/src/viz-parole-revocation/VizParoleRevocation.js
@@ -19,10 +19,10 @@ import {
   recordIsTotal,
 } from "../utils";
 
-const HEIGHT = 450;
+const SECTION_HEIGHT = 450;
+const GUTTER = 42;
 
 const VizParoleRevocationWrapper = styled.div`
-  height: ${HEIGHT}px;
   width: 100%;
 `;
 
@@ -34,16 +34,13 @@ const BreakdownBarWrapper = styled.div`
 `;
 
 function Breakdowns({ data, dimension }) {
-  const breakdownHeight = HEIGHT / data.size;
+  const breakdownHeight = SECTION_HEIGHT / data.size;
   return Array.from(data, ([key, value], i) => (
-    <BreakdownBarWrapper
-      key={key}
-      height={breakdownHeight}
-      stackOrder={data.size - i}
-    >
+    <BreakdownBarWrapper key={key} stackOrder={data.size - i}>
       <ProportionalBar
-        title={formatDemographicValue(key, dimension)}
         data={value}
+        height={breakdownHeight - GUTTER}
+        title={formatDemographicValue(key, dimension)}
         showLegend={i === data.size - 1}
       />
     </BreakdownBarWrapper>
@@ -65,7 +62,7 @@ function VizParoleRevocation({ currentMonthData, dimension }) {
               width && (
                 <BubbleChart
                   data={currentMonthData.get(TOTAL_KEY)}
-                  height={HEIGHT}
+                  height={SECTION_HEIGHT}
                   width={width}
                 />
               )


### PR DESCRIPTION
## Description of the change

Instead of simply filling the height of its container, the `ProportionalBar` now requires an explicit height that will be used to size the chart itself. The height of the title and legend will be appended to that height to make up the total height of the component.

This addresses the issues we have been having with proportional bar charts being squeezed out of existence by their legends; the result is that the heights of the containers of these multiple-chart grids are no longer entirely fixed (though they don't vary all that much, maybe by a line or two if the legend is especially long). There are ways we can address that if we decide it's important (e.g., make the legends more predictable by having their contents be consistent regardless of the underlying data) but I think they are out of scope for this PR and require further design input. Notwithstanding that concern, I think this is an improvement over the current state of affairs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #45 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
