### PR TITLE
Chrome layout and stickiness updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-measure": "^2.3.0",
     "react-scripts": "3.4.1",
     "react-simple-maps": "^2.1.2",
+    "react-sticky": "^6.0.3",
     "semiotic": "^1.20.5",
     "set-order": "^0.3.5",
     "styled-components": "^5.1.1",

--- a/src/assets/icons/recidiviz_logo.svg
+++ b/src/assets/icons/recidiviz_logo.svg
@@ -1,5 +1,4 @@
 <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>Recidiviz</title>  
-  <rect y="13" width="13" height="13" fill="#4693BE"/>
-  <rect x="12" width="14" height="14" rx="7" fill="#C53B3E"/>
+<rect y="13" width="13" height="13" fill="#087482"/>
+<rect x="12.0001" width="14" height="14" rx="7" fill="#D34727"/>
 </svg>

--- a/src/branding-bar/BrandingBar.js
+++ b/src/branding-bar/BrandingBar.js
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import useBreakpoint from "@w11r/use-breakpoint";
+import useBreakpoint, { mediaQuery } from "@w11r/use-breakpoint";
 import React from "react";
 import useCollapse from "react-collapsed";
 import styled, { css } from "styled-components";
@@ -7,7 +7,12 @@ import MenuClosedIconSrc from "../assets/icons/menuClosed.svg";
 import MenuOpenIconSrc from "../assets/icons/menuOpen.svg";
 import ExternalLinkSrc from "../assets/icons/externalLink.svg";
 import LogoIconSrc from "../assets/icons/recidiviz_logo.svg";
-import { FIXED_HEADER_HEIGHT, X_PADDING } from "../constants";
+import {
+  COLLAPSIBLE_NAV_BREAKPOINT,
+  CONTAINER_WIDTH,
+  THEME,
+  X_PADDING,
+} from "../constants";
 import NavBar from "../nav-bar";
 import { LinkPill } from "../pill";
 import MethodologyModal from "../methodology-modal";
@@ -22,31 +27,43 @@ const ICON_SIZE = "26px";
 const Y_MARGIN = "12px";
 
 const BrandingBarWrapper = styled.header`
-  align-items: flex-start;
-  background: "transparent";
+  align-items: center;
   display: flex;
   flex-wrap: wrap;
+  height: ${(props) => props.theme.headerHeight}px;
   justify-content: space-between;
-  z-index: ${(props) => props.theme.zIndex.header};
+  margin: 0 auto;
+  max-width: ${CONTAINER_WIDTH}px;
+  padding: 0 ${X_PADDING}px;
+  width: 100%;
 
-  &.fixed {
-    background: ${(props) => props.theme.colors.background};
-    left: 0;
-    height: ${(props) =>
-      props.expanded ? "auto" : `${FIXED_HEADER_HEIGHT}px`};
-    padding: 0 ${X_PADDING}px;
-    position: fixed;
-    right: 0;
-    top: 0;
-  }
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `
+      height: ${THEME.headerHeightSmall}px;
+
+      &.expanded {
+        height: auto;
+      }
+    `,
+  ])}
 `;
 
 const BrandingBarHeader = styled.div`
   ${brandingBarFlexProperties}
-
-  ${(props) => (props.collapsible ? "align-items: center;" : "")}
-  margin-top: ${(props) => (props.expanded ? `${FIXED_HEADER_HEIGHT}px` : 0)};
+  margin-top: 0;
   transition: all ${(props) => props.theme.transition.defaultTimeSettings};
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `
+      align-items: center;
+
+      ${BrandingBarWrapper}.expanded & {
+        margin-top: ${THEME.headerHeightSmall}px;
+      }
+    `,
+  ])}
 `;
 
 const Icon = styled.img`
@@ -67,22 +84,39 @@ const Logo = styled(Icon)`
 const BrandingBarTitle = styled.h1`
   color: ${(props) => props.theme.colors.heading};
   font: ${(props) => props.theme.fonts.display};
-  font-size: ${(props) =>
-    props.small
-      ? props.theme.fonts.brandSizeSmall
-      : props.theme.fonts.brandSizeLarge};
+  font-size: ${(props) => props.theme.fonts.brandSizeLarge};
   display: inline-block;
   margin-left: 16px;
-  opacity: ${(props) => (props.hide ? 0 : 1)};
   transition: all ${(props) => props.theme.transition.defaultTimeSettings};
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `
+      font-size: ${THEME.fonts.brandSizeSmall};
+      opacity: 0;
+
+      ${BrandingBarWrapper}.expanded & {
+        opacity: 1;
+      }
+    `,
+  ])}
 `;
 
 const BrandingBarLinkListWrapper = styled.div`
   align-items: center;
   display: flex;
-  margin-top: ${(props) => (props.collapsible ? "16px" : Y_MARGIN)};
-  order: ${(props) => (props.collapsible ? 2 : 0)};
-  width: ${(props) => (props.collapsible ? "100%" : "auto")};
+  margin-top: ${Y_MARGIN};
+  order: 0;
+  width: auto;
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `
+      margin-top: 16px;
+      order: 2;
+      width: 100%;
+    `,
+  ])}
 `;
 
 const BrandingBarLinkList = styled.ul`
@@ -104,12 +138,14 @@ const BrandingBarLink = styled.li`
 const MenuButton = styled.button`
   background: none;
   border: none;
-  margin: ${Y_MARGIN} 0;
+  position: fixed;
+  top: ${Y_MARGIN};
+  right: 0;
 `;
 
 const CollapsibleMenuWrapper = styled.div`
   background: ${(props) => props.theme.colors.background};
-  height: calc(100vh - ${FIXED_HEADER_HEIGHT}px);
+  height: calc(100vh - ${(props) => props.theme.headerHeightSmall}px);
   order: 3;
   width: 100%;
 `;
