### PR TITLE
Always show all breakdown categories under Revocation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -230,6 +230,7 @@ export const defaultTheme = {
     pillBackground: lightGray,
     pillValue: darkGray,
     monthlyTimeseriesBar: darkGreen5,
+    noData: "#EFEDEC",
     programParticipation: darkerGray,
     race: {
       AMERICAN_INDIAN_ALASKAN_NATIVE: darkGreen,
@@ -321,7 +322,7 @@ export const defaultTheme = {
 
 // ND colors are tinted with the theme background color (i.e. converted from opacity)
 const ndColors = {
-  background: "#F2F1F0",
+  background: "#FAF9F9",
   backgroundTealShade9: "#DAE3E4",
   black: "#303030",
   blackTint9: "#434343",

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -1,11 +1,11 @@
+import { sum } from "d3-array";
 import PropTypes from "prop-types";
 import React from "react";
 import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
 import styled from "styled-components";
 import ColorLegend from "../color-legend";
 import Tooltip from "../tooltip";
-import { getDataWithPct } from "../utils";
-import formatAsPct from "../utils/formatAsPct";
+import { formatAsPct, getDataWithPct } from "../utils";
 
 const ProportionalBarContainer = styled.figure`
   height: 100%;
@@ -14,6 +14,7 @@ const ProportionalBarContainer = styled.figure`
 `;
 
 const ProportionalBarChartWrapper = styled.div`
+  background: ${(props) => props.theme.colors.noData};
   height: 100%;
   position: relative;
   z-index: ${(props) => props.theme.zIndex.base + 1};
@@ -58,6 +59,7 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
   const TOOLTIP_PADDING = 3;
 
   const dataWithPct = getDataWithPct(data);
+  const noData = data.length === 0 || sum(data.map(({ value }) => value)) === 0;
 
   return (
     <ProportionalBarContainer>
@@ -100,7 +102,10 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
         />
       </ProportionalBarChartWrapper>
       <ProportionalBarMetadata>
-        <ProportionalBarTitle>{title}</ProportionalBarTitle>
+        <ProportionalBarTitle>
+          {title}
+          {noData && ", No Data"}
+        </ProportionalBarTitle>
         {showLegend && <ColorLegend items={data} />}
       </ProportionalBarMetadata>
     </ProportionalBarContainer>

--- a/src/utils/getDimensionalBreakdown.js
+++ b/src/utils/getDimensionalBreakdown.js
@@ -1,0 +1,28 @@
+import {
+  DIMENSION_DATA_KEYS,
+  DIMENSION_KEYS,
+  DIMENSION_MAPPINGS,
+} from "../constants";
+import categoryIsNotUnknown from "./categoryIsNotUnknown";
+import recordIsTotal from "./recordIsTotal";
+import recordIsTotalByDimension from "./recordIsTotalByDimension";
+
+export default function getDimensionalBreakdown({ data, dimension }) {
+  const categories = DIMENSION_MAPPINGS.get(dimension);
+  const filteredData = data
+    ? data.filter(recordIsTotalByDimension(dimension))
+    : null;
+  return [...categories].filter(categoryIsNotUnknown).map(([value, label]) => {
+    return {
+      id: value,
+      label,
+      record:
+        filteredData &&
+        filteredData.find((record) =>
+          dimension === DIMENSION_KEYS.total
+            ? recordIsTotal(record)
+            : record[DIMENSION_DATA_KEYS[dimension]] === value
+        ),
+    };
+  });
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,5 +6,6 @@ export { default as formatAsNumber } from "./formatAsNumber";
 export { default as formatAsPct } from "./formatAsPct";
 export { default as formatDemographicValue } from "./formatDemographicValue";
 export { default as getDataWithPct } from "./getDataWithPct";
+export { default as getDimensionalBreakdown } from "./getDimensionalBreakdown";
 export { default as recordIsTotal } from "./recordIsTotal";
 export { default as recordIsTotalByDimension } from "./recordIsTotalByDimension";

--- a/src/viz-sentence-lengths/VizSentenceLengths.js
+++ b/src/viz-sentence-lengths/VizSentenceLengths.js
@@ -3,18 +3,8 @@ import React from "react";
 import Measure from "react-measure";
 import styled from "styled-components";
 import BarChartTrellis from "../bar-chart-trellis";
-import {
-  recordIsTotalByDimension,
-  recordIsTotal,
-  categoryIsNotUnknown,
-} from "../utils";
-import {
-  DIMENSION_MAPPINGS,
-  DIMENSION_DATA_KEYS,
-  DIMENSION_KEYS,
-  SENTENCE_LENGTHS,
-  THEME,
-} from "../constants";
+import { getDimensionalBreakdown } from "../utils";
+import { SENTENCE_LENGTHS, THEME } from "../constants";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -27,28 +17,17 @@ export default function VizSentenceLengths({
 }) {
   if (!dimension || !locationId) return null;
 
-  const filteredData = sentenceLengths
-    .filter(({ district }) => district === locationId)
-    .filter(recordIsTotalByDimension(dimension));
-  const categories = DIMENSION_MAPPINGS.get(dimension);
-
-  const chartData = [...categories]
-    .filter(categoryIsNotUnknown)
-    .map(([value, label]) => {
-      const matchingRow = filteredData.find((record) =>
-        dimension === DIMENSION_KEYS.total
-          ? recordIsTotal(record)
-          : record[DIMENSION_DATA_KEYS[dimension]] === value
-      );
-      return {
-        title: label,
-        data: [...SENTENCE_LENGTHS].map(([key, lengthLabel]) => ({
-          color: THEME.colors.sentenceLengths[key],
-          label: lengthLabel,
-          value: matchingRow ? matchingRow[key] : 0,
-        })),
-      };
-    });
+  const chartData = getDimensionalBreakdown({
+    data: sentenceLengths.filter(({ district }) => district === locationId),
+    dimension,
+  }).map(({ label, record }) => ({
+    title: label,
+    data: [...SENTENCE_LENGTHS].map(([key, lengthLabel]) => ({
+      color: THEME.colors.sentenceLengths[key],
+      label: lengthLabel,
+      value: record ? record[key] : 0,
+    })),
+  }));
 
   return (
     <Measure bounds>


### PR DESCRIPTION
## Description of the change

This ensures the number of charts stays consistent, to increase clarity and avoid jarring layout changes. 

![no data](https://user-images.githubusercontent.com/5385319/88430589-8bfef680-cdad-11ea-8a18-b6d5086b6649.gif)

There was similar data transformation logic for the sentence lengths breakdowns so I factored that out into a utility function. (we may find it of use in other places as well). Creating empty records made for nicer transitions, so I've done that here, but the component doesn't require it (an empty `data` array will result in the same visual treatment).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #59 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
