### PR TITLE
Modal Component and Modal Implementations for Methodology and Data Do…

### DIFF
--- a/src/assets/icons/closeModal.svg
+++ b/src/assets/icons/closeModal.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#FFF" fill-opacity="0" d="M0 0h24v24H0z"/>
+        <g stroke="#222" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3.997 20L20 4.004M3.997 4.003L20 20.001"/>
+        </g>
+    </g>
+</svg>

--- a/src/branding-bar/BrandingBar.js
+++ b/src/branding-bar/BrandingBar.js
@@ -9,6 +9,7 @@ import LogoIconSrc from "../assets/icons/recidiviz_logo.svg";
 import { FIXED_HEADER_HEIGHT, X_PADDING } from "../constants";
 import NavBar from "../nav-bar";
 import { LinkPill } from "../pill";
+import MethodologyModal from "../methodology-modal";
 
 const brandingBarFlexProperties = css`
   align-items: baseline;
@@ -145,7 +146,9 @@ export default function BrandingBar() {
               <LinkPill href="#">Share</LinkPill>
             </BrandingBarLink>
             <BrandingBarLink>
-              <LinkPill href="#">Download Data</LinkPill>
+              <MethodologyModal
+                trigger={<LinkPill href="#">Methodology</LinkPill>}
+              />
             </BrandingBarLink>
           </BrandingBarLinkList>
         </BrandingBarLinkListWrapper>

--- a/src/constants.js
+++ b/src/constants.js
@@ -254,6 +254,7 @@ export const defaultTheme = {
       "40<": darkGreen6,
       [DEMOGRAPHIC_UNKNOWN]: darkGreen5,
     },
+    asideBackground: "rgba(206, 202, 199, 0.8)", // "#CECAC7"
     background: "#FCFCFC",
     body: medGray,
     bodyLight: white,
@@ -384,6 +385,7 @@ export const defaultTheme = {
 
 // ND colors are tinted with the theme background color (i.e. converted from opacity)
 const ndColors = {
+  asideBackground: "rgba(206, 202, 199, 0.8)", // "#CECAC7"
   background: "#FAF9F9",
   backgroundTealShade9: "#DAE3E4",
   black: "#303030",
@@ -415,6 +417,7 @@ const northDakotaTheme = {
       "40<": ndColors.brandTealTint6,
       [DEMOGRAPHIC_UNKNOWN]: ndColors.brandTealTint5,
     },
+    asideBackground: ndColors.asideBackground,
     background: ndColors.background,
     body: ndColors.blackTint6,
     bodyLight: ndColors.background,

--- a/src/download-data-modal/DownloadDataModal.js
+++ b/src/download-data-modal/DownloadDataModal.js
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import { HeadingDescription, HeadingTitle } from "../heading";
+import { LinkPill } from "../pill";
+import Modal from "../modal";
+
+const DownloadDataWrapper = styled.div``;
+const DownloadDataHeader = styled.div`
+  border-bottom: 1px solid ${(props) => props.theme.colors.divider};
+`;
+const DownloadDataHeading = styled(HeadingTitle)`
+  font-size: 20px;
+`;
+
+const DownloadDataDescription = styled(HeadingDescription)`
+  font-size: 16px;
+`;
+
+const DownloadDataBody = styled.div``;
+const DownloadDataRow = styled.div`
+  align-items: center;
+  border-bottom: 1px solid ${(props) => props.theme.colors.divider};
+  display: flex;
+  justify-content: space-between;
+  padding: 32px 0 32px 0;
+`;
+
+const DownloadDataFilename = styled(DownloadDataHeading)`
+  margin: 0;
+`;
+
+export default function DownloadDataModal({ trigger }) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Modal trigger={trigger} open={modalOpen} setOpen={setModalOpen}>
+      <DownloadDataWrapper>
+        <DownloadDataHeader>
+          <DownloadDataHeading>Download data</DownloadDataHeading>
+          <DownloadDataDescription>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nec vel vel
+            nunc lacus diam varius varius enim risus. Sagittis, in risus sed sit
+            elementum volutpat amet turpis nisi.
+          </DownloadDataDescription>
+        </DownloadDataHeader>
+        <DownloadDataBody>
+          <DownloadDataRow>
+            <DownloadDataFilename>All-Data.zip</DownloadDataFilename>
+            <LinkPill href="#">Download</LinkPill>
+          </DownloadDataRow>
+          <DownloadDataRow>
+            <DownloadDataFilename>Sentencing.csv</DownloadDataFilename>
+            <LinkPill href="#">Download</LinkPill>
+          </DownloadDataRow>
+          <DownloadDataRow>
+            <DownloadDataFilename>Label</DownloadDataFilename>
+            <LinkPill href="#">Download</LinkPill>
+          </DownloadDataRow>
+          <DownloadDataRow>
+            <DownloadDataFilename>Label</DownloadDataFilename>
+            <LinkPill href="#">Download</LinkPill>
+          </DownloadDataRow>
+          <DownloadDataRow>
+            <DownloadDataFilename>Label</DownloadDataFilename>
+            <LinkPill href="#">Download</LinkPill>
+          </DownloadDataRow>
+        </DownloadDataBody>
+      </DownloadDataWrapper>
+    </Modal>
+  );
+}
+
+DownloadDataModal.propTypes = {
+  trigger: PropTypes.node.isRequired,
+};

--- a/src/download-data-modal/index.js
+++ b/src/download-data-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DownloadDataModal";

--- a/src/methodology-modal/MethodologyModal.js
+++ b/src/methodology-modal/MethodologyModal.js
@@ -17,11 +17,8 @@ const MethodologyDescription = styled(HeadingDescription)`
 
 const MethodologyBody = styled.div``;
 
