### PR TITLE
Fix IE 11 display bugs

### DIFF
--- a/src/aspect-ratio-wrapper/AspectRatioWrapper.js
+++ b/src/aspect-ratio-wrapper/AspectRatioWrapper.js
@@ -1,0 +1,35 @@
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+
+// implements a version of the Aspect Ratio Box technique described here:
+// https://github.com/zcreativelabs/react-simple-maps/issues/37#issuecomment-349435145
+// but with explicit width (our flex layout prefers it or elements may collapse)
+const RatioContainerOuter = styled.div`
+  position: relative;
+  height: 0;
+  padding-bottom: calc(${(props) => props.aspectRatio} * 100%);
+  width: ${(props) => props.width}px;
+`;
+
+const RatioContainerInner = styled.div({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
+export default function AspectRatioWrapper({ aspectRatio, children, width }) {
+  return (
+    <RatioContainerOuter width={width} aspectRatio={aspectRatio}>
+      <RatioContainerInner>{children}</RatioContainerInner>
+    </RatioContainerOuter>
+  );
+}
+
+AspectRatioWrapper.propTypes = {
+  aspectRatio: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired,
+  width: PropTypes.number.isRequired,
+};

--- a/src/aspect-ratio-wrapper/index.js
+++ b/src/aspect-ratio-wrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AspectRatioWrapper";

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -19,9 +19,9 @@ const FooterContent = styled(PageWidthContainer)`
   align-items: center;
   display: flex;
   flex-wrap: wrap;
+  height: 320px;
   justify-content: space-between;
   margin: 0 auto;
-  min-height: 320px;
 `;
 
 const FooterCredits = styled.div`

--- a/src/sentence-types-chart/SentenceTypesChart.js
+++ b/src/sentence-types-chart/SentenceTypesChart.js
@@ -22,9 +22,7 @@ const ChartWrapper = styled.div`
   width: ${(props) => props.width}px;
 `;
 
-const sourceLabelXOffsetTransform = `translateX(-${
-  MARGIN.left + NODE_WIDTH / 2
-}px)`;
+const SOURCE_LABEL_X_OFFSET = `-${MARGIN.left + NODE_WIDTH / 2}`;
 
 const SOURCE_VALUE_SIZE = 48;
 
@@ -33,19 +31,12 @@ const SourceValue = styled.text`
   font: ${(props) => props.theme.fonts.displayMedium};
   font-size: ${SOURCE_VALUE_SIZE}px;
   letter-spacing: -0.09em;
-  transform: ${sourceLabelXOffsetTransform}
-    translateY(${(props) => -(props.yOffset - SOURCE_VALUE_SIZE)}px);
 `;
 
 const SOURCE_LABEL_SIZE = 16;
 
 const SourceLabel = styled.text`
   font-size: ${SOURCE_LABEL_SIZE}px;
-  transform: ${sourceLabelXOffsetTransform}
-    translateY(
-      ${(props) =>
-        -(props.yOffset - SOURCE_VALUE_SIZE - SOURCE_LABEL_SIZE - 8)}px
-    );
 `;
 
 const TARGET_LABEL_PADDING = 8;
@@ -53,9 +44,25 @@ const TargetLabel = styled.text`
   dominant-baseline: middle;
   font-size: 16px;
   text-anchor: start;
-  transform: translateX(${NODE_WIDTH / 2 + TARGET_LABEL_PADDING}px);
   width: ${MARGIN.right - TARGET_LABEL_PADDING}px;
 `;
+
+// because IE does not support CSS transforms on SVG elements (#182),
+// we need to render label translations as SVG attributes. These functions do that
+const getSourceValueTransform = (yOffset) => `translate(
+  ${SOURCE_LABEL_X_OFFSET},
+  ${-(yOffset - SOURCE_VALUE_SIZE)}
+)`;
+
+const getSourceLabelTransform = (
+  yOffset
+) => `translate(${SOURCE_LABEL_X_OFFSET},
+  ${-(yOffset - SOURCE_VALUE_SIZE - SOURCE_LABEL_SIZE - 8)}
+)`;
+// this one happens to not use a dynamic value at the moment but we'll leave it
+// as a function for consistency
+const getTargetLabelTransform = () =>
+  `translate(${NODE_WIDTH / 2 + TARGET_LABEL_PADDING})`;
 
 const GRADIENTS = (
   <>
@@ -169,13 +176,19 @@ export default function SentenceTypesChart({ data, width }) {
       const yOffset = d.y - d.y0;
       return (
         <>
-          <SourceValue yOffset={yOffset}>{formatAsNumber(d.value)}</SourceValue>
-          <SourceLabel yOffset={yOffset}>{d.id}</SourceLabel>
+          <SourceValue transform={getSourceValueTransform(yOffset)}>
+            {formatAsNumber(d.value)}
+          </SourceValue>
+          <SourceLabel transform={getSourceLabelTransform(yOffset)}>
+            {d.id}
+          </SourceLabel>
         </>
       );
     }
     if (targets.has(d.id)) {
-      return <TargetLabel>{d.id}</TargetLabel>;
+      return (
+        <TargetLabel transform={getTargetLabelTransform()}>{d.id}</TargetLabel>
+      );
     }
     return null;
   };

--- a/src/state-county-map/StateCountyMap.js
+++ b/src/state-county-map/StateCountyMap.js
@@ -11,6 +11,7 @@ import {
 } from "react-simple-maps";
 import styled from "styled-components";
 import { mesh } from "topojson";
+import AspectRatioWrapper from "../aspect-ratio-wrapper";
 import ndGeography from "../assets/maps/us_nd.json";
 import { DEFAULT_TENANT, TENANTS, TOTAL_KEY } from "../constants";
 import { hoverColor } from "../utils";
@@ -98,48 +99,57 @@ export default function StateCountyMap({
 
   return (
     <StateCountyMapContainer>
-      <ComposableMap
-        projection={ND_PROJECTION}
+      <AspectRatioWrapper
+        // this component wants ratio of height to width; we have the opposite
+        aspectRatio={1 / ASPECT_RATIO}
         width={width}
-        height={width / ASPECT_RATIO}
-        style={{
-          height: "auto",
-          overflow: "visible",
-          width: "100%",
-        }}
       >
-        <Geographies geography={ndGeography}>
-          {({ geographies }) => {
-            return geographies.map((geography) => (
-              <Geography
-                key={geography.properties.NAME}
-                geography={geography}
-                onClick={handleCountyClick}
-                tabIndex={-1}
-              />
-            ));
+        <ComposableMap
+          projection={ND_PROJECTION}
+          width={width}
+          height={width / ASPECT_RATIO}
+          style={{
+            height: "auto",
+            overflow: "visible",
+            width: "100%",
           }}
-        </Geographies>
-        {sortedData.map((record) => (
-          <Marker key={record.location} coordinates={[record.long, record.lat]}>
-            <LocationMarker
-              onClick={(e) => handleLocationClick(e, record)}
-              onKeyPress={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  handleLocationClick(e, record);
-                }
-              }}
-              onMouseDown={(e) => {
-                // stop clicks from moving focus to this element
-                e.preventDefault();
-              }}
-              r={markerRadiusScale(record.value)}
-              selected={record.location === currentLocation}
-              tabIndex={0}
-            />
-          </Marker>
-        ))}
-      </ComposableMap>
+        >
+          <Geographies geography={ndGeography}>
+            {({ geographies }) => {
+              return geographies.map((geography) => (
+                <Geography
+                  key={geography.properties.NAME}
+                  geography={geography}
+                  onClick={handleCountyClick}
+                  tabIndex={-1}
+                />
+              ));
+            }}
+          </Geographies>
+          {sortedData.map((record) => (
+            <Marker
+              key={record.location}
+              coordinates={[record.long, record.lat]}
+            >
+              <LocationMarker
+                onClick={(e) => handleLocationClick(e, record)}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    handleLocationClick(e, record);
+                  }
+                }}
+                onMouseDown={(e) => {
+                  // stop clicks from moving focus to this element
+                  e.preventDefault();
+                }}
+                r={markerRadiusScale(record.value)}
+                selected={record.location === currentLocation}
+                tabIndex={0}
+              />
+            </Marker>
+          ))}
+        </ComposableMap>
+      </AspectRatioWrapper>
     </StateCountyMapContainer>
   );
 }

--- a/src/state-map/StateMap.js
+++ b/src/state-map/StateMap.js
@@ -10,6 +10,7 @@ import {
 } from "react-simple-maps";
 import styled from "styled-components";
 import { mesh } from "topojson";
+import AspectRatioWrapper from "../aspect-ratio-wrapper";
 import { hoverColor } from "../utils";
 
 const GeoRegion = styled(Geography)`
@@ -67,71 +68,77 @@ export default function StateMap({
   const hoverable = clickable;
 
   return (
-    <ComposableMap
-      projection={stateProjection}
+    <AspectRatioWrapper
+      // this component wants ratio of height to width; we have the opposite
+      aspectRatio={1 / aspectRatio}
       width={width}
-      height={width / aspectRatio}
-      style={{
-        height: "auto",
-        overflow: "visible",
-        width: "100%",
-      }}
     >
-      <Geographies geography={stateTopology}>
-        {({ geographies }) => {
-          return geographies.map((geography) => {
-            const centroid = geoCentroid(geography);
-
-            return (
-              <React.Fragment key={geography.id}>
-                <GeoRegion
-                  className={classNames({
-                    clickable,
-                    hoverable,
-                    highlighted: locationId === geography.id,
-                  })}
-                  key={`region_{geography.id}`}
-                  geography={geography}
-                  onBlur={() => setHoveredLocationId()}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    if (onRegionClick) onRegionClick(geography.id);
-                  }}
-                  onFocus={() => setHoveredLocationId(geography.id)}
-                  onKeyPress={(e) => {
-                    if (onRegionClick) {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onRegionClick(geography.id);
-                      }
-                    }
-                  }}
-                  onMouseDown={(e) => {
-                    // stop clicks from moving focus to this element
-                    e.preventDefault();
-                  }}
-                  onMouseOut={() => setHoveredLocationId()}
-                  onMouseOver={() => setHoveredLocationId(geography.id)}
-                  tabIndex={clickable ? 0 : -1}
-                />
-                {LabelComponent && (
-                  <RegionMarker
-                    key={`marker_{geography.id}`}
-                    coordinates={centroid}
-                  >
-                    <LabelComponent
-                      hover={hoveredLocationId === geography.id}
-                      locationId={locationId}
-                      topologyObjectId={geography.id}
-                    />
-                  </RegionMarker>
-                )}
-              </React.Fragment>
-            );
-          });
+      <ComposableMap
+        projection={stateProjection}
+        width={width}
+        height={width / aspectRatio}
+        style={{
+          height: "auto",
+          overflow: "visible",
+          width: "100%",
         }}
-      </Geographies>
-    </ComposableMap>
+      >
+        <Geographies geography={stateTopology}>
+          {({ geographies }) => {
+            return geographies.map((geography) => {
+              const centroid = geoCentroid(geography);
+
+              return (
+                <React.Fragment key={geography.id}>
+                  <GeoRegion
+                    className={classNames({
+                      clickable,
+                      hoverable,
+                      highlighted: locationId === geography.id,
+                    })}
+                    key={`region_{geography.id}`}
+                    geography={geography}
+                    onBlur={() => setHoveredLocationId()}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      if (onRegionClick) onRegionClick(geography.id);
+                    }}
+                    onFocus={() => setHoveredLocationId(geography.id)}
+                    onKeyPress={(e) => {
+                      if (onRegionClick) {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRegionClick(geography.id);
+                        }
+                      }
+                    }}
+                    onMouseDown={(e) => {
+                      // stop clicks from moving focus to this element
+                      e.preventDefault();
+                    }}
+                    onMouseOut={() => setHoveredLocationId()}
+                    onMouseOver={() => setHoveredLocationId(geography.id)}
+                    tabIndex={clickable ? 0 : -1}
+                  />
+                  {LabelComponent && (
+                    <RegionMarker
+                      key={`marker_{geography.id}`}
+                      coordinates={centroid}
+                    >
+                      <LabelComponent
+                        hover={hoveredLocationId === geography.id}
+                        locationId={locationId}
+                        topologyObjectId={geography.id}
+                      />
+                    </RegionMarker>
+                  )}
+                </React.Fragment>
+              );
+            });
+          }}
+        </Geographies>
+      </ComposableMap>
+    </AspectRatioWrapper>
   );
 }
 


### PR DESCRIPTION
## Description of the change

An assortment of small and not especially related bugs in IE 11. All verified on Windows 10 IE 11 via Browserstack (as well as in modern browsers for regression)

- zoomed-out maps were fixed by a version of the same technique [used in pulse-dashboard](https://github.com/Recidiviz/pulse-dashboard/pull/183/files) ... SVGs don't do well with only a `viewBox` attribute in IE11
- Sankey labels were changed to use SVG transform attributes rather than CSS transform properties because IE 11 does not support the latter on SVG elements
- The footer spacing issue was a bug in flexbox alignment when the container does not have an explicit height

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #181, closes #182, closes #183 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