@@ -121,7 +157,10 @@ const NavBarWrapper = styled.div`
 const SITE_TITLE = "North Dakota Corrections";
 
 export default function BrandingBar() {
-  const useCollapsibleNav = useBreakpoint(false, ["mobile-", true]);
+  const useCollapsibleNav = useBreakpoint(false, [
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    true,
+  ]);
   const {
     getCollapseProps,
     getToggleProps,
@@ -131,23 +170,16 @@ export default function BrandingBar() {
 
   return (
     <BrandingBarWrapper
-      className={classNames({ fixed: useCollapsibleNav })}
-      expanded={useCollapsibleNav && isExpanded}
+      className={classNames({
+        expanded: isExpanded,
+      })}
     >
-      <BrandingBarHeader
-        collapsible={useCollapsibleNav}
-        expanded={useCollapsibleNav && isExpanded}
-      >
+      <BrandingBarHeader>
         <Logo alt="Recidiviz" src={LogoIconSrc} />
-        <BrandingBarTitle
-          hide={useCollapsibleNav && !isExpanded}
-          small={useCollapsibleNav}
-        >
-          {SITE_TITLE}
-        </BrandingBarTitle>
+        <BrandingBarTitle>{SITE_TITLE}</BrandingBarTitle>
       </BrandingBarHeader>
       {(!useCollapsibleNav || isExpanded) && (
-        <BrandingBarLinkListWrapper collapsible={useCollapsibleNav}>
+        <BrandingBarLinkListWrapper>
           <BrandingBarLinkList>
             <BrandingBarLink>
               <LinkPill
@@ -169,11 +201,7 @@ export default function BrandingBar() {
       {useCollapsibleNav && (
         <>
           <MenuButton {...getToggleProps()}>
-            {isExpanded ? (
-              <Icon src={MenuOpenIconSrc} />
-            ) : (
-              <Icon src={MenuClosedIconSrc} />
-            )}
+            <Icon src={isExpanded ? MenuOpenIconSrc : MenuClosedIconSrc} />
           </MenuButton>
           <CollapsibleMenuWrapper {...getCollapseProps()}>
             <NavBarWrapper>

--- a/src/branding-bar/BrandingBar.js
+++ b/src/branding-bar/BrandingBar.js
@@ -18,7 +18,7 @@ import { LinkPill } from "../pill";
 import MethodologyModal from "../methodology-modal";
 
 const brandingBarFlexProperties = css`
