### PR TITLE
Fix label placement in sentence types chart

### DIFF
--- a/src/sentence-types-chart/SentenceTypesChart.js
+++ b/src/sentence-types-chart/SentenceTypesChart.js
@@ -39,7 +39,8 @@ const SourceLabel = styled.text`
   font-size: ${SOURCE_LABEL_SIZE}px;
   transform: ${sourceLabelXOffsetTransform}
     translateY(
-      -${(props) => props.yOffset - SOURCE_VALUE_SIZE - SOURCE_LABEL_SIZE - 8}px
+      ${(props) =>
+        -(props.yOffset - SOURCE_VALUE_SIZE - SOURCE_LABEL_SIZE - 8)}px
     );
 `;
 

--- a/src/sentence-types-chart/SentenceTypesChart.js
+++ b/src/sentence-types-chart/SentenceTypesChart.js
@@ -28,7 +28,7 @@ const SourceValue = styled.text`
   font-size: ${SOURCE_VALUE_SIZE}px;
   letter-spacing: -0.09em;
   transform: ${sourceLabelXOffsetTransform}
-    translateY(-${(props) => props.yOffset - SOURCE_VALUE_SIZE}px);
+    translateY(${(props) => -(props.yOffset - SOURCE_VALUE_SIZE)}px);
 `;
 
 const SOURCE_LABEL_SIZE = 16;


### PR DESCRIPTION
## Description of the change

Improper negation of negative values could break the CSS for left-hand labels, causing it to be placed in the wrong location. This fixes that error (actually negating the `Number` rather than just putting a `-` in the output string!).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #97 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
