### PR TITLE
Mobile tooltips and highlighting for all charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "date-fns": "^2.14.0",
     "deepmerge": "^4.2.2",
     "dotenv": "^8.2.0",
+    "empty-lite": "^1.0.3",
     "env-cmd": "^10.1.0",
     "express": "^4.17.1",
     "helmet": "^3.23.3",

--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,9 @@ import { Router, Redirect } from "@reach/router";
 import { setup as setupBreakpoints } from "@w11r/use-breakpoint";
 import React from "react";
 import { ThemeProvider } from "styled-components";
-import SiteStyles from "./site-styles";
 import { CUSTOM_BREAKPOINTS, DEFAULT_TENANT, THEME } from "./constants";
+import { InfoPanelProvider } from "./info-panel";
+import SiteStyles from "./site-styles";
 import SiteLayout from "./site-layout";
 
 // set custom breakpoints for media queries
@@ -20,11 +21,13 @@ function App() {
 
   return (
     <ThemeProvider theme={THEME}>
-      <SiteStyles />
-      <Router>
-        <Redirect from="/" to={`/${currentTenant}`} noThrow replace />
-        <SiteLayout path=":tenantId/*" />
-      </Router>
+      <InfoPanelProvider>
+        <SiteStyles />
+        <Router>
+          <Redirect from="/" to={`/${currentTenant}`} noThrow replace />
+          <SiteLayout path=":tenantId/*" />
+        </Router>
+      </InfoPanelProvider>
     </ThemeProvider>
   );
 }

--- a/src/bar-chart-trellis/BarChartTrellis.js
+++ b/src/bar-chart-trellis/BarChartTrellis.js
@@ -4,7 +4,7 @@ import { FacetController, OrdinalFrame } from "semiotic";
 import styled from "styled-components";
 import { SENTENCE_LENGTH_KEYS, SENTENCE_LENGTHS, THEME } from "../constants";
 import ChartWrapper from "../chart-wrapper";
-import Tooltip from "../tooltip";
+import ResponsiveTooltipController from "../responsive-tooltip-controller";
 
 const CHART_HEIGHT = 360;
 const CHART_MIN_WIDTH = 320;
@@ -24,16 +24,9 @@ const ColumnLabel = styled.text`
   text-anchor: middle;
 `;
 
-const renderTooltip = (chartTitle) => ({ pieces: [d] }) => (
-  <Tooltip>
-    {chartTitle}
-    <br />
-    {d.value} serving {d.label} year(s)
-  </Tooltip>
-);
-
 export default function BarChartTrellis({ data, width }) {
   const [highlightedLabel, setHighlightedLabel] = useState();
+  const [selectedChartTitle, setSelectedChartTitle] = useState();
 
   let chartWidth = data.length > 1 ? width / 2 : width;
 
@@ -47,53 +40,84 @@ export default function BarChartTrellis({ data, width }) {
     { baseline: false, orient: "left", tickLineGenerator: () => null },
   ];
 
+  const renderTooltip = (columnData) => {
+    const {
+      pieces: [d],
+    } = columnData;
+
+    return {
+      title: selectedChartTitle || "",
+      records: [
+        {
+          label: `${d.label} year${
+            d.label === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
+              ? ""
+              : "s"
+          }`,
+          value: d.value,
+        },
+      ],
+    };
+  };
+
   return (
     <Wrapper>
-      <FacetController
-        baseMarkProps={{
-          transitionDuration: { fill: THEME.transition.defaultDurationMs },
-        }}
-        margin={MARGIN}
-        oAccessor="label"
-        oLabel={(label) => {
-          const postfix =
-            label === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
-              ? " year"
-              : "";
-          return <ColumnLabel>{`${label}${postfix}`}</ColumnLabel>;
-        }}
-        oPadding={8}
-        rAccessor="value"
-        sharedRExtent
-        size={[chartWidth, CHART_HEIGHT]}
-        style={(d) => ({
-          fill: highlightedLabel === d.label ? THEME.colors.highlight : d.color,
-        })}
-        type="bar"
-      >
-        {data.map(({ title, data: chartData }, index) => (
-          <OrdinalFrame
-            axes={alternatingAxes && index % 2 ? undefined : axes}
-            customHoverBehavior={(d) =>
-              d ? setHighlightedLabel(d.column.name) : setHighlightedLabel()
-            }
-            data={chartData}
-            hoverAnnotation
-            // using indices actually makes a better experience here;
-            // the charts animate in and out based on how many there are
-            // and we avoid bugs that happen when values change but the
-            // identifiers (i.e. titles) stay the same
-            // eslint-disable-next-line react/no-array-index-key
-            key={index}
-            title={
-              <ChartTitle x={0 - chartWidth / 2 + MARGIN.left}>
-                {title}
-              </ChartTitle>
-            }
-            tooltipContent={renderTooltip(title)}
-          />
-        ))}
-      </FacetController>
+      <ResponsiveTooltipController
+        getTooltipProps={renderTooltip}
+        hoverAnnotation
+        render={(responsiveTooltipProps) => (
+          <FacetController
+            baseMarkProps={{
+              transitionDuration: { fill: THEME.transition.defaultDurationMs },
+            }}
+            margin={MARGIN}
+            oAccessor="label"
+            oLabel={(label) => {
+              const postfix =
+                label === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
+                  ? " year"
+                  : "";
+              return <ColumnLabel>{`${label}${postfix}`}</ColumnLabel>;
+            }}
+            oPadding={8}
+            rAccessor="value"
+            sharedRExtent
+            size={[chartWidth, CHART_HEIGHT]}
+            style={(d) => ({
+              fill:
+                highlightedLabel === d.label ? THEME.colors.highlight : d.color,
+            })}
+            type="bar"
+          >
+            {data.map(({ title, data: chartData }, index) => (
+              <OrdinalFrame
+                axes={alternatingAxes && index % 2 ? undefined : axes}
+                customHoverBehavior={(d) => {
+                  setSelectedChartTitle(title);
+                  if (d) {
+                    setHighlightedLabel(d.column.name);
+                  } else {
+                    setHighlightedLabel();
+                  }
+                }}
+                data={chartData}
+                // using indices actually makes a better experience here;
+                // the charts animate in and out based on how many there are
+                // and we avoid bugs that happen when values change but the
+                // identifiers (i.e. titles) stay the same
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                title={
+                  <ChartTitle x={0 - chartWidth / 2 + MARGIN.left}>
+                    {title}
+                  </ChartTitle>
+                }
+                {...responsiveTooltipProps}
+              />
+            ))}
+          </FacetController>
+        )}
+      />
     </Wrapper>
   );
 }

