### PR TITLE
UI error states

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@google-cloud/storage": "^5.1.2",
     "@reach/menu-button": "^0.10.5",
     "@reach/router": "^1.3.4",
+    "@sentry/react": "^5.21.4",
     "@w11r/use-breakpoint": "^1.7.0",
     "cache-manager": "^3.3.0",
     "classnames": "^2.2.6",

--- a/src/chart-error/ChartError.js
+++ b/src/chart-error/ChartError.js
@@ -1,0 +1,25 @@
+import React from "react";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  align-items: center;
+  background: ${(props) => props.theme.colors.chartErrorBackground};
+  display: flex;
+  height: 494px;
+  justify-content: center;
+  text-align: center;
+`;
+
+const ErrorText = styled.div`
+  opacity: 0.8;
+`;
+
+export default function ChartError() {
+  return (
+    <Wrapper>
+      <ErrorText>
+        The data for this graph could not be loaded. Please check again later.
+      </ErrorText>
+    </Wrapper>
+  );
+}

--- a/src/chart-error/index.js
+++ b/src/chart-error/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ChartError";

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from "@sentry/react";
 import useBreakpoint, { mediaQuery } from "@w11r/use-breakpoint";
 import { ascending } from "d3-array";
 import PropTypes from "prop-types";
@@ -6,6 +7,7 @@ import Measure from "react-measure";
 import { StickyContainer, Sticky } from "react-sticky";
 import { exact, tail } from "set-order";
 import styled from "styled-components";
+import ChartError from "../chart-error";
 import {
   COLLAPSIBLE_NAV_BREAKPOINT,
   OTHER_LABEL,
@@ -165,11 +167,18 @@ function DetailSection({
 
         <DetailSectionDescription>{description}</DetailSectionDescription>
         <DetailSectionVizContainer>
-          <VizComponent
-            data={vizData}
-            {...{ dimension, month, locationId, setMonthList }}
-            onLocationClick={setLocationId}
-          />
+          <ErrorBoundary
+            beforeCapture={(scope) => {
+              scope.setTag("boundary", "chart");
+            }}
+            fallback={ChartError}
+          >
+            <VizComponent
+              data={vizData}
+              {...{ dimension, month, locationId, setMonthList }}
+              onLocationClick={setLocationId}
+            />
+          </ErrorBoundary>
         </DetailSectionVizContainer>
       </DetailSectionContainer>
     </StickyContainer>

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -19,7 +19,7 @@ const FooterContent = styled(PageWidthContainer)`
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  height: 320px;
+  height: ${(props) => props.theme.footerHeight};
   justify-content: space-between;
   margin: 0 auto;
 `;

--- a/src/page-error/PageError.js
+++ b/src/page-error/PageError.js
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+import { HeadingTitle, HeadingDescription } from "../heading";
+
+const Wrapper = styled.div`
+  margin: 0 auto;
+  max-width: 720px;
+  padding: 88px 0;
+  text-align: center;
+`;
+
+export default function PageError() {
+  return (
+    <Wrapper>
+      <div>
+        <HeadingTitle>We’ll be back soon</HeadingTitle>
+        <HeadingDescription>
+          This data for this page could not be loaded at the moment. We will be
+          back up as soon as possible. Thank you for your patience.
+        </HeadingDescription>
+      </div>
+    </Wrapper>
+  );
+}

--- a/src/page-error/index.js
+++ b/src/page-error/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PageError";

--- a/src/page-not-found/PageNotFound.js
+++ b/src/page-not-found/PageNotFound.js
@@ -1,0 +1,26 @@
+import React from "react";
+import styled from "styled-components";
+import { HeadingTitle, HeadingDescription } from "../heading";
+
+const Wrapper = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 88px 0;
+`;
+
+export default function PageNotFound() {
+  return (
+    <Wrapper>
+      <div>
+        <HeadingTitle>Error 404: Page not found.</HeadingTitle>
+        <HeadingDescription>
+          <p>The page that you are looking for is missing.</p>
+          <p>
+            Go to <a href="https://docr.nd.gov">docr.nd.gov</a>
+          </p>
+        </HeadingDescription>
+      </div>
+    </Wrapper>
+  );
+}

