### PR TITLE
Adds Segment integration to the app.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,14 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#000000" />
+
+    <script>
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var t=analytics.methods[e];analytics[t]=analytics.factory(t)}analytics.load=function(e,t){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+e+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=t};analytics.SNIPPET_VERSION="4.1.0";
+      analytics.load("DMgmUv5wXE2lEEtRaXRpzxCA8dK7BHBE");
+      analytics.page();
+      }}();
+    </script>
+
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/page-routes/PageRoutes.js
+++ b/src/page-routes/PageRoutes.js
@@ -20,6 +20,10 @@ export default function PageRoutes() {
     window.scrollTo(0, 0);
   }, [location.pathname]);
 
+  useEffect(() => {
+    window.analytics.page(location.pathname);
+  }, [location]);
+
   return (
     <PagesContainer>
       <Router>

--- a/src/page-routes/PageRoutes.js
+++ b/src/page-routes/PageRoutes.js
@@ -22,7 +22,7 @@ export default function PageRoutes() {
 
   useEffect(() => {
     window.analytics.page(location.pathname);
-  }, [location]);
+  }, [location.pathname]);
 
   return (
     <PagesContainer>


### PR DESCRIPTION
## Description of the change

@macfarlandian in testing this locally, I can see the page views getting sent up to Segment, but not in all cases. Specifically, when I click on the app's links in the sidebar or the bottom of the page to take me to one of the other views, it doesn't send up a new page view to Segment. Views are recorded only when either a) I visit the app fresh by typing in the URL (in which case it sends up a page view of /us_nd/overview) or b) I click in the URL bar in the browser and click enter to trigger a new page load (or just refresh the page for that matter). So if I go to the app but then click around to Parole, Probation, and Sentencing through the app's navigation, it only records a page view for Overview. Any idea why that might be the case?

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