--- a/src/bar-chart-trellis/BarChartTrellis.js
+++ b/src/bar-chart-trellis/BarChartTrellis.js
@@ -42,15 +42,15 @@ export default function BarChartTrellis({ data, width }) {
 
   const renderTooltip = (columnData) => {
     const {
-      pieces: [d],
+      summary: [d],
     } = columnData;
 
     return {
       title: selectedChartTitle || "",
       records: [
         {
-          label: `${d.label} year${
-            d.label === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
+          label: `${d.column} year${
+            d.column === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
               ? ""
               : "s"
           }`,
@@ -65,7 +65,11 @@ export default function BarChartTrellis({ data, width }) {
       <ResponsiveTooltipController
         getTooltipProps={renderTooltip}
         hoverAnnotation
-        render={(responsiveTooltipProps) => (
+        render={({
+          customClickBehavior,
+          customHoverBehavior,
+          ...responsiveTooltipProps
+        }) => (
           <FacetController
             baseMarkProps={{
               transitionDuration: { fill: THEME.transition.defaultDurationMs },
@@ -92,13 +96,16 @@ export default function BarChartTrellis({ data, width }) {
             {data.map(({ title, data: chartData }, index) => (
               <OrdinalFrame
                 axes={alternatingAxes && index % 2 ? undefined : axes}
+                // we have to extend these custom behavior functions
+                // to get the chart title into state for the tooltip;
+                // they are guaranteed to be provided by ResponsiveTooltipController
+                customClickBehavior={(d) => {
+                  setSelectedChartTitle(title);
+                  customClickBehavior(d);
+                }}
                 customHoverBehavior={(d) => {
                   setSelectedChartTitle(title);
-                  if (d) {
-                    setHighlightedLabel(d.column.name);
-                  } else {
-                    setHighlightedLabel();
-                  }
+                  customHoverBehavior(d);
                 }}
                 data={chartData}
                 // using indices actually makes a better experience here;
@@ -117,6 +124,9 @@ export default function BarChartTrellis({ data, width }) {
             ))}
           </FacetController>
         )}
+        setHighlighted={(d) =>
+          setHighlightedLabel(d ? d.column.name : undefined)
+        }
       />
     </Wrapper>
   );

--- a/src/bar-chart-trellis/BarChartTrellis.js
+++ b/src/bar-chart-trellis/BarChartTrellis.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { FacetController, OrdinalFrame } from "semiotic";
 import styled from "styled-components";
 import { SENTENCE_LENGTH_KEYS, SENTENCE_LENGTHS, THEME } from "../constants";
@@ -27,6 +27,12 @@ const ColumnLabel = styled.text`
 export default function BarChartTrellis({ data, width }) {
   const [highlightedLabel, setHighlightedLabel] = useState();
   const [selectedChartTitle, setSelectedChartTitle] = useState();
+
+  // ResponsiveTooltipController expects this to be a stable reference
+  const setHighlighted = useCallback(
+    (d) => setHighlightedLabel(d ? d.column.name : undefined),
+    [setHighlightedLabel]
+  );
 
   let chartWidth = data.length > 1 ? width / 2 : width;
 
@@ -124,9 +130,7 @@ export default function BarChartTrellis({ data, width }) {
             ))}
           </FacetController>
         )}
-        setHighlighted={(d) =>
-          setHighlightedLabel(d ? d.column.name : undefined)
-        }
+        setHighlighted={setHighlighted}
       />
     </Wrapper>
   );

--- a/src/constants.js
+++ b/src/constants.js
@@ -263,6 +263,7 @@ export const defaultTheme = {
       probationRevoked: darkGreen6,
       other: darkGreen4,
     },
+    infoPanelTitle: "#F57E62",
     pillBackground: lightGray,
     pillValue: darkGray,
     monthlyTimeseriesBar: darkGreen5,

--- a/src/info-panel/InfoPanel.js
+++ b/src/info-panel/InfoPanel.js
@@ -13,7 +13,18 @@ const InfoPanelWrapper = styled.div`
   padding-top: 8px;
   position: fixed;
   right: 0;
-  z-index: ${(props) => props.theme.zIndex.tooltip};
+  z-index: ${(props) => props.theme.zIndex.modal};
+`;
+
+const InfoPanelOverlay = styled.div`
+  background: ${(props) => props.theme.colors.tooltipBackground};
+  bottom: 0;
+  left: 0%;
+  opacity: 0.1;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: ${(props) => props.theme.zIndex.modal};
 `;
 
 const CloseButtonWrapper = styled.div`
@@ -39,22 +50,25 @@ export default function InfoPanel({ data, renderContents }) {
   const enabled = useBreakpoint(false, ["mobile-", true]);
   const infoPanelDispatch = useInfoPanelDispatch();
 
+  const dismiss = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    infoPanelDispatch({ type: "clear" });
+  };
+
   if (enabled && data && renderContents) {
     return (
-      <InfoPanelWrapper className="InfoPanel">
-        <CloseButtonWrapper>
-          <CloseButton
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              infoPanelDispatch({ type: "clear" });
-            }}
-          >
-            <MenuOpenIcon width={ICON_SIZE} height={ICON_SIZE} />
-          </CloseButton>
-        </CloseButtonWrapper>
-        {renderContents(data)}
-      </InfoPanelWrapper>
+      <>
+        <InfoPanelOverlay onClick={dismiss} />
+        <InfoPanelWrapper className="InfoPanel">
+          <CloseButtonWrapper>
+            <CloseButton onClick={dismiss}>
+              <MenuOpenIcon width={ICON_SIZE} height={ICON_SIZE} />
+            </CloseButton>
+          </CloseButtonWrapper>
+          {renderContents(data)}
+        </InfoPanelWrapper>
+      </>
     );
   }
   return null;

--- a/src/info-panel/InfoPanel.js
+++ b/src/info-panel/InfoPanel.js
@@ -1,0 +1,71 @@
+import useBreakpoint from "@w11r/use-breakpoint";
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+import { ReactComponent as MenuOpenIcon } from "../assets/icons/menuOpen.svg";
+import { useInfoPanelDispatch } from "./InfoPanelContext";
+
+const InfoPanelWrapper = styled.div`
+  background: ${(props) => props.theme.colors.tooltipBackground};
+  border-radius: 0;
+  bottom: 0;
+  left: 0;
+  padding-top: 8px;
+  position: fixed;
+  right: 0;
+  z-index: ${(props) => props.theme.zIndex.tooltip};
+`;
+
+const CloseButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  margin-right: 24px;
+
+  rect {
+    fill: ${(props) => props.theme.colors.bodyLight} !important;
+  }
+`;
+
+const ICON_SIZE = 16;
+
+export default function InfoPanel({ data, renderContents }) {
+  const enabled = useBreakpoint(false, ["mobile-", true]);
+  const infoPanelDispatch = useInfoPanelDispatch();
+
+  if (enabled && data && renderContents) {
+    return (
+      <InfoPanelWrapper className="InfoPanel">
+        <CloseButtonWrapper>
+          <CloseButton
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              infoPanelDispatch({ type: "clear" });
+            }}
+          >
+            <MenuOpenIcon width={ICON_SIZE} height={ICON_SIZE} />
+          </CloseButton>
+        </CloseButtonWrapper>
+        {renderContents(data)}
+      </InfoPanelWrapper>
+    );
+  }
+  return null;
+}
+
+InfoPanel.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any),
+  renderContents: PropTypes.func,
+};
+
+InfoPanel.defaultProps = {
+  data: undefined,
+  renderContents: undefined,
+};

