### PR TITLE
Fix IE11 CSS issues

### DIFF
--- a/src/bubble-chart/BubbleChart.js
+++ b/src/bubble-chart/BubbleChart.js
@@ -25,13 +25,16 @@ const BubbleChartWrapper = styled.div`
 `;
 
 const BubbleValueLabel = styled.text`
-  dominant-baseline: central;
   fill: ${(props) => props.theme.colors.bodyLight};
   font: ${(props) => props.theme.fonts.displayMedium};
   letter-spacing: -0.09em;
   font-size: 20px;
   text-anchor: middle;
 `;
+// this is a magic number based on the font size of BubbleValueLabel;
+// it is a workaround for the lack of IE support for the dominant-baseline attribute
+// to vertically center this text relative to its origin
+const BUBBLE_VALUE_Y_OFFSET = 8;
 
 const LegendWrapper = styled.div`
   bottom: 0;
@@ -152,7 +155,9 @@ export default function BubbleChart({ data: initialData, height, width }) {
             // 1) if the value is zero there will be no bubble, so no label
             // 2) if the bubble is really small (less than ~1%) the label won't fit
             d.pct >= 0.01 && (
-              <BubbleValueLabel>{formatAsPct(d.pct)}</BubbleValueLabel>
+              <BubbleValueLabel dy={BUBBLE_VALUE_Y_OFFSET}>
+                {formatAsPct(d.pct)}
+              </BubbleValueLabel>
             )
           }
           nodeSizeAccessor={getRadius}

--- a/src/methodology-modal/MethodologyModal.js
+++ b/src/methodology-modal/MethodologyModal.js
@@ -15,7 +15,7 @@ const MethodologyHeading = styled(HeadingTitle)``;
 
 const MethodologyDescription = styled(HeadingDescription)`
   font-size: 16px;
-  min-height: unset;
+  min-height: 0;
 `;
 
 const MethodologyBody = styled.div``;

--- a/src/sentence-types-chart/SentenceTypesChart.js
+++ b/src/sentence-types-chart/SentenceTypesChart.js
@@ -41,11 +41,14 @@ const SourceLabel = styled.text`
 
 const TARGET_LABEL_PADDING = 8;
 const TargetLabel = styled.text`
-  dominant-baseline: middle;
   font-size: 16px;
   text-anchor: start;
   width: ${MARGIN.right - TARGET_LABEL_PADDING}px;
 `;
+// this is a magic number based on the label's font size;
+// workaround for lack of dominant-baseline support in IE
+// to vertically center the text on origin
+const TARGET_LABEL_Y_OFFSET = 6;
 
 // because IE does not support CSS transforms on SVG elements (#182),
 // we need to render label translations as SVG attributes. These functions do that
@@ -62,7 +65,9 @@ const getSourceLabelTransform = (
 // this one happens to not use a dynamic value at the moment but we'll leave it
 // as a function for consistency
 const getTargetLabelTransform = () =>
-  `translate(${NODE_WIDTH / 2 + TARGET_LABEL_PADDING})`;
+  `translate(${
+    NODE_WIDTH / 2 + TARGET_LABEL_PADDING
+  }, ${TARGET_LABEL_Y_OFFSET})`;
 
 const GRADIENTS = (
   <>

--- a/src/state-judicial-district-map/StateJudicialDistrictMap.js
+++ b/src/state-judicial-district-map/StateJudicialDistrictMap.js
@@ -14,7 +14,6 @@ const StateJudicialDistrictMapWrapper = styled.div`
 `;
 
 const ParticipantCount = styled.text`
-  dominant-baseline: middle;
   fill: ${(props) =>
     // eslint-disable-next-line no-nested-ternary
     props.active
@@ -28,6 +27,10 @@ const ParticipantCount = styled.text`
   pointer-events: none;
   text-anchor: middle;
 `;
+// this is a magic number based on the font size of the label;
+// it is a workaround for the lack of IE support for the dominant-baseline attribute
+// to vertically center this text relative to its origin
+const PARTICIPANT_COUNT_Y_OFFSET = 8;
 
 const OtherWrapper = styled.button`
   background: none;
@@ -68,6 +71,7 @@ export default function StateJudicialDistrictMap({
     return districtRecord ? (
       <ParticipantCount
         active={locationId === districtRecord.district}
+        dy={PARTICIPANT_COUNT_Y_OFFSET}
         hover={hover}
       >
         {formatAsNumber(districtRecord.value)}


### PR DESCRIPTION
## Description of the change

Did another round of QA on latest master and found two issues that were IE-only (one related to a change in this release candidate and one bonus). This fixes both: 

- IE doesn't support the CSS `unset` keyword so there were still enormous paragraph spaces in the Methodology modal
- IE doesn't support the SVG `dominant-baseline` property we used to adjust vertical spacing on some text labels; the workaround is to use numeric Y offsets instead (I hard-coded them rather than try to do any fancy calculations on the fly, which didn't seem necessary)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