-  align-items: baseline;
+  align-items: center;
   display: flex;
 `;
 
@@ -81,24 +81,43 @@ const Logo = styled(Icon)`
   margin: ${Y_MARGIN} 0;
 `;
 
-const BrandingBarTitle = styled.h1`
-  color: ${(props) => props.theme.colors.heading};
-  font: ${(props) => props.theme.fonts.display};
-  font-size: ${(props) => props.theme.fonts.brandSizeLarge};
+const BrandingBarTitleWrapper = styled.div`
   display: inline-block;
   margin-left: 16px;
   transition: all ${(props) => props.theme.transition.defaultTimeSettings};
-
   ${mediaQuery([
     COLLAPSIBLE_NAV_BREAKPOINT,
     `
-      font-size: ${THEME.fonts.brandSizeSmall};
       opacity: 0;
 
       ${BrandingBarWrapper}.expanded & {
         opacity: 1;
       }
     `,
+  ])}
+`;
+
+const BrandingBarTitle = styled.h1`
+  color: ${(props) => props.theme.colors.heading};
+  font: ${(props) => props.theme.fonts.display};
+  font-size: ${(props) => props.theme.fonts.brandSizeLarge};
+  margin-bottom: 0;
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `font-size: ${THEME.fonts.brandSizeSmall};`,
+  ])}
+`;
+
+const BrandingBarSubtitle = styled.h2`
+  color: ${(props) => props.theme.colors.body};
+  font: ${(props) => props.theme.fonts.body};
+  font-size: ${(props) => props.theme.fonts.brandSubtitleSize};
+  margin: 0;
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `font-size: ${THEME.fonts.brandSubtitleSizeSmall};`,
   ])}
 `;
 
