### PR TITLE
remove min paragraph height in methodology modal

### DIFF
--- a/src/methodology-modal/MethodologyModal.js
+++ b/src/methodology-modal/MethodologyModal.js
@@ -15,6 +15,7 @@ const MethodologyHeading = styled(HeadingTitle)``;
 
 const MethodologyDescription = styled(HeadingDescription)`
   font-size: 16px;
+  min-height: unset;
 `;
 
 const MethodologyBody = styled.div``;


### PR DESCRIPTION
## Description of the change

Just caught this bug I must have introduced in #186 ... was causing massive space between paragraphs in the Methodology modal due to CSS inheritance. This change restores the previous behavior, which applies more normal-looking margins to the paragraph text.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
