### PR TITLE
Section controls are sticky on mobile

### DIFF
--- a/src/branding-bar/BrandingBar.js
+++ b/src/branding-bar/BrandingBar.js
@@ -1,12 +1,12 @@
-import useBreakpoint, { mediaQuery } from "@w11r/use-breakpoint";
+import classNames from "classnames";
+import useBreakpoint from "@w11r/use-breakpoint";
 import React from "react";
 import useCollapse from "react-collapsed";
 import styled, { css } from "styled-components";
-
 import MenuClosedIconSrc from "../assets/icons/menuClosed.svg";
 import MenuOpenIconSrc from "../assets/icons/menuOpen.svg";
 import LogoIconSrc from "../assets/icons/recidiviz_logo.svg";
-import { FIXED_HEADER_HEIGHT, X_PADDING, THEME } from "../constants";
+import { FIXED_HEADER_HEIGHT, X_PADDING } from "../constants";
 import NavBar from "../nav-bar";
 import { LinkPill } from "../pill";
 
@@ -19,24 +19,24 @@ const ICON_SIZE = "26px";
 
 const Y_MARGIN = "12px";
 
-const brandingBarFixedStyles = `
-  background: ${THEME.colors.background};
-  left: 0;
-  min-height: ${FIXED_HEADER_HEIGHT}px;
-  padding: 0 ${X_PADDING}px;
-  position: fixed;
-  right: 0;
-  top: 0;
-`;
-
 const BrandingBarWrapper = styled.header`
   align-items: flex-start;
   background: "transparent";
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  z-index: ${(props) => props.theme.zIndex.header};
 
-  ${mediaQuery(["mobile-", brandingBarFixedStyles])}
+  &.fixed {
+    background: ${(props) => props.theme.colors.background};
+    left: 0;
+    height: ${(props) =>
+      props.expanded ? "auto" : `${FIXED_HEADER_HEIGHT}px`};
+    padding: 0 ${X_PADDING}px;
+    position: fixed;
+    right: 0;
+    top: 0;
+  }
 `;
 
 const BrandingBarHeader = styled.div`
@@ -122,7 +122,10 @@ export default function BrandingBar() {
   } = useCollapse();
 
   return (
-    <BrandingBarWrapper>
+    <BrandingBarWrapper
+      className={classNames({ fixed: useCollapsibleNav })}
+      expanded={useCollapsibleNav && isExpanded}
+    >
       <BrandingBarHeader
         collapsible={useCollapsibleNav}
         expanded={useCollapsibleNav && isExpanded}

--- a/src/constants.js
+++ b/src/constants.js
@@ -356,10 +356,11 @@ export const defaultTheme = {
   },
   zIndex: {
     base: 1,
-    menu: 10,
-    tooltip: 50,
-    header: 75,
-    modal: 100,
+    control: 50,
+    menu: 100,
+    tooltip: 500,
+    header: 750,
+    modal: 1000,
   },
 };
 

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -1,9 +1,11 @@
+import useBreakpoint from "@w11r/use-breakpoint";
+import classNames from "classnames";
 import { ascending } from "d3-array";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { exact, tail } from "set-order";
 import styled from "styled-components";
-import { OTHER_LABEL, TOTAL_KEY } from "../constants";
+import { FIXED_HEADER_HEIGHT, OTHER_LABEL, TOTAL_KEY } from "../constants";
 import { DimensionControl, MonthControl, LocationControl } from "../controls";
 import { HeadingTitle, HeadingDescription } from "../heading";
 
@@ -17,14 +19,13 @@ const SectionDivider = styled.hr`
 
 const sectionTextWidth = 420;
 
-const DetailSectionContainer = styled.section``;
-
-const DetailSectionHeader = styled.header`
+const DetailSectionContainer = styled.section`
   align-items: center;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
 `;
+
 const DetailSectionTitle = styled.h1`
   color: ${(props) => props.theme.colors.heading};
   flex: 0 1 auto;
@@ -34,23 +35,35 @@ const DetailSectionTitle = styled.h1`
   margin-right: 32px;
   width: ${sectionTextWidth}px;
 `;
+
 const DetailSectionControls = styled.div`
+  background: ${(props) => props.theme.colors.background};
   display: flex;
   flex: 0 0 auto;
   flex-wrap: wrap;
   justify-content: flex-start;
   max-width: 100%;
+  padding-bottom: 16px;
+
+  &.sticky {
+    position: sticky;
+    top: ${FIXED_HEADER_HEIGHT}px;
+    width: 100%;
+    z-index: ${(props) => props.theme.zIndex.control};
+  }
 `;
 
 const DetailSectionDescription = styled.p`
   color: ${(props) => props.theme.colors.body};
   font: ${(props) => props.theme.fonts.body};
-  max-width: ${sectionTextWidth}px;
+  padding-right: calc(100% - ${sectionTextWidth}px);
+  width: 100%;
 `;
 
 const DetailSectionVizContainer = styled.div`
   margin-bottom: 24px;
   margin-top: 32px;
+  width: 100%;
 `;
 
 const sortLocations = exact([tail(OTHER_LABEL)], ascending);
@@ -84,28 +97,29 @@ function DetailSection({
   const [locationList] = useState(initialLocationList);
   const [locationId, setLocationId] = useState();
 
+  const sticky = useBreakpoint(false, ["mobile-", true]);
+
   return (
     <DetailSectionContainer>
-      <DetailSectionHeader>
-        <DetailSectionTitle>{title}</DetailSectionTitle>
-        <DetailSectionControls>
-          {showMonthControl && monthList && (
-            <MonthControl months={monthList} onChange={setMonth} />
-          )}
-          {
-            // we need both a flag and data to enable location control
-            showLocationControl && locationList && (
-              <LocationControl
-                label={locationControlLabel}
-                locations={locationList}
-                onChange={setLocationId}
-                value={locationId}
-              />
-            )
-          }
-          {showDimensionControl && <DimensionControl onChange={setDimension} />}
-        </DetailSectionControls>
-      </DetailSectionHeader>
+      <DetailSectionTitle>{title}</DetailSectionTitle>
+      <DetailSectionControls className={classNames({ sticky })}>
+        {showMonthControl && monthList && (
+          <MonthControl months={monthList} onChange={setMonth} />
+        )}
+        {
+          // we need both a flag and data to enable location control
+          showLocationControl && locationList && (
+            <LocationControl
+              label={locationControlLabel}
+              locations={locationList}
+              onChange={setLocationId}
+              value={locationId}
+            />
+          )
+        }
+        {showDimensionControl && <DimensionControl onChange={setDimension} />}
+      </DetailSectionControls>
+
       <DetailSectionDescription>{description}</DetailSectionDescription>
       <DetailSectionVizContainer>
         <VizComponent

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -45,7 +45,6 @@ const BrandingBarWrapper = styled.div`
   margin-bottom: 64px;
   min-height: ${FIXED_HEADER_HEIGHT}px;
   width: 100%;
-  z-index: ${(props) => props.theme.zIndex.header};
 
   ${mediaQuery(["mobile-", "margin-bottom: 16px;"])}
 `;


### PR DESCRIPTION
## Description of the change

On small screens, controls that affect the charts in a particular section will now stick to the top of the screen (below the header) as you scroll. I had to rearrange the markup and update styles slightly so that the controls were a direct child of the section container, due to how `position: sticky` works; there should be no apparent layout change due to this on larger screens.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #40 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