@@ -176,7 +195,12 @@ export default function BrandingBar() {
     >
       <BrandingBarHeader>
         <Logo alt="Recidiviz" src={LogoIconSrc} />
-        <BrandingBarTitle>{SITE_TITLE}</BrandingBarTitle>
+        <BrandingBarTitleWrapper>
+          <BrandingBarTitle>{SITE_TITLE}</BrandingBarTitle>
+          <BrandingBarSubtitle>
+            A Spotlight Dashboard by Recidiviz
+          </BrandingBarSubtitle>
+        </BrandingBarTitleWrapper>
       </BrandingBarHeader>
       {(!useCollapsibleNav || isExpanded) && (
         <BrandingBarLinkListWrapper>

--- a/src/color-legend/ColorLegend.js
+++ b/src/color-legend/ColorLegend.js
@@ -7,6 +7,7 @@ const ColorLegendWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   font: ${(props) => props.theme.fonts.body};
+  font-size: 12px;
 `;
 
 const ColorLegendItem = styled.div`

--- a/src/constants.js
+++ b/src/constants.js
@@ -334,6 +334,8 @@ export const defaultTheme = {
     displayNormal,
     brandSizeSmall: "14px",
     brandSizeLarge: "22px",
+    brandSubtitleSize: "14px",
+    brandSubtitleSizeSmall: "13px",
   },
   headerHeightSmall: 50,
   headerHeight: 112,

--- a/src/constants.js
+++ b/src/constants.js
@@ -206,7 +206,7 @@ export const CUSTOM_BREAKPOINTS = {
 export const COLLAPSIBLE_NAV_BREAKPOINT = "mobile-";
 
 const bodyFontFamily = "'Libre Franklin', sans-serif";
-export const BODY_FONT_SIZE = 12;
+export const BODY_FONT_SIZE = 16;
 const bodyLineHeight = 1.5;
 const bodyMedium = `500 ${BODY_FONT_SIZE}px/${bodyLineHeight} ${bodyFontFamily}`;
 const bodyBold = `600 ${BODY_FONT_SIZE}px/${bodyLineHeight} ${bodyFontFamily}`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -194,7 +194,6 @@ export const INCARCERATION_REASON_LABELS = {
 
 export const CONTAINER_WIDTH = 1144;
 export const X_PADDING = 8;
-export const FIXED_HEADER_HEIGHT = 50;
 
 // these are overrides to defaults in @w11r/use-breakpoint
 export const CUSTOM_BREAKPOINTS = {
@@ -203,6 +202,8 @@ export const CUSTOM_BREAKPOINTS = {
   desktop: [1024, 1279],
   xl: [1280, 10000],
 };
+
+export const COLLAPSIBLE_NAV_BREAKPOINT = "mobile-";
 
 const bodyFontFamily = "'Libre Franklin', sans-serif";
 export const BODY_FONT_SIZE = 12;
@@ -334,6 +335,8 @@ export const defaultTheme = {
     brandSizeSmall: "14px",
     brandSizeLarge: "22px",
   },
+  headerHeightSmall: 50,
+  headerHeight: 112,
   maps: {
     // these are style objects that we can pass directly to react-simple-maps
     default: {

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -1,13 +1,16 @@
-import useBreakpoint from "@w11r/use-breakpoint";
+import useBreakpoint, { mediaQuery } from "@w11r/use-breakpoint";
 import classNames from "classnames";
 import { ascending } from "d3-array";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
+import { StickyContainer, Sticky } from "react-sticky";
 import { exact, tail } from "set-order";
 import styled from "styled-components";
-import { OTHER_LABEL, TOTAL_KEY } from "../constants";
+import { OTHER_LABEL, TOTAL_KEY, THEME } from "../constants";
 import { DimensionControl, MonthControl, LocationControl } from "../controls";
 import { HeadingTitle, HeadingDescription } from "../heading";
+
+const STICKY_CONTROLS_BREAKPOINT = "mobile-";
 
 const PageContainer = styled.article``;
 const HeadingContainer = styled.header``;
@@ -17,11 +20,15 @@ const SectionDivider = styled.hr`
   border-top: 1px solid ${(props) => props.theme.colors.divider};
 `;
 
-const DetailSectionContainer = styled.section`
+const DetailSectionContainer = styled.section``;
+
+const DetailSectionHeading = styled.header`
   align-items: center;
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
+  max-width: 100%;
+
+  ${mediaQuery([STICKY_CONTROLS_BREAKPOINT, `display: block;`])};
 `;
 
 const DetailSectionTitle = styled.h1`
@@ -31,6 +38,7 @@ const DetailSectionTitle = styled.h1`
   font-size: 20px;
   margin-bottom: 16px;
   margin-right: 32px;
+  max-width: 100%;
   width: ${(props) => props.theme.sectionTextWidthNormal}px;
 
   .wide-text & {
@@ -47,10 +55,7 @@ const DetailSectionControls = styled.div`
   max-width: 100%;
   padding-bottom: 16px;
 
-  &.sticky {
-    position: sticky;
-    top: ${(props) => props.theme.headerHeightSmall}px;
-    width: 100%;
+  &.is-sticky {
     z-index: ${(props) => props.theme.zIndex.control};
   }
 `;
@@ -114,39 +119,64 @@ function DetailSection({
   const [locationList] = useState(initialLocationList);
   const [locationId, setLocationId] = useState();
 
-  const sticky = useBreakpoint(false, ["mobile-", true]);
+  const enableStickyControls = useBreakpoint(false, ["mobile-", true]);
+
+  // TODO: this may change when we stack multiple sticky things
+  const stickyControlOffset = THEME.headerHeightSmall;
 
   return (
-    <DetailSectionContainer>
-      <DetailSectionTitle>{title}</DetailSectionTitle>
-      <DetailSectionControls className={classNames({ sticky })}>
-        {showMonthControl && monthList && (
-          <MonthControl months={monthList} onChange={setMonth} />
-        )}
-        {
-          // we need both a flag and data to enable location control
-          showLocationControl && locationList && (
-            <LocationControl
-              label={locationControlLabel}
-              locations={locationList}
-              onChange={setLocationId}
-              value={locationId}
-            />
-          )
-        }
-        {showDimensionControl && <DimensionControl onChange={setDimension} />}
-        {otherControls}
-      </DetailSectionControls>
+    <StickyContainer>
+      <DetailSectionContainer>
+        <DetailSectionHeading>
+          <DetailSectionTitle>{title}</DetailSectionTitle>
+          <Sticky disableCompensation={!enableStickyControls} bottomOffset={32}>
+            {({ style: stickyStyles, isSticky }) => (
+              <DetailSectionControls
+                className={classNames({
+                  "is-sticky": enableStickyControls && isSticky,
+                })}
+                style={
+                  enableStickyControls
+                    ? {
+                        ...stickyStyles,
+                        top: (stickyStyles.top || 0) + stickyControlOffset,
+                      }
+                    : undefined
+                }
+              >
+                {showMonthControl && monthList && (
+                  <MonthControl months={monthList} onChange={setMonth} />
+                )}
+                {
+                  // we need both a flag and data to enable location control
+                  showLocationControl && locationList && (
+                    <LocationControl
+                      label={locationControlLabel}
+                      locations={locationList}
+                      onChange={setLocationId}
+                      value={locationId}
+                    />
+                  )
+                }
+                {showDimensionControl && (
+                  <DimensionControl onChange={setDimension} />
+                )}
+                {otherControls}
+              </DetailSectionControls>
+            )}
+          </Sticky>
+        </DetailSectionHeading>
 
-      <DetailSectionDescription>{description}</DetailSectionDescription>
-      <DetailSectionVizContainer>
-        <VizComponent
-          data={vizData}
-          {...{ dimension, month, locationId, setMonthList }}
-          onLocationClick={setLocationId}
-        />
-      </DetailSectionVizContainer>
-    </DetailSectionContainer>
+        <DetailSectionDescription>{description}</DetailSectionDescription>
+        <DetailSectionVizContainer>
+          <VizComponent
+            data={vizData}
+            {...{ dimension, month, locationId, setMonthList }}
+            onLocationClick={setLocationId}
+          />
+        </DetailSectionVizContainer>
+      </DetailSectionContainer>
+    </StickyContainer>
   );
 }
 

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { exact, tail } from "set-order";
 import styled from "styled-components";
-import { FIXED_HEADER_HEIGHT, OTHER_LABEL, TOTAL_KEY } from "../constants";
+import { OTHER_LABEL, TOTAL_KEY } from "../constants";
 import { DimensionControl, MonthControl, LocationControl } from "../controls";
 import { HeadingTitle, HeadingDescription } from "../heading";
 
@@ -49,7 +49,7 @@ const DetailSectionControls = styled.div`
 
   &.sticky {
     position: sticky;
-    top: ${FIXED_HEADER_HEIGHT}px;
+    top: ${(props) => props.theme.headerHeightSmall}px;
     width: 100%;
     z-index: ${(props) => props.theme.zIndex.control};
   }

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -44,11 +44,6 @@ const DetailSectionTitle = styled.h1`
   margin-bottom: 16px;
   margin-right: 32px;
   max-width: 100%;
-  width: ${(props) => props.theme.sectionTextWidthNormal}px;
-
-  .wide-text & {
-    width: ${(props) => props.theme.sectionTextWidthWide}px;
-  }
 `;
 
 const DetailSectionControls = styled.div`
@@ -90,6 +85,8 @@ const PageControlsWrapper = styled.div`
   justify-content: flex-end;
   padding-bottom: 8px;
   z-index: ${(props) => props.theme.zIndex.menu + 10};
+
+  ${mediaQuery([STICKY_CONTROLS_BREAKPOINT, `justify-content: flex-start;`])};
 `;
 
 const sortLocations = exact([tail(OTHER_LABEL)], ascending);

--- a/src/nav-bar/NavBar.js
+++ b/src/nav-bar/NavBar.js
@@ -23,7 +23,7 @@ const NavItem = styled.li``;
 
 const NavList = styled.ul`
   font: ${(props) => props.theme.fonts.body};
-  font-size: 11px;
+  font-size: 15px;
   font-weight: 600;
   line-height: 2;
   list-style: none;

--- a/src/page-routes/PageRoutes.js
+++ b/src/page-routes/PageRoutes.js
@@ -1,6 +1,5 @@
-import { Router, Redirect } from "@reach/router";
-import React from "react";
-
+import { Router, Redirect, useLocation } from "@reach/router";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { PATHS } from "../constants";
 import PageOverview from "../page-overview";
@@ -13,6 +12,14 @@ import PageRacialDisparities from "../page-racial-disparities/PageRacialDisparit
 const PagesContainer = styled.main``;
 
 export default function PageRoutes() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // hacky nonsense to make the page scroll to the top after navigation,
+    // per https://github.com/reach/router/issues/198
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+
   return (
     <PagesContainer>
       <Router>

--- a/src/population-viz/PopulationViz.js
+++ b/src/population-viz/PopulationViz.js
@@ -59,6 +59,7 @@ const MapWrapper = styled.figure`
 const MapCaption = styled.figcaption`
   color: ${(props) => props.theme.colors.body};
   font: ${(props) => props.theme.fonts.body};
+  font-size: 12px;
 `;
 
 const DemographicsWrapper = styled.div`

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -39,6 +39,7 @@ const ProportionalBarTitle = styled.div`
   color: ${(props) => props.theme.colors.body};
   flex: 0 1 auto;
   font: ${(props) => props.theme.fonts.body};
+  font-size: 12px;
   margin-right: 15px;
 `;
 

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -18,7 +18,7 @@ import BackgroundImageSrc from "../assets/images/background.png";
 import SecondaryNav from "../secondary-nav";
 import InfoPanel from "../info-panel";
 
-const NAV_WIDTH = 150;
+const NAV_WIDTH = 240;
 
 const BRANDING_BAR_MARGIN = 16;
 

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -5,9 +5,10 @@ import styled, { css } from "styled-components";
 import { useMatch } from "@reach/router";
 import BrandingBar from "../branding-bar";
 import {
+  COLLAPSIBLE_NAV_BREAKPOINT,
   CONTAINER_WIDTH,
-  FIXED_HEADER_HEIGHT,
   PATHS,
+  THEME,
   X_PADDING,
 } from "../constants";
 import Footer from "../footer";
@@ -19,41 +20,45 @@ import InfoPanel from "../info-panel";
 
 const NAV_WIDTH = 150;
 
+const BRANDING_BAR_MARGIN = 16;
+
 const SiteContainer = styled.div`
   ${(props) =>
     props.showBackground &&
     css`
       background-image: url(${BackgroundImageSrc});
       background-size: cover;
-      ${mediaQuery(["mobile-", "background-size: contain;"])}
       background-repeat: no-repeat;
     `}
-
+  padding-top: ${(props) => props.theme.headerHeight + BRANDING_BAR_MARGIN}px;
   width: 100%;
+
+  ${mediaQuery([
+    COLLAPSIBLE_NAV_BREAKPOINT,
+    `padding-top: ${THEME.headerHeightSmall + BRANDING_BAR_MARGIN}px;`,
+  ])}
 `;
 
 const BodyWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
   margin: 0 auto;
   max-width: ${CONTAINER_WIDTH}px;
-  padding: 0 ${X_PADDING}px;
+
+  ${mediaQuery([COLLAPSIBLE_NAV_BREAKPOINT, `padding: 0 ${X_PADDING}px;`])}
 `;
 
 const BrandingBarWrapper = styled.div`
-  flex: 0 0 auto;
-  margin-bottom: 64px;
-  min-height: ${FIXED_HEADER_HEIGHT}px;
-  width: 100%;
-
-  ${mediaQuery(["mobile-", "margin-bottom: 16px;"])}
+  background: ${(props) => props.theme.colors.background};
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: ${(props) => props.theme.zIndex.header};
 `;
 
 const NavBarWrapper = styled.div`
-  /* on small screens this will grow to fill an entire row  */
-  flex: 1 0 auto;
+  position: fixed;
   width: ${NAV_WIDTH}px;
+  z-index: ${(props) => props.theme.zIndex.base};
 `;
 
 const SecondaryNavWrapper = styled.div`
@@ -62,12 +67,10 @@ const SecondaryNavWrapper = styled.div`
 `;
 
 const MainContentWrapper = styled.div`
-  /*
-    flex-grow is mega large because we want this component to take up
-    all available space when it shares a row with NavBarWrapper
-  */
-  flex: 2000 0 auto;
-  width: 320px;
+  padding-left: ${NAV_WIDTH}px;
+  width: 100%;
+
+  ${mediaQuery([COLLAPSIBLE_NAV_BREAKPOINT, `padding-left: 0;`])}
 `;
 
 const FooterWrapper = styled.div`
@@ -77,7 +80,7 @@ const FooterWrapper = styled.div`
 `;
 
 function SiteLayout({ tenantId }) {
-  const showNav = useBreakpoint(false, ["tablet+", true]);
+  const showNav = useBreakpoint(true, [COLLAPSIBLE_NAV_BREAKPOINT, false]);
   const onOverviewPage = useMatch(`/:tenantId/${PATHS.overview}`);
 
   return (

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -9,6 +9,7 @@ const TooltipWrapper = styled.div`
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
   color: ${(props) => props.theme.colors.bodyLight};
   font: ${(props) => props.theme.fonts.body};
+  font-size: 14px;
   padding: 16px;
   z-index: ${(props) => props.theme.zIndex.tooltip};
 

--- a/src/viz-prison-population/VizPrisonPopulation.js
+++ b/src/viz-prison-population/VizPrisonPopulation.js
@@ -30,7 +30,7 @@ export default function VizPrisonPopulation(props) {
       mapLabel="Prison facilities in North Dakota"
       locationAccessorFn={locationAccessorFn}
       populationAccessorFn={populationAccessorFn}
-      totalPopulationLabel="People on prison"
+      totalPopulationLabel="People in prison"
     />
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9993,7 +9993,7 @@ prop-types@15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10136,7 +10136,7 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-raf@^3.4.1:
+raf@^3.3.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -10384,6 +10384,14 @@ react-simple-maps@^2.1.2:
     d3-selection "^1.4.1"
     d3-zoom "^1.8.3"
     topojson-client "^3.0.0"
+
+react-sticky@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
+  integrity sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==
+  dependencies:
+    prop-types "^15.5.8"
+    raf "^3.3.0"
 
 react@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
## Description of the change

This is unfortunately kind of a grab bag of sometimes-related changes: 

- the branding bar and left-side navigation are always fixed on the screen
- page-level controls (e.g. the race picker on the race narrative page) stick to the top of the screen on all devices; on mobile, the section-level controls stick to the bottom of them when present
    - this feature exceeded the capabilities of our humble friend `position: sticky`, so I had to switch to a JS-based implementation; it's not quite as smooth but it gives us the necessary control to nest elements in a way that makes sense and stack multiple fixed elements at the top of the screen (branding bar + page control + section control)
- new title and logo in the branding bar
- increased type sizes for navigation, body, and tooltips

Co-branding was originally part of this PR but it was already getting bloated so I have kicked it to #105 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #86 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
