### PR TITLE
Use native mobile select UI for dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@accessible/slider": "^2.0.2",
     "@google-cloud/storage": "^5.1.2",
+    "@reach/auto-id": "^0.11.2",
     "@reach/menu-button": "^0.10.5",
     "@reach/router": "^1.3.4",
     "@w11r/use-breakpoint": "^1.7.0",

--- a/src/controls/Dropdown.js
+++ b/src/controls/Dropdown.js
@@ -146,7 +146,7 @@ export default function Dropdown({
 
         {renderNativeSelect && (
           <>
-            <ControlValue>{selectedOption.label}</ControlValue>
+            <ControlValue aria-hidden>{selectedOption.label}</ControlValue>
             <HiddenSelect
               aria-labelledby={labelId}
               value={currentOptionId}

--- a/src/controls/Dropdown.js
+++ b/src/controls/Dropdown.js
@@ -1,3 +1,4 @@
+import { useId } from "@reach/auto-id";
 import useBreakpoint from "@w11r/use-breakpoint";
 import classNames from "classnames";
 import React, { useState, useEffect } from "react";
@@ -107,6 +108,7 @@ export default function Dropdown({
   }, [selectedId]);
 
   const renderNativeSelect = useBreakpoint(false, ["mobile-", true]);
+  const labelId = useId();
 
   return (
     <DropdownWrapper
@@ -118,11 +120,11 @@ export default function Dropdown({
       })}
     >
       <ControlContainer>
-        <ControlLabel>{label}</ControlLabel>
+        <ControlLabel id={labelId}>{label}</ControlLabel>
 
         {!renderNativeSelect && (
           <Menu>
-            <MenuButton>
+            <MenuButton aria-labelledby={labelId}>
               <ControlValue>{selectedOption.label}</ControlValue>
             </MenuButton>
             <MenuPopover>
@@ -146,6 +148,7 @@ export default function Dropdown({
           <>
             <ControlValue>{selectedOption.label}</ControlValue>
             <HiddenSelect
+              aria-labelledby={labelId}
               value={currentOptionId}
               onChange={(event) => setCurrentOptionId(event.target.value)}
             >

--- a/src/controls/Dropdown.js
+++ b/src/controls/Dropdown.js
@@ -1,3 +1,4 @@
+import useBreakpoint from "@w11r/use-breakpoint";
 import classNames from "classnames";
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
@@ -67,6 +68,15 @@ const DropdownMenu = styled.div`
   }
 `;
 
+const HiddenSelect = styled.select`
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;
+
 // if selectedId prop is provided, this behaves like a controlled component;
 // in the absence of that it will be uncontrolled and expose the ID of
 // its selected option via a listener
@@ -96,6 +106,8 @@ export default function Dropdown({
     }
   }, [selectedId]);
 
+  const renderNativeSelect = useBreakpoint(false, ["mobile-", true]);
+
   return (
     <DropdownWrapper
       className={classNames({
@@ -105,28 +117,47 @@ export default function Dropdown({
           highlighted || currentOptionId !== options[0].id,
       })}
     >
-      <Menu>
-        <ControlContainer>
-          <ControlLabel>{label}</ControlLabel>
-          <MenuButton>
+      <ControlContainer>
+        <ControlLabel>{label}</ControlLabel>
+
+        {!renderNativeSelect && (
+          <Menu>
+            <MenuButton>
+              <ControlValue>{selectedOption.label}</ControlValue>
+            </MenuButton>
+            <MenuPopover>
+              <DropdownMenu>
+                <MenuItems>
+                  {options.map((option) => (
+                    <MenuItem
+                      key={option.id}
+                      onSelect={() => setCurrentOptionId(option.id)}
+                    >
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </MenuItems>
+              </DropdownMenu>
+            </MenuPopover>
+          </Menu>
+        )}
+
+        {renderNativeSelect && (
+          <>
             <ControlValue>{selectedOption.label}</ControlValue>
-          </MenuButton>
-          <MenuPopover>
-            <DropdownMenu>
-              <MenuItems>
-                {options.map((option) => (
-                  <MenuItem
-                    key={option.id}
-                    onSelect={() => setCurrentOptionId(option.id)}
-                  >
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </MenuItems>
-            </DropdownMenu>
-          </MenuPopover>
-        </ControlContainer>
-      </Menu>
+            <HiddenSelect
+              value={currentOptionId}
+              onChange={(event) => setCurrentOptionId(event.target.value)}
+            >
+              {options.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))}
+            </HiddenSelect>
+          </>
+        )}
+      </ControlContainer>
     </DropdownWrapper>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,6 +1439,14 @@
     "@reach/utils" "0.10.5"
     tslib "^2.0.0"
 
+"@reach/auto-id@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.11.2.tgz#c66a905c5401d1ac3da8d26165b8d27d6e778fa6"
+  integrity sha512-YZ21b0Kb88wJ0t7QjSznWOYskARQMnmXY9Y2XZ5RyYcZ2krT4s3+ghghpfaPs6BKcrZDonZCrU65OFDJPa1jAw==
+  dependencies:
+    "@reach/utils" "0.11.2"
+    tslib "^2.0.0"
+
 "@reach/descendants@0.10.5":
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.5.tgz#2611174e9e9b326dba548356221e2f8c8f5c8612"
@@ -1507,6 +1515,15 @@
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.5.tgz#fbac944d29565f6dd7abd0e1b13950e99b1e470b"
   integrity sha512-5E/xxQnUbmpI/LrufBAOXjunl96DnqX6B4zC2MO2KH/dRzLug5gM5VuOwV26egsp0jvsSPxojwciOhS43px3qw==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^2.0.0"
+    warning "^4.0.3"
+
+"@reach/utils@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.11.2.tgz#be1f03650db56fd67a16d3fc70e5262cdb139cec"
+  integrity sha512-fBTolYj+rKTROXmf0zHO0rCWSvw7J0ALmYj5QxW4DmITMOH5uyRuWDWOfqohIGFbOtF/sum50WTB3tvx76d+Aw==
   dependencies:
     "@types/warning" "^3.0.0"
     tslib "^2.0.0"


### PR DESCRIPTION
## Description of the change

On smaller screens we want the native select UI rather than our custom dropdown markup, which provides small touch targets and has a tendency to flow off the screen. I couldn't really find an alternative React library that did anything acceptably close to what we want here, so instead I went with an old-fashioned "invisible `select`" hack (on mobile devices only; existing behavior should be unchanged on larger screens).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #140 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
