### PR TITLE
Remove Sentence Lengths from Sentencing Page

### DIFF
--- a/server/core/metricsApi.js
+++ b/server/core/metricsApi.js
@@ -71,7 +71,6 @@ const FILES_BY_METRIC_TYPE = {
   race: ["racial_disparities.json"],
   sentencing: [
     "judicial_districts.json",
-    "sentence_lengths_by_district_by_demographics.json",
     "sentence_type_by_district_by_demographics.json",
   ],
 };

--- a/src/page-sentencing/PageSentencing.js
+++ b/src/page-sentencing/PageSentencing.js
@@ -2,7 +2,6 @@ import React from "react";
 import DetailPage from "../detail-page";
 import useChartData from "../hooks/useChartData";
 import Loading from "../loading";
-import VizSentenceLengths from "../viz-sentence-lengths";
 import VizSentencePopulation from "../viz-sentence-population";
 import VizSentenceTypes from "../viz-sentence-types";
 
@@ -35,7 +34,6 @@ export default function PageSentencing() {
         locations: apiData.judicial_districts,
       },
     },
-
     {
       title: "What types of sentences do people receive?",
       description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -48,21 +46,6 @@ export default function PageSentencing() {
       VizComponent: VizSentenceTypes,
       vizData: {
         sentenceTypes: apiData.sentence_type_by_district_by_demographics,
-        locations: apiData.judicial_districts,
-      },
-    },
-    {
-      title: "How long do they serve?",
-      description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    Vestibulum in finibus tellus, et ullamcorper augue. Quisque eleifend
-    tortor vitae iaculis egestas. Donec dictum, nunc nec tincidunt cursus,
-    ipsum dui gravida.`,
-      showDimensionControl: true,
-      showLocationControl: true,
-      locationControlLabel: "Judicial District",
-      VizComponent: VizSentenceLengths,
-      vizData: {
-        sentenceLengths: apiData.sentence_lengths_by_district_by_demographics,
         locations: apiData.judicial_districts,
       },
     },


### PR DESCRIPTION
## Description of the change

Removing the sentencing length `SECTION` element from the sentencing page and preventing the request for its data, but I've left the visualization component around as well as the original data file.

I don't have access to remove any of the data files from the server though.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #95 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
