### PR TITLE
Fix tooltip stacking issues

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -11,6 +11,7 @@ const TooltipWrapper = styled.div`
   font: ${(props) => props.theme.fonts.body};
   font-size: 14px;
   padding: 16px;
+  position: relative;
   z-index: ${(props) => props.theme.zIndex.tooltip};
 
   .InfoPanel & {


### PR DESCRIPTION
## Description of the change

Z-index values weren't actually being applied to the Tooltip component in charts, which could cause other elements on the page to cover them up (legends, menu buttons).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues
Closes #122, closes #123 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
