### PR TITLE
Sentencing Page: Population Chart - Use Total Population Count

### DIFF
--- a/server/core/demo_data/sentence_type_by_district_by_demographics.json
+++ b/server/core/demo_data/sentence_type_by_district_by_demographics.json
@@ -1,117 +1,117 @@
-{"probation_count": 7511, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 6193, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 630, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1147, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 2324, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1262, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 1472, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1420, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 652, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 2027, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 2433, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 337, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 940, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 433, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 49, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 265, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 172, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 71, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 423, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 394, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 14, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 155, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 44, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 171, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 259, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 55, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 206, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 175, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 52, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 225, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 275, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 63, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 69, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 373, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 426, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 259, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 154, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 350, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 457, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 245, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 519, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 113, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 154, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 144, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 139, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 19, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 126, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 79, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 156, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 113, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 16, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 133, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 336, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 226, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 233, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 268, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 131, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 133, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 150, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 283, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 289, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 98, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 212, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 348, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 135, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 41, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 47, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 101, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 155, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 177, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 81, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 45, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 9, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 58, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 18, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 12, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 44, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 75, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 72, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 79, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 78, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 200, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 82, "state_code": "US_ND", "age_bucket": "<25"}
-{"probation_count": 253, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 102, "state_code": "US_ND", "age_bucket": "25-29"}
-{"probation_count": 51, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 198, "state_code": "US_ND", "age_bucket": "30-34"}
-{"probation_count": 169, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 163, "state_code": "US_ND", "age_bucket": "35-39"}
-{"probation_count": 11, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 19, "state_code": "US_ND", "age_bucket": "40<"}
-{"probation_count": 285, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 88, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 301, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 177, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 269, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 435, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 493, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 250, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 589, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 327, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 97, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 49, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 172, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 210, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 143, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 229, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 143, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 21, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 134, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 546, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 441, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 30, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 254, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 342, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 214, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 505, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 356, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 202, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 75, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 165, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 49, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 305, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 144, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 92, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 18, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 29, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 145, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 0, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 132, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 459, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 208, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 125, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 266, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 32, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 202, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 381, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 110, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 142, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 153, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 93, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 137, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 260, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 76, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 189, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 171, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 41, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 170, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 182, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 76, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 99, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 46, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 43, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 36, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 56, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 54, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 60, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 50, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 11, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 35, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 368, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 15, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 79, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 5, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 208, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 104, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 185, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 128, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 127, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 984, "district": "NORTHEAST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 822, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 614, "district": "NORTHEAST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 496, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 685, "district": "SOUTHEAST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 374, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 151, "district": "SOUTHEAST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 315, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 1345, "district": "SOUTH_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 614, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 280, "district": "SOUTH_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 726, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 91, "district": "SOUTHWEST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 246, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 500, "district": "SOUTHWEST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 242, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 249, "district": "EAST_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 335, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 890, "district": "EAST_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 604, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 155, "district": "NORTHEAST_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 39, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 610, "district": "NORTHEAST_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 591, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 122, "district": "NORTHWEST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 159, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 147, "district": "NORTHWEST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 62, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 369, "district": "NORTH_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 319, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 315, "district": "NORTH_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 245, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 349, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 1151, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 857, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 1613, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 2441, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 422, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 1373, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 1946, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 2491, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 1061, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 7034, "district": "ALL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 6034, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 477, "district": "ALL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 159, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 1598, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1318, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 836, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 689, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 1625, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1340, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 591, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 488, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 1139, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 939, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 765, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 630, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 269, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 221, "state_code": "US_ND", "age_bucket": "ALL"}
-{"probation_count": 684, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 564, "state_code": "US_ND", "age_bucket": "ALL"}
+{"probation_count": 7511, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 6193, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 11648}
+{"probation_count": 630, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1147, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 1510}
+{"probation_count": 2324, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1262, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 3048}
+{"probation_count": 1472, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1420, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 2458}
+{"probation_count": 652, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 2027, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 2277}
+{"probation_count": 2433, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 337, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 2354}
+{"probation_count": 940, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 433, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 1167}
+{"probation_count": 49, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 265, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 266}
+{"probation_count": 172, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 71, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 206}
+{"probation_count": 423, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 394, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 694}
+{"probation_count": 14, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 155, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 143}
+{"probation_count": 44, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 171, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 182}
+{"probation_count": 259, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 55, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 266}
+{"probation_count": 206, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 175, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 323}
+{"probation_count": 52, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 225, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 235}
+{"probation_count": 275, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 63, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 287}
+{"probation_count": 69, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 373, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 375}
+{"probation_count": 426, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 259, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 582}
+{"probation_count": 154, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 350, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 428}
+{"probation_count": 457, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 245, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 596}
+{"probation_count": 519, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 113, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 537}
+{"probation_count": 154, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 144, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 253}
+{"probation_count": 139, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 19, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 134}
+{"probation_count": 126, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 79, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 174}
+{"probation_count": 156, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 113, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 228}
+{"probation_count": 16, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 133, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 126}
+{"probation_count": 336, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 226, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 477}
+{"probation_count": 233, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 268, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 425}
+{"probation_count": 131, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 133, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 224}
+{"probation_count": 150, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 283, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 368}
+{"probation_count": 289, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 270}
+{"probation_count": 98, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 212, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 263}
+{"probation_count": 348, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 135, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 410}
+{"probation_count": 41, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 47, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 74}
+{"probation_count": 101, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 155, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 217}
+{"probation_count": 177, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 81, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 219}
+{"probation_count": 45, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 9, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 45}
+{"probation_count": 58, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 18, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 64}
+{"probation_count": 12, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 44, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 47}
+{"probation_count": 75, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 72, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 124}
+{"probation_count": 79, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 78, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 133}
+{"probation_count": 200, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 82, "state_code": "US_ND", "age_bucket": "<25", "total_population_count": 239}
+{"probation_count": 253, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 102, "state_code": "US_ND", "age_bucket": "25-29", "total_population_count": 301}
+{"probation_count": 51, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 198, "state_code": "US_ND", "age_bucket": "30-34", "total_population_count": 211}
+{"probation_count": 169, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 163, "state_code": "US_ND", "age_bucket": "35-39", "total_population_count": 282}
+{"probation_count": 11, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 19, "state_code": "US_ND", "age_bucket": "40<", "total_population_count": 25}
+{"probation_count": 285, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 88, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 317}
+{"probation_count": 301, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 177, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 406}
+{"probation_count": 269, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 435, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 598}
+{"probation_count": 493, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 443}
+{"probation_count": 250, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 589, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 713}
+{"probation_count": 327, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 97, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 360}
+{"probation_count": 49, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 172, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 187}
+{"probation_count": 210, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 143, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 300}
+{"probation_count": 229, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 143, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 316}
+{"probation_count": 21, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 134, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 131}
+{"probation_count": 546, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 441, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 838}
+{"probation_count": 30, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 254, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 241}
+{"probation_count": 342, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 214, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 472}
+{"probation_count": 505, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 356, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 731}
+{"probation_count": 202, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 75, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 235}
+{"probation_count": 165, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 49, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 181}
+{"probation_count": 305, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 144, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 381}
+{"probation_count": 92, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 18, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 93}
+{"probation_count": 29, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 145, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 147}
+{"probation_count": 0, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 132, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 112}
+{"probation_count": 459, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 208, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 566}
+{"probation_count": 125, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 266, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 332}
+{"probation_count": 32, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 202, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 198}
+{"probation_count": 381, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 110, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 417}
+{"probation_count": 142, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 153, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 250}
+{"probation_count": 93, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 137, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 195}
+{"probation_count": 260, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 76, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 285}
+{"probation_count": 189, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 171, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 306}
+{"probation_count": 41, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 170, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 179}
+{"probation_count": 182, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 76, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 219}
+{"probation_count": 99, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 46, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 123}
+{"probation_count": 43, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 36, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 67}
+{"probation_count": 56, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 54, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 93}
+{"probation_count": 60, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 50, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 93}
+{"probation_count": 11, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 35, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 39}
+{"probation_count": 368, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 15, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 325}
+{"probation_count": 79, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 29, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 91}
+{"probation_count": 5, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 208, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 181}
+{"probation_count": 104, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 185, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 245}
+{"probation_count": 128, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 127, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 216}
+{"probation_count": 984, "district": "NORTHEAST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 822, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1535}
+{"probation_count": 614, "district": "NORTHEAST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 496, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 943}
+{"probation_count": 685, "district": "SOUTHEAST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 374, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 900}
+{"probation_count": 151, "district": "SOUTHEAST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 315, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 396}
+{"probation_count": 1345, "district": "SOUTH_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 614, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1665}
+{"probation_count": 280, "district": "SOUTH_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 726, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 855}
+{"probation_count": 91, "district": "SOUTHWEST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 246, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 286}
+{"probation_count": 500, "district": "SOUTHWEST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 242, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 630}
+{"probation_count": 249, "district": "EAST_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 335, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 496}
+{"probation_count": 890, "district": "EAST_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 604, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1269}
+{"probation_count": 155, "district": "NORTHEAST_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 39, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 164}
+{"probation_count": 610, "district": "NORTHEAST_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 591, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1020}
+{"probation_count": 122, "district": "NORTHWEST", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 159, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 238}
+{"probation_count": 147, "district": "NORTHWEST", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 62, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 177}
+{"probation_count": 369, "district": "NORTH_CENTRAL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 319, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 584}
+{"probation_count": 315, "district": "NORTH_CENTRAL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 245, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 476}
+{"probation_count": 349, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "incarceration_count": 1151, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1275}
+{"probation_count": 857, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "BLACK", "incarceration_count": 1613, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 2099}
+{"probation_count": 2441, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "HISPANIC", "incarceration_count": 422, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 2433}
+{"probation_count": 1373, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "WHITE", "incarceration_count": 1946, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 2821}
+{"probation_count": 2491, "district": "ALL", "gender": "ALL", "race_or_ethnicity": "OTHER", "incarceration_count": 1061, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 3019}
+{"probation_count": 7034, "district": "ALL", "gender": "MALE", "race_or_ethnicity": "ALL", "incarceration_count": 6034, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 11107}
+{"probation_count": 477, "district": "ALL", "gender": "FEMALE", "race_or_ethnicity": "ALL", "incarceration_count": 159, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 540}
+{"probation_count": 1598, "district": "NORTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1318, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 2478}
+{"probation_count": 836, "district": "SOUTHEAST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 689, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1296}
+{"probation_count": 1625, "district": "SOUTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 1340, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 2520}
+{"probation_count": 591, "district": "SOUTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 488, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 917}
+{"probation_count": 1139, "district": "EAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 939, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1766}
+{"probation_count": 765, "district": "NORTHEAST_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 630, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1185}
+{"probation_count": 269, "district": "NORTHWEST", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 221, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 416}
+{"probation_count": 684, "district": "NORTH_CENTRAL", "gender": "ALL", "race_or_ethnicity": "ALL", "incarceration_count": 564, "state_code": "US_ND", "age_bucket": "ALL", "total_population_count": 1060}

--- a/src/viz-sentence-population/VizSentencePopulation.js
+++ b/src/viz-sentence-population/VizSentencePopulation.js
@@ -11,7 +11,7 @@ export default function VizSentencePopulation(props) {
   } = props;
 
   const populationAccessorFn = (record) =>
-    Number(record.incarceration_count) + Number(record.probation_count);
+    Number(record.total_population_count);
 
   return (
     <PopulationViz


### PR DESCRIPTION
## Description of the change

The Population visualization on the Sentencing Page now expects to access its population count data from a field called `total_population_count` instead of adding up the `probation_count` and `incarceration_count` fields.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #100 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
