### PR TITLE
New focused population chart for Racial Disparities

### DIFF
--- a/src/page-racial-disparities/PageRacialDisparities.js
+++ b/src/page-racial-disparities/PageRacialDisparities.js
@@ -33,8 +33,9 @@ const ETHNONYMS = {
 };
 
 const BodySizeP = styled.p`
+  color: ${(props) => props.theme.fonts.heading};
   font: ${(props) => props.theme.fonts.body};
-  max-width: ${(props) => props.theme.sectionTextWidth}px;
+  opacity: 0.7;
 `;
 
 const Footnote = styled.span`
@@ -44,6 +45,10 @@ const Footnote = styled.span`
 
 const FootnoteText = styled.p`
   font-size: 0.8em;
+`;
+
+const IntroVizWrapper = styled.div`
+  margin: 48px 0;
 `;
 
 const formatDecimal = (number) => number.toFixed(1);
@@ -278,6 +283,11 @@ export default function PageRacialDisparities() {
         </DynamicText>{" "}
         times.
       </p>
+      <IntroVizWrapper>
+        <VizPopulationDisparity
+          data={{ countsByRace: racialDisparityCounts }}
+        />
+      </IntroVizWrapper>
       <BodySizeP>
         Use the dropdown control on the right to investigate how a specific race
         is affected by each part of the system. Due to a very small number of
@@ -322,7 +332,6 @@ export default function PageRacialDisparities() {
       ),
       VizComponent: VizPopulationDisparity,
       vizData: {
-        category,
         countsByRace: racialDisparityCounts,
       },
     },

--- a/src/page-racial-disparities/PageRacialDisparities.js
+++ b/src/page-racial-disparities/PageRacialDisparities.js
@@ -22,6 +22,7 @@ import {
   getCorrectionsPopulationCurrent,
 } from "./helpers";
 import VizPopulationDisparity from "./VizPopulationDisparity";
+import VizPopulationFocus from "./VizPopulationFocus";
 import VizRevocationDisparity from "./VizRevocationDisparity";
 
 const ETHNONYMS = {
@@ -330,8 +331,9 @@ export default function PageRacialDisparities() {
           </FootnoteText>
         </>
       ),
-      VizComponent: VizPopulationDisparity,
+      VizComponent: VizPopulationFocus,
       vizData: {
+        category,
         countsByRace: racialDisparityCounts,
       },
     },

--- a/src/page-racial-disparities/VizPopulationDisparity.js
+++ b/src/page-racial-disparities/VizPopulationDisparity.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 import { DIMENSION_DATA_KEYS, RACE_LABELS, TOTAL_KEY } from "../constants";
-import Disclaimer from "../disclaimer";
 import ProportionalBar from "../proportional-bar";
 import { demographicsAscending } from "../utils";
 import { getCorrectionsPopulationCurrent, useBarHeight } from "./helpers";
@@ -23,18 +22,13 @@ const sortByRace = (a, b) =>
     b[DIMENSION_DATA_KEYS.race]
   );
 