--- a/src/page-not-found/PageNotFound.js
+++ b/src/page-not-found/PageNotFound.js
@@ -1,8 +1,11 @@
+import { Link } from "@reach/router";
 import React from "react";
 import styled from "styled-components";
 import { HeadingTitle, HeadingDescription } from "../heading";
 
 const Wrapper = styled.div`
+  margin: 0 auto;
+  max-width: 768px;
   padding: 88px 0;
   text-align: center;
 `;
@@ -14,7 +17,9 @@ export default function PageNotFound() {
       <HeadingDescription>
         <p>The page that you are looking for is missing.</p>
         <p>
-          Go to <a href="https://docr.nd.gov">docr.nd.gov</a>
+          Click <Link to="/">here</Link> to return to the homepage of the
+          dashboard, or visit the North Dakota Department of Corrections at{" "}
+          <a href="https://docr.nd.gov">docr.nd.gov</a>.
         </p>
       </HeadingDescription>
     </Wrapper>

--- a/src/page-not-found/PageNotFound.js
+++ b/src/page-not-found/PageNotFound.js
@@ -3,24 +3,20 @@ import styled from "styled-components";
 import { HeadingTitle, HeadingDescription } from "../heading";
 
 const Wrapper = styled.div`
-  align-items: center;
-  display: flex;
-  justify-content: center;
   padding: 88px 0;
+  text-align: center;
 `;
 
 export default function PageNotFound() {
   return (
     <Wrapper>
-      <div>
-        <HeadingTitle>Error 404: Page not found.</HeadingTitle>
-        <HeadingDescription>
-          <p>The page that you are looking for is missing.</p>
-          <p>
-            Go to <a href="https://docr.nd.gov">docr.nd.gov</a>
-          </p>
-        </HeadingDescription>
-      </div>
+      <HeadingTitle>Error 404: Page not found.</HeadingTitle>
+      <HeadingDescription>
+        <p>The page that you are looking for is missing.</p>
+        <p>
+          Go to <a href="https://docr.nd.gov">docr.nd.gov</a>
+        </p>
+      </HeadingDescription>
     </Wrapper>
   );
 }

--- a/src/page-not-found/index.js
+++ b/src/page-not-found/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PageNotFound";

--- a/src/page-routes/PageRoutes.js
+++ b/src/page-routes/PageRoutes.js
@@ -4,12 +4,13 @@ import { Helmet } from "react-helmet";
 import styled from "styled-components";
 import { ALL_PAGES, PATHS } from "../constants";
 import useCurrentPage from "../hooks/useCurrentPage";
+import PageNotFound from "../page-not-found";
 import PageOverview from "../page-overview";
-import PageSentencing from "../page-sentencing";
 import PagePrison from "../page-prison";
 import PageProbation from "../page-probation";
 import PageParole from "../page-parole";
-import PageRacialDisparities from "../page-racial-disparities/PageRacialDisparities";
+import PageRacialDisparities from "../page-racial-disparities";
+import PageSentencing from "../page-sentencing";
 import { getSiteTitle } from "../utils";
 
 const PagesContainer = styled.main``;
@@ -41,6 +42,7 @@ export default function PageRoutes() {
         <PageProbation path={PATHS.probation} />
         <PageParole path={PATHS.parole} />
         <PageRacialDisparities path={PATHS.race} />
+        <PageNotFound default />
       </Router>
     </PagesContainer>
   );

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from "@sentry/react";
 import useBreakpoint, { mediaQuery } from "@w11r/use-breakpoint";
 import PropTypes from "prop-types";
 import React from "react";
@@ -11,6 +12,7 @@ import PageRoutes from "../page-routes";
 import SecondaryNav from "../secondary-nav";
 import InfoPanel from "../info-panel";
 import Cobranding from "../cobranding";
+import PageError from "../page-error";
 import PageWidthContainer from "../page-width-container";
 import { THEME } from "../theme";
 
@@ -24,7 +26,7 @@ const SiteContainer = styled.div`
 
 const BodyWrapper = styled(PageWidthContainer)`
   margin: 0 auto;
-  min-height: 100vh;
+  min-height: calc(100vh - ${(props) => props.theme.footerHeight});
   padding-top: ${(props) => props.theme.headerHeight + BRANDING_BAR_MARGIN}px;
 
   ${mediaQuery([
@@ -82,24 +84,26 @@ function SiteLayout({ tenantId }) {
         <BrandingBarWrapper>
           <BrandingBar />
         </BrandingBarWrapper>
-        {tenantId && (
-          <>
-            {showNav && (
-              <NavBarWrapper>
-                <NavBar />
-                <Cobranding />
-              </NavBarWrapper>
-            )}
-            <MainContentWrapper>
-              <PageRoutes />
-              {!onOverviewPage && (
-                <SecondaryNavWrapper>
-                  <SecondaryNav />
-                </SecondaryNavWrapper>
+        <ErrorBoundary fallback={PageError}>
+          {tenantId && (
+            <>
+              {showNav && (
+                <NavBarWrapper>
+                  <NavBar />
+                  <Cobranding />
+                </NavBarWrapper>
               )}
-            </MainContentWrapper>
-          </>
-        )}
+              <MainContentWrapper>
+                <PageRoutes />
+                {!onOverviewPage && (
+                  <SecondaryNavWrapper>
+                    <SecondaryNav />
+                  </SecondaryNavWrapper>
+                )}
+              </MainContentWrapper>
+            </>
+          )}
+        </ErrorBoundary>
       </BodyWrapper>
       <FooterWrapper>
         <Footer />

--- a/src/site-layout/SiteLayout.js
+++ b/src/site-layout/SiteLayout.js
@@ -84,7 +84,12 @@ function SiteLayout({ tenantId }) {
         <BrandingBarWrapper>
           <BrandingBar />
         </BrandingBarWrapper>
-        <ErrorBoundary fallback={PageError}>
+        <ErrorBoundary
+          beforeCapture={(scope) => {
+            scope.setTag("boundary", "page");
+          }}
+          fallback={PageError}
+        >
           {tenantId && (
             <>
               {showNav && (

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -76,6 +76,7 @@ export const defaultTheme = {
     body: charcoal,
     bodyLight: white,
     chartAxis: charcoal,
+    chartErrorBackground: buttonBackground,
     controlBackground: buttonBackground,
     controlLabel: charcoal,
     controlValue: black,

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -139,6 +139,7 @@ export const defaultTheme = {
     brandSubtitleSize: "14px",
     brandSubtitleSizeSmall: "13px",
   },
+  footerHeight: "320px",
   headerHeightSmall: 50,
   headerHeight: 112,
   sectionTextWidth: "60vw",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,70 @@
   resolved "https://registry.yarnpkg.com/@react-hook/previous/-/previous-1.0.1.tgz#61f499e855873dcdb64e7b98f302194548f267f4"
   integrity sha512-O7VaRLDEHRy1hxh03CmtWRxDhCwIVQBBkf1kYdYqUP3KNrPnQMIVIYYYQpHIIiNcS1BO6zmBKM4bugFDNgP8Iw==
 
+"@sentry/browser@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.21.4.tgz#50cb1f815f5468bb7c891fee329b8298f2aa5d9a"
+  integrity sha512-/bRGMNjJc4Qt9Me9qLobZe0pREUAMFQAR7GOF9HbgzxUc49qVvmPRglvwzwhPJ6XKPg0NH/C6MOn+yuIRjfMag==
+  dependencies:
+    "@sentry/core" "5.21.4"
+    "@sentry/types" "5.21.4"
+    "@sentry/utils" "5.21.4"
+    tslib "^1.9.3"
+
+"@sentry/core@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.21.4.tgz#e2557344e106ad3af0dbe7a81fc00909c768470c"
+  integrity sha512-2hB0shKL6RUuLqqmnDUPvwiV25OSnchxkJ6NbLqnn2DYLqLARfZuVcw2II4wb/Jlw7SDnbkQIPs0/ax7GPe1Nw==
+  dependencies:
+    "@sentry/hub" "5.21.4"
+    "@sentry/minimal" "5.21.4"
+    "@sentry/types" "5.21.4"
+    "@sentry/utils" "5.21.4"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.21.4.tgz#5cfc400f48796286f1a24cb013fdbd40958841b3"
+  integrity sha512-bgEgBHK6OWoAkrnYwVsIOw+sR4MWpe5/CB7H7r+GBJsSnBysncbSaBgndKmtb1GTWdzMxMlvXU16zC6TR5JX5Q==
+  dependencies:
+    "@sentry/types" "5.21.4"
+    "@sentry/utils" "5.21.4"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.21.4.tgz#7a6872e98fe21cb4addd36b3a0b9906c13076047"
+  integrity sha512-pIpIH2ZTwdijGTw6VwfkTETAEoc9k/Aejz6mAjFDMzlOPb3bCx+W8EbGzFOxuwOsiE84bysd2UPVgFY4YSLV/g==
+  dependencies:
+    "@sentry/hub" "5.21.4"
+    "@sentry/types" "5.21.4"
+    tslib "^1.9.3"
+
+"@sentry/react@^5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.21.4.tgz#814525a33256698bfee43cf9e60d2a41f96ea132"
+  integrity sha512-7mzpgIJx1JkBr//IiJoN5rjYziUcg5wpO5lfcjKEtHZd1O076z2qHIdyEaP8/+845vDddK032srWSqPGFKFkWA==
+  dependencies:
+    "@sentry/browser" "5.21.4"
+    "@sentry/minimal" "5.21.4"
+    "@sentry/types" "5.21.4"
+    "@sentry/utils" "5.21.4"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/types@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.21.4.tgz#f088a36ca765657b74b869f8739056961383c159"
+  integrity sha512-uJTRxW//NPO0UJJzRQOtYHg5tiSBvn1dRk5FvURXmeXt9d9XtwmRhHWDwI51uAkyv+51tun3v+0OZQfLvAI+gQ==
+
+"@sentry/utils@5.21.4":
+  version "5.21.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.21.4.tgz#353264fdd5743edf140daf4c37209d350c9d8258"
+  integrity sha512-zY8OvaE/lU+DCzTSFrDZNXZmBLM/0URUlyYD4RubqzrgKY/eP1pSbEsDzYYhc+OrBr8TjG66N+5T3gMZX0BfNg==
+  dependencies:
+    "@sentry/types" "5.21.4"
+    tslib "^1.9.3"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -6236,7 +6300,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -12283,6 +12347,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^1.9.3:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tslib@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description of the change

Adds error handling and UI for three error states for which the site currently presents a broken or otherwise substandard interface: 
- Error panel for errors contained to a single chart
- Error page for errors that are not contained to a single chart (e.g. widespread data loading failure)
 - "404 page" for invalid URLs

<img width="957" alt="Screen Shot 2020-08-27 at 1 56 13 PM" src="https://user-images.githubusercontent.com/5385319/91494136-3cf52700-e86d-11ea-8b1d-e164b3fdb5e4.png">
<img width="1309" alt="Screen Shot 2020-08-27 at 1 56 38 PM" src="https://user-images.githubusercontent.com/5385319/91494142-3ebeea80-e86d-11ea-8a31-b45cfb01680d.png">
<img width="1311" alt="Screen Shot 2020-08-27 at 1 57 05 PM" src="https://user-images.githubusercontent.com/5385319/91494151-4088ae00-e86d-11ea-800d-0fa70f005bf1.png">

I used the Sentry React SDK to implement this to ensure that these errors are still reported to Sentry when we catch them (along with a tag that indicates how much of the page was affected). This does not, however, log invalid URL visits to Sentry, because there isn't actually any error to catch ... I'm not so sure we would really want that in Sentry anyway?

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #174 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
