### PR TITLE
Use percentages on Y axis in prison term lengths charts

### DIFF
--- a/src/bar-chart-trellis/BarChartTrellis.js
+++ b/src/bar-chart-trellis/BarChartTrellis.js
@@ -2,9 +2,10 @@ import PropTypes from "prop-types";
 import React, { useState, useCallback } from "react";
 import { FacetController, OrdinalFrame } from "semiotic";
 import styled from "styled-components";
-import { SENTENCE_LENGTH_KEYS, SENTENCE_LENGTHS, THEME } from "../constants";
 import ChartWrapper from "../chart-wrapper";
+import { SENTENCE_LENGTH_KEYS, SENTENCE_LENGTHS, THEME } from "../constants";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
+import { getDataWithPct, formatAsPct } from "../utils";
 
 const CHART_HEIGHT = 360;
 const CHART_MIN_WIDTH = 320;
@@ -43,24 +44,30 @@ export default function BarChartTrellis({ data, width }) {
   }
 
   const axes = [
-    { baseline: false, orient: "left", tickLineGenerator: () => null },
+    {
+      baseline: false,
+      orient: "left",
+      tickFormat: formatAsPct,
+      tickLineGenerator: () => null,
+    },
   ];
 
   const renderTooltip = (columnData) => {
     const {
       summary: [d],
     } = columnData;
-
     return {
       title: selectedChartTitle || "",
       records: [
         {
-          label: `${d.column} year${
-            d.column === SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
+          label: `${d.data.label} year${
+            d.data.label ===
+            SENTENCE_LENGTHS.get(SENTENCE_LENGTH_KEYS.lessThanOne)
               ? ""
               : "s"
           }`,
-          value: d.value,
+          pct: d.data.pct,
+          value: d.data.value,
         },
       ],
     };
@@ -90,8 +97,7 @@ export default function BarChartTrellis({ data, width }) {
               return <ColumnLabel>{`${label}${postfix}`}</ColumnLabel>;
             }}
             oPadding={8}
-            rAccessor="value"
-            sharedRExtent
+            rAccessor="pct"
             size={[chartWidth, CHART_HEIGHT]}
             style={(d) => ({
               fill:
@@ -113,13 +119,14 @@ export default function BarChartTrellis({ data, width }) {
                   setSelectedChartTitle(title);
                   customHoverBehavior(d);
                 }}
-                data={chartData}
+                data={getDataWithPct(chartData)}
                 // using indices actually makes a better experience here;
                 // the charts animate in and out based on how many there are
                 // and we avoid bugs that happen when values change but the
                 // identifiers (i.e. titles) stay the same
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
+                rExtent={[0, 1]}
                 title={
                   <ChartTitle x={0 - chartWidth / 2 + MARGIN.left}>
                     {title}

--- a/src/viz-sentence-lengths/VizSentenceLengths.js
+++ b/src/viz-sentence-lengths/VizSentenceLengths.js
@@ -25,7 +25,7 @@ export default function VizSentenceLengths({
     data: [...SENTENCE_LENGTHS].map(([key, lengthLabel]) => ({
       color: THEME.colors.sentenceLengths[key],
       label: lengthLabel,
-      value: record ? record[key] : 0,
+      value: record ? Number(record[key]) : 0,
     })),
   }));
 


### PR DESCRIPTION
## Description of the change

This makes it easier to see the trends within each demographic category, since the raw numbers are distributed quite unevenly across categories. Includes the percentage in tooltips now as well as the raw number.

before: 
![Screenshot_2020-08-03 Recidiviz Public Dashboard](https://user-images.githubusercontent.com/5385319/89212837-0c291700-d579-11ea-96d6-8939d3705f87.png)

after:
![Screen Shot 2020-08-03 at 10 51 13 AM](https://user-images.githubusercontent.com/5385319/89212853-12b78e80-d579-11ea-9d03-802f442fc811.png)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #119 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