--- a/src/info-panel/InfoPanelContainer.js
+++ b/src/info-panel/InfoPanelContainer.js
@@ -1,0 +1,8 @@
+import React from "react";
+import InfoPanel from "./InfoPanel";
+import { useInfoPanelState } from "./InfoPanelContext";
+
+export default function InfoPanelContainer() {
+  const state = useInfoPanelState();
+  return <InfoPanel {...state} />;
+}

--- a/src/info-panel/InfoPanelContext.js
+++ b/src/info-panel/InfoPanelContext.js
@@ -1,0 +1,54 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+const InfoPanelStateContext = React.createContext();
+const InfoPanelDispatchContext = React.createContext();
+
+function infoPanelReducer(state, action) {
+  switch (action.type) {
+    case "update": {
+      return { ...state, ...action.payload };
+    }
+    case "clear": {
+      return {};
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+}
+
+export function InfoPanelProvider({ children }) {
+  const [state, dispatch] = React.useReducer(infoPanelReducer, {});
+  return (
+    <InfoPanelStateContext.Provider value={state}>
+      <InfoPanelDispatchContext.Provider value={dispatch}>
+        {children}
+      </InfoPanelDispatchContext.Provider>
+    </InfoPanelStateContext.Provider>
+  );
+}
+
+InfoPanelProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export function useInfoPanelState() {
+  const context = React.useContext(InfoPanelStateContext);
+  if (context === undefined) {
+    throw new Error(
+      "useInfoPanelState must be used within an InfoPanelProvider"
+    );
+  }
+  return context;
+}
+
+export function useInfoPanelDispatch() {
+  const context = React.useContext(InfoPanelDispatchContext);
+  if (context === undefined) {
+    throw new Error(
+      "useInfoPanelDispatch must be used within an InfoPanelProvider"
+    );
+  }
+  return context;
+}

--- a/src/info-panel/index.js
+++ b/src/info-panel/index.js
@@ -1,0 +1,2 @@
+export { default } from "./InfoPanelContainer";
+export * from "./InfoPanelContext";

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -4,8 +4,8 @@ import React from "react";
 import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
 import styled from "styled-components";
 import ColorLegend from "../color-legend";
-import Tooltip from "../tooltip";
-import { formatAsPct, getDataWithPct } from "../utils";
+import { getDataWithPct } from "../utils";
+import ResponsiveTooltipController from "../responsive-tooltip-controller";
 
 const ProportionalBarContainer = styled.figure`
   height: 100%;
@@ -48,58 +48,29 @@ const ProportionalBarTitle = styled.div`
   margin-right: 15px;
 `;
 
-const ProportionalBarTooltipText = styled.p`
-  ${(props) => (props.bold ? `font: ${props.theme.fonts.bodyBold};` : "")}
-  line-height: 2;
-  margin: 0;
-  white-space: nowrap;
-`;
-
 export default function ProportionalBar({ data, height, showLegend, title }) {
-  const TOOLTIP_PADDING = 3;
-
   const dataWithPct = getDataWithPct(data);
   const noData = data.length === 0 || sum(data.map(({ value }) => value)) === 0;
 
   return (
     <ProportionalBarContainer>
       <ProportionalBarChartWrapper>
-        <ResponsiveOrdinalFrame
-          data={dataWithPct}
-          margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
-          oAccessor={() => title}
-          pieceClass="ProportionalBarChart__segment"
-          pieceHoverAnnotation
-          projection="horizontal"
-          rAccessor="value"
-          renderKey="label"
-          responsiveWidth
-          // the width value is just a placeholder, it will be 100% per responsiveWidth
-          size={[0, height]}
-          style={(d) => ({ fill: d.color })}
-          tooltipContent={(d) => {
-            return (
-              <Tooltip
-                style={{
-                  // d.y is the vertical center of the hover target; since we know there is only one bar,
-                  // we know it is the vertical center of the entire chart and we can use it
-                  // to push the tooltip below the chart
-                  transform: `translateX(-50%) translateY(${
-                    d.y + TOOLTIP_PADDING
-                  }px)`,
-                }}
-              >
-                <ProportionalBarTooltipText>
-                  {d.label}
-                </ProportionalBarTooltipText>
-                <ProportionalBarTooltipText bold>
-                  {d.value} ({formatAsPct(d.pct)})
-                </ProportionalBarTooltipText>
-              </Tooltip>
-            );
-          }}
-          type="bar"
-        />
+        <ResponsiveTooltipController pieceHoverAnnotation>
+          <ResponsiveOrdinalFrame
+            data={dataWithPct}
+            margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
+            oAccessor={() => title}
+            pieceClass="ProportionalBarChart__segment"
+            projection="horizontal"
+            rAccessor="value"
+            renderKey="label"
+            responsiveWidth
+            // the width value is just a placeholder, it will be 100% per responsiveWidth
+            size={[0, height]}
+            style={(d) => ({ fill: d.color })}
+            type="bar"
+          />
+        </ResponsiveTooltipController>
       </ProportionalBarChartWrapper>
       <ProportionalBarMetadata>
         <ProportionalBarTitle>

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -1,9 +1,10 @@
 import { sum } from "d3-array";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
 import styled from "styled-components";
 import ColorLegend from "../color-legend";
+import { THEME } from "../constants";
 import { getDataWithPct } from "../utils";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 
@@ -22,14 +23,6 @@ const ProportionalBarChartWrapper = styled.div`
   .ProportionalBarChart__segment {
     stroke: ${(props) => props.theme.colors.background};
     stroke-width: 2;
-
-    &:hover {
-      fill: ${(props) => props.theme.colors.highlight};
-      /* the hover target is actually an invisible overlay, this reveals it */
-      opacity: 1 !important;
-      transition: opacity
-        ${(props) => props.theme.transition.defaultTimeSettings};
-    }
   }
 `;
 
@@ -49,14 +42,22 @@ const ProportionalBarTitle = styled.div`
 `;
 
 export default function ProportionalBar({ data, height, showLegend, title }) {
+  const [highlighted, setHighlighted] = useState();
+
   const dataWithPct = getDataWithPct(data);
   const noData = data.length === 0 || sum(data.map(({ value }) => value)) === 0;
 
   return (
     <ProportionalBarContainer>
       <ProportionalBarChartWrapper>
-        <ResponsiveTooltipController pieceHoverAnnotation>
+        <ResponsiveTooltipController
+          pieceHoverAnnotation
+          setHighlighted={setHighlighted}
+        >
           <ResponsiveOrdinalFrame
+            baseMarkProps={{
+              transitionDuration: { fill: THEME.transition.defaultDurationMs },
+            }}
             data={dataWithPct}
             margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
             oAccessor={() => title}
@@ -67,7 +68,12 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
             responsiveWidth
             // the width value is just a placeholder, it will be 100% per responsiveWidth
             size={[0, height]}
-            style={(d) => ({ fill: d.color })}
+            style={(d) => ({
+              fill:
+                (highlighted || {}).label === d.label
+                  ? THEME.colors.highlight
+                  : d.color,
+            })}
             type="bar"
           />
         </ResponsiveTooltipController>

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -1,0 +1,62 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useInfoPanelDispatch } from "../info-panel";
+import Tooltip from "../tooltip";
+
+function chartDataToTooltipProps({ label, value, pct }) {
+  return {
+    title: label,
+    records: [
+      {
+        value,
+        pct,
+      },
+    ],
+  };
+}
+
+// a wrapper around visualization components that passes props
+// as needed for native hover annotations in Semiotic but also
+// uses same configuration to power our custom InfoPanel component
+// (which is for touch screens, which Semiotic does not natively support
+// for hover-equivalent interactions)
+export default function ResponsiveTooltipController({
+  children,
+  getTooltipProps,
+  hoverAnnotation,
+  pieceHoverAnnotation,
+}) {
+  const infoPanelDispatch = useInfoPanelDispatch();
+
+  // childProps are props that Semiotic will recognize; non-Semiotic children
+  // should implement the same API if they want to use this controller
+  const tooltipContent = (d) => <Tooltip {...getTooltipProps(d)} />;
+  const childProps = { hoverAnnotation, pieceHoverAnnotation, tooltipContent };
+
+  childProps.customClickBehavior = (d) =>
+    infoPanelDispatch({
+      type: "update",
+      payload: { data: d, renderContents: tooltipContent },
+    });
+
+  return (
+    <>
+      {React.Children.map(children, (child) =>
+        React.cloneElement(child, childProps)
+      )}
+    </>
+  );
+}
+
+ResponsiveTooltipController.propTypes = {
+  children: PropTypes.node.isRequired,
+  getTooltipProps: PropTypes.func,
+  hoverAnnotation: PropTypes.bool,
+  pieceHoverAnnotation: PropTypes.bool,
+};
+
+ResponsiveTooltipController.defaultProps = {
+  getTooltipProps: chartDataToTooltipProps,
+  hoverAnnotation: undefined,
+  pieceHoverAnnotation: undefined,
+};

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -51,7 +51,14 @@ export default function ResponsiveTooltipController({
   // childProps are props that Semiotic will recognize; non-Semiotic children
   // should implement the same API if they want to use this controller
   const tooltipContent = (d) => <Tooltip {...getTooltipProps(d)} />;
-  const childProps = { hoverAnnotation, tooltipContent };
+  const renderNull = () => null;
+
+  const childProps = {
+    hoverAnnotation,
+    // some mobile browsers fire hover events on tap;
+    // returning null prevents us from showing both tooltip and info panel simultaneously
+    tooltipContent: enableInfoPanel ? renderNull : tooltipContent,
+  };
 
   // not all chart frames support this so don't include it by default
   // or Semiotic will yell at you

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -1,6 +1,7 @@
+import empty from "empty-lite";
 import PropTypes from "prop-types";
-import React from "react";
-import { useInfoPanelDispatch } from "../info-panel";
+import React, { useEffect } from "react";
+import { useInfoPanelDispatch, useInfoPanelState } from "../info-panel";
 import Tooltip from "../tooltip";
 
 function chartDataToTooltipProps({ label, value, pct }) {
@@ -26,8 +27,17 @@ export default function ResponsiveTooltipController({
   hoverAnnotation,
   pieceHoverAnnotation,
   render,
+  setHighlighted,
 }) {
   const infoPanelDispatch = useInfoPanelDispatch();
+  const infoPanelState = useInfoPanelState();
+
+  useEffect(() => {
+    // when state is cleared, make sure highlight is cleared also
+    if (empty(infoPanelState) && setHighlighted) {
+      setHighlighted();
+    }
+  }, [infoPanelState, setHighlighted]);
 
   // childProps are props that Semiotic will recognize; non-Semiotic children
   // should implement the same API if they want to use this controller
@@ -39,11 +49,21 @@ export default function ResponsiveTooltipController({
   if (pieceHoverAnnotation)
     childProps.pieceHoverAnnotation = pieceHoverAnnotation;
 
-  childProps.customClickBehavior = (d) =>
+  childProps.customClickBehavior = (d) => {
     infoPanelDispatch({
       type: "update",
       payload: { data: d, renderContents: tooltipContent },
     });
+    if (setHighlighted) {
+      setHighlighted(d);
+    }
+  };
+
+  childProps.customHoverBehavior = (d) => {
+    if (setHighlighted) {
+      setHighlighted(d);
+    }
+  };
 
   if (render) {
     return render(childProps);
@@ -67,6 +87,7 @@ ResponsiveTooltipController.propTypes = {
   hoverAnnotation: PropTypes.bool,
   pieceHoverAnnotation: PropTypes.bool,
   render: PropTypes.func,
+  setHighlighted: PropTypes.func,
 };
 
 ResponsiveTooltipController.defaultProps = {
@@ -75,4 +96,5 @@ ResponsiveTooltipController.defaultProps = {
   hoverAnnotation: undefined,
   pieceHoverAnnotation: undefined,
   render: undefined,
+  setHighlighted: undefined,
 };

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -25,6 +25,7 @@ export default function ResponsiveTooltipController({
   getTooltipProps,
   hoverAnnotation,
   pieceHoverAnnotation,
+  render,
 }) {
   const infoPanelDispatch = useInfoPanelDispatch();
 
@@ -44,24 +45,34 @@ export default function ResponsiveTooltipController({
       payload: { data: d, renderContents: tooltipContent },
     });
 
-  return (
-    <>
-      {React.Children.map(children, (child) =>
-        React.cloneElement(child, childProps)
-      )}
-    </>
-  );
+  if (render) {
+    return render(childProps);
+  }
+  if (children) {
+    return (
+      <>
+        {React.Children.map(children, (child) =>
+          React.cloneElement(child, childProps)
+        )}
+      </>
+    );
+  }
+
+  throw new Error("You must provide either children or a render prop");
 }
 
 ResponsiveTooltipController.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   getTooltipProps: PropTypes.func,
   hoverAnnotation: PropTypes.bool,
   pieceHoverAnnotation: PropTypes.bool,
+  render: PropTypes.func,
 };
 
 ResponsiveTooltipController.defaultProps = {
+  children: undefined,
   getTooltipProps: chartDataToTooltipProps,
   hoverAnnotation: undefined,
   pieceHoverAnnotation: undefined,
+  render: undefined,
 };

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -31,7 +31,12 @@ export default function ResponsiveTooltipController({
   // childProps are props that Semiotic will recognize; non-Semiotic children
   // should implement the same API if they want to use this controller
   const tooltipContent = (d) => <Tooltip {...getTooltipProps(d)} />;
-  const childProps = { hoverAnnotation, pieceHoverAnnotation, tooltipContent };
+  const childProps = { hoverAnnotation, tooltipContent };
+
+  // not all chart frames support this so don't include it by default
+  // or Semiotic will yell at you
+  if (pieceHoverAnnotation)
+    childProps.pieceHoverAnnotation = pieceHoverAnnotation;
 
   childProps.customClickBehavior = (d) =>
     infoPanelDispatch({

--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -1,3 +1,4 @@
+import useBreakpoint from "@w11r/use-breakpoint";
 import empty from "empty-lite";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
@@ -31,6 +32,7 @@ export default function ResponsiveTooltipController({
 }) {
   const infoPanelDispatch = useInfoPanelDispatch();
   const infoPanelState = useInfoPanelState();
+  const enableInfoPanel = useBreakpoint(false, ["mobile-", true]);
 
   useEffect(() => {
     // when state is cleared, make sure highlight is cleared also
@@ -38,6 +40,13 @@ export default function ResponsiveTooltipController({
       setHighlighted();
     }
   }, [infoPanelState, setHighlighted]);
+
+  // if info panel becomes disabled we should clear its state
+  useEffect(() => {
+    if (!enableInfoPanel) {
+      infoPanelDispatch({ type: "clear" });
+    }
+  }, [enableInfoPanel, infoPanelDispatch]);
 
   // childProps are props that Semiotic will recognize; non-Semiotic children
   // should implement the same API if they want to use this controller
@@ -50,12 +59,14 @@ export default function ResponsiveTooltipController({
     childProps.pieceHoverAnnotation = pieceHoverAnnotation;
 
   childProps.customClickBehavior = (d) => {
-    infoPanelDispatch({
-      type: "update",
-      payload: { data: d, renderContents: tooltipContent },
-    });
-    if (setHighlighted) {
-      setHighlighted(d);
+    if (enableInfoPanel) {
+      infoPanelDispatch({
+        type: "update",
+        payload: { data: d, renderContents: tooltipContent },
+      });
+      if (setHighlighted) {
+        setHighlighted(d);
+      }
     }
   };
 

--- a/src/responsive-tooltip-controller/index.js
+++ b/src/responsive-tooltip-controller/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ResponsiveTooltipController";

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -15,6 +15,7 @@ import NavBar from "../nav-bar";
 import PageRoutes from "../page-routes";
 import BackgroundImageSrc from "../assets/images/background.png";
 import SecondaryNav from "../secondary-nav";
+import InfoPanel from "../info-panel";
 
 const NAV_WIDTH = 150;
 
@@ -107,6 +108,7 @@ function SiteLayout({ tenantId }) {
       <FooterWrapper>
         <Footer />
       </FooterWrapper>
+      <InfoPanel />
     </SiteContainer>
   );
 }

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -10,7 +10,6 @@ const TooltipWrapper = styled.div`
   color: ${(props) => props.theme.colors.bodyLight};
   font: ${(props) => props.theme.fonts.body};
   padding: 16px;
-  padding-bottom: 8px;
   z-index: ${(props) => props.theme.zIndex.tooltip};
 
   .InfoPanel & {
@@ -38,6 +37,10 @@ const TooltipRecordList = styled.div`
 `;
 const TooltipRecord = styled.div`
   margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   .InfoPanel & {
     font: ${(props) => props.theme.fonts.displayMedium};

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -10,14 +10,15 @@ const TooltipWrapper = styled.div`
   color: ${(props) => props.theme.colors.bodyLight};
   font: ${(props) => props.theme.fonts.body};
   padding: 16px;
+  padding-bottom: 8px;
   z-index: ${(props) => props.theme.zIndex.tooltip};
 
   .InfoPanel & {
     background: transparent;
     border-radius: 0;
     box-shadow: none;
-    padding: 32px;
-    padding-top: 0px;
+    overflow-x: auto;
+    padding: 0 32px 16px;
     width: 100%;
   }
 `;
@@ -29,14 +30,27 @@ const TooltipTitle = styled.div`
     margin-bottom: 24px;
   }
 `;
-const TooltipRecordList = styled.div``;
+const TooltipRecordList = styled.div`
+  .InfoPanel & {
+    display: flex;
+  }
+`;
 const TooltipRecord = styled.div`
+  margin-bottom: 16px;
+
   .InfoPanel & {
     font: ${(props) => props.theme.fonts.displayMedium};
     font-size: 24px;
+    margin-right: 24px;
   }
 `;
-const TooltipLabel = styled.div``;
+const TooltipLabel = styled.div`
+  .InfoPanel & {
+    font: ${(props) => props.theme.fonts.body};
+    font-size: 16px;
+    opacity: 0.6;
+  }
+`;
 const TooltipValue = styled.div``;
 const TooltipPct = styled.div``;
 

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,13 +1,71 @@
-const { default: styled } = require("styled-components");
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+import { formatAsPct, formatAsNumber } from "../utils";
 
-const Tooltip = styled.div`
+const TooltipWrapper = styled.div`
   background: ${(props) => props.theme.colors.tooltipBackground};
   border-radius: 4px;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
   color: ${(props) => props.theme.colors.bodyLight};
   font: ${(props) => props.theme.fonts.body};
-  padding: 12px;
+  padding: 16px;
   z-index: ${(props) => props.theme.zIndex.tooltip};
+
+  .InfoPanel & {
+    background: transparent;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 32px;
+    padding-top: 0px;
+    width: 100%;
+  }
 `;
+
+const TooltipTitle = styled.div`
+  color: ${(props) => props.theme.colors.infoPanelTitle};
+
+  .InfoPanel & {
+    margin-bottom: 24px;
+  }
+`;
+const TooltipRecordList = styled.div``;
+const TooltipRecord = styled.div`
+  .InfoPanel & {
+    font: ${(props) => props.theme.fonts.displayMedium};
+    font-size: 24px;
+  }
+`;
+const TooltipLabel = styled.div``;
+const TooltipValue = styled.div``;
+const TooltipPct = styled.div``;
+
+export const Tooltip = ({ title, records }) => {
+  return (
+    <TooltipWrapper>
+      <TooltipTitle>{title}</TooltipTitle>
+      <TooltipRecordList>
+        {records.map(({ label, value, pct }, i) => (
+          <TooltipRecord key={label || i}>
+            {label && <TooltipLabel>{label}</TooltipLabel>}
+            <TooltipValue>{formatAsNumber(value)}</TooltipValue>
+            {pct && <TooltipPct>{formatAsPct(pct)}</TooltipPct>}
+          </TooltipRecord>
+        ))}
+      </TooltipRecordList>
+    </TooltipWrapper>
+  );
+};
+
+Tooltip.propTypes = {
+  records: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.number.isRequired,
+      pct: PropTypes.number,
+    })
+  ).isRequired,
+  title: PropTypes.string.isRequired,
+};
 
 export default Tooltip;

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -94,8 +94,10 @@ export const Tooltip = ({ title, records }) => {
         {records.map(({ label, value, pct }, i) => (
           <TooltipRecord key={label || i}>
             {label && <TooltipLabel>{label}</TooltipLabel>}
-            <TooltipValue>{formatAsNumber(value)}</TooltipValue>
-            {pct && <TooltipPct>{formatAsPct(pct)}</TooltipPct>}
+            <TooltipValue>
+              {typeof value === "number" ? formatAsNumber(value) : value}
+            </TooltipValue>
+            {pct !== undefined && <TooltipPct>{formatAsPct(pct)}</TooltipPct>}
           </TooltipRecord>
         ))}
       </TooltipRecordList>
@@ -107,7 +109,8 @@ Tooltip.propTypes = {
   records: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
-      value: PropTypes.number.isRequired,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        .isRequired,
       pct: PropTypes.number,
     })
   ).isRequired,

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -17,7 +17,7 @@ const TooltipWrapper = styled.div`
     border-radius: 0;
     box-shadow: none;
     overflow-x: auto;
-    padding: 0 32px 16px;
+    padding: 0 32px 32px;
     width: 100%;
   }
 `;