-const SectionTitle = styled.h1`
-  color: ${(props) => props.theme.colors.heading};
-  font: ${(props) => props.theme.fonts.display};
+const SectionTitle = styled(HeadingTitle)`
   font-size: 20px;
-  margin-bottom: 16px;
 `;
 
 export default function MethodologyModal({ trigger }) {

--- a/src/methodology-modal/MethodologyModal.js
+++ b/src/methodology-modal/MethodologyModal.js
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import { HeadingDescription, HeadingTitle } from "../heading";
+import Modal from "../modal";
+
+const MethodologyWrapper = styled.div``;
+const MethodologyHeader = styled.div`
+  margin-bottom: 48px;
+`;
+const MethodologyHeading = styled(HeadingTitle)``;
+
+const MethodologyDescription = styled(HeadingDescription)`
+  font-size: 16px;
+`;
+
+const MethodologyBody = styled.div``;
+
+const SectionTitle = styled.h1`
+  color: ${(props) => props.theme.colors.heading};
+  font: ${(props) => props.theme.fonts.display};
+  font-size: 20px;
+  margin-bottom: 16px;
+`;
+
+export default function MethodologyModal({ trigger }) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Modal trigger={trigger} open={modalOpen} setOpen={setModalOpen}>
+      <MethodologyWrapper>
+        <MethodologyHeader>
+          <MethodologyHeading>Methodology</MethodologyHeading>
+          <MethodologyDescription>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nec vel vel
+            nunc lacus diam varius varius enim risus. Sagittis, in risus sed sit
+            elementum volutpat amet turpis nisi.
+          </MethodologyDescription>
+        </MethodologyHeader>
+        <MethodologyBody>
+          <SectionTitle>Header</SectionTitle>
+          <MethodologyDescription>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nec vel vel
+            nunc lacus diam varius varius enim risus. Sagittis, in risus sed sit
+            elementum volutpat amet turpis nisi.
+          </MethodologyDescription>
+          <SectionTitle>Header</SectionTitle>
+          <MethodologyDescription>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nec vel vel
+            nunc lacus diam varius varius enim risus. Sagittis, in risus sed sit
+            elementum volutpat amet turpis nisi.
+          </MethodologyDescription>
+          <SectionTitle>Header</SectionTitle>
+          <MethodologyDescription>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nec vel vel
+            nunc lacus diam varius varius enim risus. Sagittis, in risus sed sit
+            elementum volutpat amet turpis nisi.
+          </MethodologyDescription>
+        </MethodologyBody>
+      </MethodologyWrapper>
+    </Modal>
+  );
+}
+
+MethodologyModal.propTypes = {
+  trigger: PropTypes.node.isRequired,
+};

--- a/src/methodology-modal/index.js
+++ b/src/methodology-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./MethodologyModal";

--- a/src/modal/Modal.js
+++ b/src/modal/Modal.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import ModalDialog from "./ModalDialog";
+
+const ModalWrapper = styled.div``;
+const TriggerWrapper = styled.div``;
+
+export default function Modal(props) {
+  const { trigger, open, setOpen, height, width, children } = props;
+
+  const closeModal = () => {
+    setOpen(false);
+  };
+
+  return (
+    <ModalWrapper>
+      <TriggerWrapper onClick={() => setOpen(true)}>{trigger}</TriggerWrapper>
+      <ModalDialog
+        open={open}
+        closeModal={closeModal}
+        height={height}
+        width={width}
+      >
+        {children}
+      </ModalDialog>
+    </ModalWrapper>
+  );
+}
+
+Modal.propTypes = {
+  trigger: PropTypes.node.isRequired,
+  open: PropTypes.bool.isRequired,
+  setOpen: PropTypes.func.isRequired,
+  height: PropTypes.string,
+  width: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+Modal.defaultProps = {
+  height: "auto",
+  width: "65vw",
+};

--- a/src/modal/ModalDialog.js
+++ b/src/modal/ModalDialog.js
@@ -47,6 +47,12 @@ export default function ModalDialog(props) {
   const { open, closeModal, height, width, children } = props;
   const smallScreen = useBreakpoint(false, ["mobile-", true]);
   const PADDING = smallScreen ? DEFAULT_PADDING / 4 : DEFAULT_PADDING;
+  // WARNING: On smaller screens we are explicitly setting the width of
+  // the modal to 90% and otherwise ignorning any value that is passed
+  // in. This could lead to confusing results in the case that a smaller
+  // width modal is actually desired on smaller screens. Mostly this was
+  // a hack to meet a launch deadline and some additional care should be
+  // taken to make this more robust.
   const WIDTH = smallScreen ? "90%" : width;
 
   const ref = useRef(null);

--- a/src/modal/ModalDialog.js
+++ b/src/modal/ModalDialog.js
@@ -1,0 +1,99 @@
+import React, { useRef } from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import useBreakpoint from "@w11r/use-breakpoint";
+
+import CloseModalSrc from "../assets/icons/closeModal.svg";
+
+const BackgroundAside = styled.aside`
+  align-items: center;
+  background-color: ${(props) => props.theme.colors.asideBackground};
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: ${(props) => props.theme.zIndex.modal};
+`;
+
+const ModalDialogWrapper = styled.div`
+  align-self: center;
+  background-color: ${(props) => props.theme.colors.background};
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  height: ${(props) => props.height};
+  max-height: 90vh;
+  max-width: 90wh;
+  overflow-y: auto;
+  padding: ${(props) => props.padding}px;
+  position: relative;
+  width: ${(props) => props.width};
+`;
+
+const CloseButtonImg = styled.img`
+  cursor: pointer;
+  height: 20px;
+  position: absolute;
+  right: ${(props) => props.position}px;
+  top: ${(props) => props.position}px;
+`;
+
+const DEFAULT_PADDING = 64;
+
+export default function ModalDialog(props) {
+  const { open, closeModal, height, width, children } = props;
+  const smallScreen = useBreakpoint(false, ["mobile-", true]);
+  const PADDING = smallScreen ? DEFAULT_PADDING / 4 : DEFAULT_PADDING;
+  const WIDTH = smallScreen ? "90%" : width;
+
+  const ref = useRef(null);
+
+  if (!open) return null;
+
+  const isOutsideModal = (event, element) =>
+    event.target instanceof HTMLElement &&
+    element &&
+    !element.contains(event.target);
+
+  const handleOnClick = (event) => {
+    event.stopPropagation();
+
+    if (isOutsideModal(event, ref.current) && closeModal) {
+      closeModal(event);
+    }
+  };
+
+  return ReactDOM.createPortal(
+    <BackgroundAside onClick={handleOnClick}>
+      <ModalDialogWrapper
+        ref={ref}
+        height={height}
+        width={WIDTH}
+        padding={PADDING}
+      >
+        {closeModal && (
+          <CloseButtonImg
+            onClick={closeModal}
+            src={CloseModalSrc}
+            alt="close button"
+            role="button"
+            position={PADDING}
+          />
+        )}
+        {children}
+      </ModalDialogWrapper>
+    </BackgroundAside>,
+    document.getElementById("root")
+  );
+}
+
+ModalDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  height: PropTypes.string.isRequired,
+  width: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/modal/index.js
+++ b/src/modal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Modal";


### PR DESCRIPTION
…wnloads

## Description of the change

This PR includes a modal component primitive and 2 implementations: 1). For the methodology modal and 2). For the Download Data modal.  The latter modal isn't used anywhere and isn't accessible, but I wanted to start with two modals to help ensure the base modal component was reasonably robust and capable of serving the different visual treatments each of these modal implementations called for in the mocks.

The base modal component has more or less been copied from the COVID project but has been simplified a bit by removing a few of its properties (i.e. Title, Description, etc.).  Instead, this base modal basically just provides a background aside, some basic close modal functionality, and an otherwise blank canvas for implementation modals to fill out.  This leads to more flexibility in individual modal design but does come with the risk of repetition if many of our future modals end up being similar in style.

**Mobile**

<img width="405" alt="Screen Shot 2020-07-31 at 2 10 37 PM" src="https://user-images.githubusercontent.com/25503/89065895-8029ac00-d33a-11ea-8ace-a8a24390f62d.png">

<img width="410" alt="Screen Shot 2020-07-31 at 2 10 28 PM" src="https://user-images.githubusercontent.com/25503/89065898-81f36f80-d33a-11ea-91a8-fadfcc6e3c2a.png">

**Desktop**

<img width="1166" alt="Screen Shot 2020-07-31 at 2 10 50 PM" src="https://user-images.githubusercontent.com/25503/89066008-b0714a80-d33a-11ea-9b57-46d2eaa96132.png">

<img width="1155" alt="Screen Shot 2020-07-31 at 2 10 59 PM" src="https://user-images.githubusercontent.com/25503/89066014-b2d3a480-d33a-11ea-90ea-05fdab794bf2.png">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #85 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