-export default function VizPopulationDisparity({
-  data: { countsByRace, category },
-}) {
+export default function VizPopulationDisparity({ data: { countsByRace } }) {
   const filteredData = countsByRace.filter(notTotal).sort(sortByRace);
 
   const totalPopulationData = filteredData.map((record) => {
     const raceValue = record[DIMENSION_DATA_KEYS.race];
     return {
-      color:
-        raceValue === category
-          ? THEME.colors.highlight
-          : THEME.colors.race[raceValue],
+      color: THEME.colors.race[raceValue],
       label: RACE_LABELS.get(raceValue),
       value: record.total_state_population,
     };
@@ -43,10 +37,7 @@ export default function VizPopulationDisparity({
   const correctionsPopulationData = filteredData.map((record) => {
     const raceValue = record[DIMENSION_DATA_KEYS.race];
     return {
-      color:
-        raceValue === category
-          ? THEME.colors.highlight
-          : THEME.colors.race[raceValue],
+      color: THEME.colors.race[raceValue],
       label: RACE_LABELS.get(raceValue),
       value: getCorrectionsPopulationCurrent(record),
     };
@@ -72,14 +63,12 @@ export default function VizPopulationDisparity({
           showLegend
         />
       </BreakdownWrapper>
-      <Disclaimer type="small-data" />
     </Wrapper>
   );
 }
 
 VizPopulationDisparity.propTypes = {
   data: PropTypes.shape({
-    category: PropTypes.string.isRequired,
     countsByRace: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
 };

--- a/src/page-racial-disparities/VizPopulationDisparity.js
+++ b/src/page-racial-disparities/VizPopulationDisparity.js
@@ -4,16 +4,14 @@ import styled from "styled-components";
 import { DIMENSION_DATA_KEYS, RACE_LABELS, TOTAL_KEY } from "../constants";
 import ProportionalBar from "../proportional-bar";
 import { demographicsAscending } from "../utils";
-import { getCorrectionsPopulationCurrent, useBarHeight } from "./helpers";
+import {
+  BreakdownWrapper,
+  getCorrectionsPopulationCurrent,
+  useBarHeight,
+} from "./helpers";
 import { THEME } from "../theme";
 
 const Wrapper = styled.div``;
-
-const BreakdownWrapper = styled.div`
-  padding-bottom: 16px;
-  position: relative;
-  z-index: ${(props) => props.theme.zIndex.base + props.stackOrder};
-`;
 
 const notTotal = (record) => record[DIMENSION_DATA_KEYS.race] !== TOTAL_KEY;
 const sortByRace = (a, b) =>

--- a/src/page-racial-disparities/VizPopulationFocus.js
+++ b/src/page-racial-disparities/VizPopulationFocus.js
@@ -1,0 +1,85 @@
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+import { RACE_LABELS } from "../constants";
+import ProportionalBar from "../proportional-bar";
+import { recordIsAllRaces } from "../utils";
+import {
+  BreakdownWrapper,
+  getCorrectionsPopulationCurrent,
+  matchRace,
+  useBarHeight,
+} from "./helpers";
+import { THEME } from "../theme";
+
+const Wrapper = styled.div``;
+
+export default function VizPopulationFocus({
+  data: { category, countsByRace },
+}) {
+  const recordForCategory = countsByRace.find(matchRace(category));
+  const recordForTotals = countsByRace.find(recordIsAllRaces);
+
+  const categoryColor = THEME.colors.racialDisparities.selected;
+  const otherColor = THEME.colors.racialDisparities.remainder;
+
+  const totalPopulationData = [
+    {
+      color: categoryColor,
+      label: RACE_LABELS.get(category),
+      value: recordForCategory.total_state_population,
+    },
+    {
+      color: otherColor,
+      label: "All other racial/ethnic groups",
+      value:
+        recordForTotals.total_state_population -
+        recordForCategory.total_state_population,
+    },
+  ];
+
+  const correctionsPopulationData = [
+    {
+      color: categoryColor,
+      label: RACE_LABELS.get(category),
+      value: getCorrectionsPopulationCurrent(recordForCategory),
+    },
+    {
+      color: otherColor,
+      label: "All other racial/ethnic groups",
+      value:
+        getCorrectionsPopulationCurrent(recordForTotals) -
+        getCorrectionsPopulationCurrent(recordForCategory),
+    },
+  ];
+
+  const barHeight = useBarHeight();
+
+  return (
+    <Wrapper>
+      <BreakdownWrapper stackOrder={1}>
+        <ProportionalBar
+          data={totalPopulationData}
+          height={barHeight}
+          title="Proportions of total state population"
+          showLegend={false}
+        />
+      </BreakdownWrapper>
+      <BreakdownWrapper stackOrder={0}>
+        <ProportionalBar
+          data={correctionsPopulationData}
+          height={barHeight}
+          title="Proportions of people sentenced and under DOCR control"
+          showLegend
+        />
+      </BreakdownWrapper>
+    </Wrapper>
+  );
+}
+
+VizPopulationFocus.propTypes = {
+  data: PropTypes.shape({
+    category: PropTypes.string.isRequired,
+    countsByRace: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+};

--- a/src/page-racial-disparities/VizRevocationDisparity.js
+++ b/src/page-racial-disparities/VizRevocationDisparity.js
@@ -6,6 +6,7 @@ import { TOTAL_KEY, VIOLATION_LABELS } from "../constants";
 import Disclaimer from "../disclaimer";
 import ProportionalBar from "../proportional-bar";
 import {
+  BreakdownWrapper,
   DynamicText,
   getSupervisionCounts36Mo,
   matchRace,
@@ -14,12 +15,6 @@ import {
 import { THEME } from "../theme";
 
 const Wrapper = styled.div``;
-
-const BreakdownWrapper = styled.div`
-  padding-bottom: 16px;
-  position: relative;
-  z-index: ${(props) => props.theme.zIndex.base + props.stackOrder};
-`;
 
 export default function VizRevocationDisparity({
   data: { countsByRace, category, ethnonym, supervisionType },

--- a/src/page-racial-disparities/helpers.js
+++ b/src/page-racial-disparities/helpers.js
@@ -84,3 +84,9 @@ const BAR_HEIGHTS = { default: 150, small: 70 };
 export function useBarHeight() {
   return useBreakpoint(BAR_HEIGHTS.default, ["mobile-", BAR_HEIGHTS.small]);
 }
+
+export const BreakdownWrapper = styled.div`
+  padding-bottom: 16px;
+  position: relative;
+  z-index: ${(props) => props.theme.zIndex.base + props.stackOrder};
+`;

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -107,6 +107,10 @@ export const defaultTheme = {
     noData: "#EFEDEC",
     programParticipation: black,
     race: assignDataVizColors(Array.from(RACE_LABELS.keys())),
+    racialDisparities: {
+      selected: brightGreen,
+      remainder: dataVizColorMap.get("paleBlue"),
+    },
     releaseTypes: assignDataVizColors(Array.from(RELEASE_TYPE_KEYS.keys())),
     sentenceLengths: dataVizColorMap.get("paleBlue"),
     sentencing: {
@@ -170,6 +174,9 @@ const northDakotaTheme = {
     map: {
       fillHover: ndColors.brandOrangeTint1,
       fillActive: ndColors.brandOrange,
+    },
+    racialDisparities: {
+      selected: ndColors.brandOrange,
     },
     sliderThumb: ndColors.brandTeal,
   },


### PR DESCRIPTION
## Description of the change

Takes the existing "population disparity" chart, which shows the full racial/ethnic breakdown, and moves it to the introduction. In its former place (in the first section with dynamic text that is focused on a single group) we add a new "focused" chart that displays basically the same data but specifically highlights the selected group as a proportion of the whole rather than showing all individual groups.

![Screenshot_2020-08-07 Racial Disparities North Dakota Corrections and Rehabilitation Dashboard](https://user-images.githubusercontent.com/5385319/89678018-4d843400-d8a3-11ea-8229-272be3cdea46.png)

This addresses the issue we had with the "highlight color" not standing out enough against our new multi-hue dataviz color palette, while also reinforcing the narrative of the page with additional visual aids.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #158 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