@@ -46,6 +46,7 @@ const TooltipRecord = styled.div`
     font: ${(props) => props.theme.fonts.displayMedium};
     font-size: 24px;
     margin-right: 24px;
+    margin-bottom: 0;
   }
 `;
 const TooltipLabel = styled.div`

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -32,6 +32,7 @@ const TooltipTitle = styled.div`
 `;
 const TooltipRecordList = styled.div`
   .InfoPanel & {
+    align-items: flex-end;
     display: flex;
   }
 `;
@@ -51,8 +52,35 @@ const TooltipLabel = styled.div`
     opacity: 0.6;
   }
 `;
-const TooltipValue = styled.div``;
-const TooltipPct = styled.div``;
+const TooltipValue = styled.div`
+  display: inline-block;
+
+  .InfoPanel & {
+    display: block;
+  }
+`;
+const TooltipPct = styled.div`
+  display: inline-block;
+  margin-left: 8px;
+
+  &::before {
+    content: "(";
+  }
+
+  &::after {
+    content: ")";
+  }
+
+  .InfoPanel & {
+    display: block;
+    margin-left: 0;
+
+    &::before,
+    &::after {
+      content: "";
+    }
+  }
+`;
 
 export const Tooltip = ({ title, records }) => {
   return (

--- a/src/utils/addEmptyMonthsToData.js
+++ b/src/utils/addEmptyMonthsToData.js
@@ -22,7 +22,7 @@ export default function addEmptyMonthsToData({
   const newDataPoints = [...dataPoints];
 
   const end = new Date();
-  const start = subMonths(end, monthCount);
+  const start = subMonths(end, monthCount - 1);
   eachMonthOfInterval({ start, end }).forEach((monthDate) => {
     const year = monthDate.getFullYear();
     // months are 1-indexed in our data source

--- a/src/viz-sentence-types/VizSentenceTypes.js
+++ b/src/viz-sentence-types/VizSentenceTypes.js
@@ -24,8 +24,12 @@ export default function VizSentenceTypes({
         dimension
       );
       return [
-        { source: "Incarceration", target, value: record.incarceration_count },
-        { source: "Probation", target, value: record.probation_count },
+        {
+          source: "Incarceration",
+          target,
+          value: Number(record.incarceration_count),
+        },
+        { source: "Probation", target, value: Number(record.probation_count) },
       ];
     })
     .reduce((flat, val) => flat.concat(val), []);

--- a/src/viz-supervision-success/VizSupervisionSuccess.js
+++ b/src/viz-supervision-success/VizSupervisionSuccess.js
@@ -16,7 +16,9 @@ import {
 function makeTimeseriesRecord(record) {
   return {
     month: `${record.year}-${record.month}`,
-    value: parseFloat(record.success_rate),
+    projected: Number(record.projected_completion_count),
+    actual: Number(record.successful_termination_count),
+    rate: parseFloat(record.success_rate),
   };
 }
 
@@ -63,7 +65,13 @@ export default function VizSupervisionSuccess({
     emptyValue: 0,
   })
     .map(makeTimeseriesRecord)
-    .sort((a, b) => ascending(a.month, b.month));
+    .sort((a, b) => {
+      const [yearA, monthA] = a.month.split("-");
+      const [yearB, monthB] = b.month.split("-");
+      return (
+        ascending(yearA, yearB) || ascending(Number(monthA), Number(monthB))
+      );
+    });
 
   const breakdownData = successByDemographics
     .filter(isSelectedLocation)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,6 +4656,11 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+empty-lite@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/empty-lite/-/empty-lite-1.0.3.tgz#31e8706bb21f6805577d67d114b3d10bc29e5e45"
+  integrity sha512-C/9UypWKjavsEZspLk9dKauBDKqdE67r19s0SZrCbiIdpASoQAVXEHxRRUmO9C7xxPEQijVKPDzXX94kZKpQag==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"


### PR DESCRIPTION
## Description of the change

Adds a mobile-only implementation of tooltips as a fixed "info panel" on the bottom of the screen (essentially a modal), and imposes a little more structure and consistency to chart tooltips in general. 

![Screen Shot 2020-07-28 at 17 50 57](https://user-images.githubusercontent.com/5385319/88744210-8bdb5f80-d0fb-11ea-93a5-1dd54fdaeab6.png)

![Screen Shot 2020-07-28 at 17 51 51](https://user-images.githubusercontent.com/5385319/88744213-8da52300-d0fb-11ea-9f90-48af7ff1eab9.png)

The main action is in `ResponsiveTooltipController`, which adapts the desired behaviors to Semiotic's API, and the `info-panel` modules. (Semiotic doesn't really support any of the mobile functionality natively, which is why I had to build something that can sit alongside it and consume the same tooltip content.) Changes in the chart components are mainly just adding support for this new controller (in some cases replacing existing interaction logic), so I would recommend looking at them after (and hiding whitespace changes, because there is a lot of re-wrapping and nesting going on).

Unfortunately this PR got pretty long, but it does add full interactivity to all the charts (except maps, since they are still subject to refactoring in #71). WIP was reviewed with Juan to determine final design and mobile behavior.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #58 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
