### PR TITLE
New chart hover interactions that include legends

### DIFF
--- a/src/bar-chart-trellis/BarChartTrellis.js
+++ b/src/bar-chart-trellis/BarChartTrellis.js
@@ -7,7 +7,7 @@ import { SENTENCE_LENGTH_KEYS, SENTENCE_LENGTHS } from "../constants";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 import { THEME } from "../theme";
 
-import { getDataWithPct, formatAsPct, hoverColor } from "../utils";
+import { getDataWithPct, formatAsPct, highlightFade } from "../utils";
 
 const CHART_HEIGHT = 360;
 const CHART_MIN_WIDTH = 320;
@@ -103,7 +103,9 @@ export default function BarChartTrellis({ data, width }) {
             size={[chartWidth, CHART_HEIGHT]}
             style={(d) => ({
               fill:
-                highlightedLabel === d.label ? hoverColor(d.color) : d.color,
+                highlightedLabel && highlightedLabel !== d.label
+                  ? highlightFade(d.color)
+                  : d.color,
             })}
             type="bar"
           >

--- a/src/bubble-chart/BubbleChart.js
+++ b/src/bubble-chart/BubbleChart.js
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import ColorLegend from "../color-legend";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 import { THEME } from "../theme";
-import { formatAsPct, getDataWithPct, hoverColor } from "../utils";
+import { formatAsPct, getDataWithPct, highlightFade } from "../utils";
 
 const margin = { top: 0, left: 0, right: 0, bottom: 40 };
 
@@ -163,8 +163,8 @@ export default function BubbleChart({ data: initialData, height, width }) {
           nodeSizeAccessor={getRadius}
           nodeStyle={(d) => ({
             fill:
-              (highlighted || {}).label === d.label
-                ? hoverColor(d.color)
+              highlighted && highlighted.label !== d.label
+                ? highlightFade(d.color)
                 : d.color,
           })}
           nodes={data}

--- a/src/bubble-chart/BubbleChart.js
+++ b/src/bubble-chart/BubbleChart.js
@@ -173,7 +173,11 @@ export default function BubbleChart({ data: initialData, height, width }) {
         />
       </ResponsiveTooltipController>
       <LegendWrapper>
-        <ColorLegend items={initialData} />
+        <ColorLegend
+          highlighted={highlighted}
+          items={initialData}
+          setHighlighted={setHighlighted}
+        />
       </LegendWrapper>
     </BubbleChartWrapper>
   );

--- a/src/color-legend/ColorLegend.js
+++ b/src/color-legend/ColorLegend.js
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
+import { highlightFade } from "../utils";
 
 const ColorLegendWrapper = styled.div`
   display: flex;
@@ -49,6 +50,8 @@ const ColorLegendItemSwatch = styled.div`
   border-radius: ${swatchSize / 2}px;
   height: ${swatchSize}px;
   margin-left: ${swatchSize / 2}px;
+  transition: background-color
+    ${(props) => props.theme.transition.defaultTimeSettings};
   width: ${swatchSize}px;
 `;
 
@@ -68,7 +71,13 @@ export default function ColorLegend({ highlighted, items, setHighlighted }) {
           onMouseOver={() => setHighlighted({ label })}
         >
           <ColorLegendItemLabel>{label}</ColorLegendItemLabel>
-          <ColorLegendItemSwatch color={color} />
+          <ColorLegendItemSwatch
+            color={
+              highlighted && highlighted.label !== label
+                ? highlightFade(color)
+                : color
+            }
+          />
         </ColorLegendItem>
       ))}
     </ColorLegendWrapper>

--- a/src/color-legend/ColorLegend.js
+++ b/src/color-legend/ColorLegend.js
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
@@ -10,15 +11,37 @@ const ColorLegendWrapper = styled.div`
 
 const ColorLegendItem = styled.div`
   align-items: center;
+  cursor: pointer;
   display: flex;
   flex: 0 0 auto;
   margin-right: 8px;
+  padding-bottom: 4px;
+  position: relative;
   white-space: nowrap;
 
   &:last-child {
     margin-right: 0;
   }
+
+  &::after {
+    background: ${(props) => props.color};
+    bottom: 0;
+    content: "";
+    display: block;
+    height: 1px;
+    left: 50%;
+    position: absolute;
+    transition: ${(props) =>
+      `width ${props.theme.transition.defaultTimeSettings}, left ${props.theme.transition.defaultTimeSettings}`};
+    width: 0;
+  }
+
+  &.highlighted::after {
+    width: 100%;
+    left: 0;
+  }
 `;
+
 const ColorLegendItemLabel = styled.div``;
 const swatchSize = 8;
 const ColorLegendItemSwatch = styled.div`
@@ -29,11 +52,21 @@ const ColorLegendItemSwatch = styled.div`
   width: ${swatchSize}px;
 `;
 
-export default function ColorLegend({ items }) {
+export default function ColorLegend({ highlighted, items, setHighlighted }) {
   return (
     <ColorLegendWrapper aria-hidden>
       {items.map(({ label, color }) => (
-        <ColorLegendItem key={label}>
+        <ColorLegendItem
+          className={classNames({
+            highlighted: (highlighted || {}).label === label,
+          })}
+          color={color}
+          key={label}
+          onBlur={() => setHighlighted()}
+          onFocus={() => setHighlighted({ label })}
+          onMouseOut={() => setHighlighted()}
+          onMouseOver={() => setHighlighted({ label })}
+        >
           <ColorLegendItemLabel>{label}</ColorLegendItemLabel>
           <ColorLegendItemSwatch color={color} />
         </ColorLegendItem>
@@ -43,10 +76,16 @@ export default function ColorLegend({ items }) {
 }
 
 ColorLegend.propTypes = {
+  highlighted: PropTypes.shape({ label: PropTypes.string.isRequired }),
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       color: PropTypes.string.isRequired,
     })
   ).isRequired,
+  setHighlighted: PropTypes.func.isRequired,
+};
+
+ColorLegend.defaultProps = {
+  highlighted: undefined,
 };

--- a/src/monthly-timeseries/MonthlyTimeseries.js
+++ b/src/monthly-timeseries/MonthlyTimeseries.js
@@ -7,7 +7,7 @@ import ChartWrapper from "../chart-wrapper";
 import Disclaimer from "../disclaimer";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 import { THEME } from "../theme";
-import { formatAsPct, formatAsNumber, hoverColor } from "../utils";
+import { formatAsPct, formatAsNumber, highlightFade } from "../utils";
 
 const MonthlyTimeseriesWrapper = styled(ChartWrapper)`
   width: 100%;
@@ -76,8 +76,8 @@ export default function MonthlyTimeseries({ data }) {
           size={[undefined, 350]}
           style={(d) => ({
             fill:
-              highlighted && d.column === highlighted.column.name
-                ? hoverColor(THEME.colors.monthlyTimeseriesBar)
+              highlighted && d.column !== highlighted.column.name
+                ? highlightFade(THEME.colors.monthlyTimeseriesBar)
                 : THEME.colors.monthlyTimeseriesBar,
           })}
           type="bar"

--- a/src/page-racial-disparities/VizPopulationDisparity.js
+++ b/src/page-racial-disparities/VizPopulationDisparity.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { DIMENSION_DATA_KEYS, RACE_LABELS, TOTAL_KEY } from "../constants";
 import ProportionalBar from "../proportional-bar";
@@ -42,6 +42,7 @@ export default function VizPopulationDisparity({ data: { countsByRace } }) {
   });
 
   const barHeight = useBarHeight();
+  const [highlighted, setHighlighted] = useState();
 
   return (
     <Wrapper>
@@ -49,6 +50,8 @@ export default function VizPopulationDisparity({ data: { countsByRace } }) {
         <ProportionalBar
           data={totalPopulationData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title="Proportions of races in the state"
           showLegend={false}
         />
@@ -57,6 +60,8 @@ export default function VizPopulationDisparity({ data: { countsByRace } }) {
         <ProportionalBar
           data={correctionsPopulationData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title="Proportions of races sentenced and under DOCR control"
           showLegend
         />

--- a/src/page-racial-disparities/VizPopulationFocus.js
+++ b/src/page-racial-disparities/VizPopulationFocus.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { RACE_LABELS } from "../constants";
 import ProportionalBar from "../proportional-bar";
@@ -54,6 +54,7 @@ export default function VizPopulationFocus({
   ];
 
   const barHeight = useBarHeight();
+  const [highlighted, setHighlighted] = useState();
 
   return (
     <Wrapper>
@@ -61,6 +62,8 @@ export default function VizPopulationFocus({
         <ProportionalBar
           data={totalPopulationData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title="Proportions of total state population"
           showLegend={false}
         />
@@ -69,6 +72,8 @@ export default function VizPopulationFocus({
         <ProportionalBar
           data={correctionsPopulationData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title="Proportions of people sentenced and under DOCR control"
           showLegend
         />

--- a/src/page-racial-disparities/VizRevocationDisparity.js
+++ b/src/page-racial-disparities/VizRevocationDisparity.js
@@ -1,6 +1,6 @@
 import { ascending } from "d3-array";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { TOTAL_KEY, VIOLATION_LABELS } from "../constants";
 import Disclaimer from "../disclaimer";
@@ -42,6 +42,7 @@ export default function VizRevocationDisparity({
   );
 
   const barHeight = useBarHeight();
+  const [highlighted, setHighlighted] = useState();
 
   return (
     <Wrapper>
@@ -49,6 +50,8 @@ export default function VizRevocationDisparity({
         <ProportionalBar
           data={totalData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title="Proportions of revocation reasons overall"
           showLegend={false}
         />
@@ -57,6 +60,8 @@ export default function VizRevocationDisparity({
         <ProportionalBar
           data={categoryData}
           height={barHeight}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
           title={
             <>
               Proportions of revocation reasons for{" "}

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -5,7 +5,7 @@ import ResponsiveOrdinalFrame from "semiotic/lib/ResponsiveOrdinalFrame";
 import styled from "styled-components";
 import ColorLegend from "../color-legend";
 import { THEME } from "../theme";
-import { getDataWithPct, hoverColor } from "../utils";
+import { getDataWithPct, highlightFade } from "../utils";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 
 const ProportionalBarContainer = styled.figure`
@@ -80,8 +80,8 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
             size={[0, height]}
             style={(d) => ({
               fill:
-                (highlighted || {}).label === d.label
-                  ? hoverColor(d.color)
+                highlighted && highlighted.label !== d.label
+                  ? highlightFade(d.color)
                   : d.color,
             })}
             type="bar"

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -95,7 +95,11 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
         </ProportionalBarTitle>
         {showLegend && (
           <ProportionalBarLegendWrapper>
-            <ColorLegend items={data} />
+            <ColorLegend
+              highlighted={highlighted}
+              items={data}
+              setHighlighted={setHighlighted}
+            />
           </ProportionalBarLegendWrapper>
         )}
       </ProportionalBarMetadata>

--- a/src/proportional-bar/ProportionalBar.js
+++ b/src/proportional-bar/ProportionalBar.js
@@ -51,18 +51,29 @@ const ProportionalBarLegendWrapper = styled.div`
   justify-content: flex-end;
 `;
 
-export default function ProportionalBar({ data, height, showLegend, title }) {
-  const [highlighted, setHighlighted] = useState();
+export default function ProportionalBar({
+  data,
+  height,
+  highlighted: externalHighlighted,
+  setHighlighted: setExternalHighlighted,
+  showLegend,
+  title,
+}) {
+  const [localHighlighted, setLocalHighlighted] = useState();
 
   const dataWithPct = getDataWithPct(data);
   const noData = data.length === 0 || sum(data.map(({ value }) => value)) === 0;
+
+  const highlighted = localHighlighted || externalHighlighted;
 
   return (
     <ProportionalBarContainer>
       <ProportionalBarChartWrapper>
         <ResponsiveTooltipController
           pieceHoverAnnotation
-          setHighlighted={setHighlighted}
+          // we don't ever want mark hover to affect other charts
+          // so it can only control the local highlight state
+          setHighlighted={setLocalHighlighted}
         >
           <ResponsiveOrdinalFrame
             baseMarkProps={{
@@ -98,7 +109,9 @@ export default function ProportionalBar({ data, height, showLegend, title }) {
             <ColorLegend
               highlighted={highlighted}
               items={data}
-              setHighlighted={setHighlighted}
+              // legend may cover multiple charts in some layouts,
+              // so it prefers the external highlight when present
+              setHighlighted={setExternalHighlighted || setLocalHighlighted}
             />
           </ProportionalBarLegendWrapper>
         )}
@@ -116,10 +129,14 @@ ProportionalBar.propTypes = {
     })
   ).isRequired,
   height: PropTypes.number.isRequired,
+  highlighted: PropTypes.shape({ label: PropTypes.string.isRequired }),
+  setHighlighted: PropTypes.func,
   showLegend: PropTypes.bool,
   title: PropTypes.node.isRequired,
 };
 
 ProportionalBar.defaultProps = {
+  highlighted: undefined,
+  setHighlighted: undefined,
   showLegend: true,
 };

--- a/src/sentence-types-chart/SentenceTypesChart.js
+++ b/src/sentence-types-chart/SentenceTypesChart.js
@@ -198,13 +198,15 @@ export default function SentenceTypesChart({ data, width }) {
     return null;
   };
 
-  const shouldHighlight = (d) => {
+  const shouldFade = (d) => {
     return (
       highlighted &&
-      (highlighted.id === d.id ||
-        // edges connected to this node
-        (d.source || {}).id === highlighted.id ||
-        (d.target || {}).id === highlighted.id)
+      ((d.id && highlighted.id !== d.id) ||
+        // edges not connected to this node
+        (d.source &&
+          d.source.id !== highlighted.id &&
+          d.target &&
+          d.target.id !== highlighted.id))
     );
   };
 
@@ -223,7 +225,7 @@ export default function SentenceTypesChart({ data, width }) {
             }}
             edges={data}
             edgeStyle={(d) => ({
-              fill: shouldHighlight(d)
+              fill: shouldFade(d)
                 ? THEME.colors.sentencing.hover
                 : `url(#${d.source.id.toLowerCase()}Gradient)`,
             })}
@@ -238,9 +240,7 @@ export default function SentenceTypesChart({ data, width }) {
             nodes={nodes}
             nodeLabels={renderNodeLabel}
             nodeStyle={(d) => ({
-              fill: shouldHighlight(d)
-                ? THEME.colors.sentencing.hover
-                : d.color,
+              fill: shouldFade(d) ? THEME.colors.sentencing.hover : d.color,
             })}
             size={[Math.max(width, MIN_WIDTH), 500]}
           />

--- a/src/single-dimension-viz/SingleDimensionViz.js
+++ b/src/single-dimension-viz/SingleDimensionViz.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import Measure from "react-measure";
 import styled from "styled-components";
 import BubbleChart from "../bubble-chart";
@@ -24,11 +24,14 @@ const BreakdownBarWrapper = styled.div`
 
 function Breakdowns({ data, dimension }) {
   const breakdownHeight = SECTION_HEIGHT / data.size;
+  const [highlighted, setHighlighted] = useState();
   return Array.from(data, ([key, value], i) => (
     <BreakdownBarWrapper key={key} stackOrder={data.size - i}>
       <ProportionalBar
         data={value}
         height={breakdownHeight - GUTTER}
+        highlighted={highlighted}
+        setHighlighted={setHighlighted}
         title={formatDemographicValue(key, dimension)}
         showLegend={i === data.size - 1}
       />

--- a/src/state-county-map/StateCountyMap.js
+++ b/src/state-county-map/StateCountyMap.js
@@ -1,8 +1,9 @@
+import classNames from "classnames";
 import { descending } from "d3-array";
 import { geoAlbers } from "d3-geo";
 import { scaleSqrt } from "d3-scale";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import {
   ComposableMap,
   Geographies,
@@ -14,7 +15,7 @@ import { mesh } from "topojson";
 import AspectRatioWrapper from "../aspect-ratio-wrapper";
 import ndGeography from "../assets/maps/us_nd.json";
 import { DEFAULT_TENANT, TENANTS, TOTAL_KEY } from "../constants";
-import { hoverColor } from "../utils";
+import { highlightFade } from "../utils";
 
 const MAX_MARKER_RADIUS = 19;
 
@@ -42,9 +43,9 @@ const LocationMarker = styled.circle`
   stroke-width: 1.5px;
   transition: fill ${(props) => props.theme.transition.defaultTimeSettings};
 
-  &:hover {
+  &.fade {
     fill: ${(props) =>
-      hoverColor(
+      highlightFade(
         props.selected
           ? props.theme.colors.highlight
           : props.theme.colors.mapMarkers.fill
@@ -97,6 +98,8 @@ export default function StateCountyMap({
     mesh(ndGeography)
   );
 
+  const [hovered, setHovered] = useState();
+
   return (
     <StateCountyMapContainer>
       <AspectRatioWrapper
@@ -132,6 +135,9 @@ export default function StateCountyMap({
               coordinates={[record.long, record.lat]}
             >
               <LocationMarker
+                className={classNames({
+                  fade: hovered && hovered.location !== record.location,
+                })}
                 onClick={(e) => handleLocationClick(e, record)}
                 onKeyPress={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -142,6 +148,10 @@ export default function StateCountyMap({
                   // stop clicks from moving focus to this element
                   e.preventDefault();
                 }}
+                onBlur={() => setHovered()}
+                onFocus={() => setHovered(record)}
+                onMouseOut={() => setHovered()}
+                onMouseOver={() => setHovered(record)}
                 r={markerRadiusScale(record.value)}
                 selected={record.location === currentLocation}
                 tabIndex={0}

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -118,9 +118,9 @@ export const defaultTheme = {
       // unlike other charts, this one has a monochromatic palette with opacity
       incarceration: baseSentencingColor.copy({ opacity: 0.9 }).toString(),
       probation: baseSentencingColor.copy({ opacity: 0.7 }).toString(),
-      both: baseSentencingColor.copy({ opacity: 0.5 }).toString(),
-      target: baseSentencingColor.copy({ opacity: 0.4 }).toString(),
-      hover: baseSentencingColor.toString(),
+      both: baseSentencingColor.copy({ opacity: 0.6 }).toString(),
+      target: baseSentencingColor.copy({ opacity: 0.5 }).toString(),
+      hover: baseSentencingColor.copy({ opacity: 0.2 }).toString(),
     },
     sliderThumb: darkGreen,
     statistic: black,

--- a/src/utils/highlightFade.js
+++ b/src/utils/highlightFade.js
@@ -1,7 +1,7 @@
-import { color as d3Color } from "d3-color";
+import { color } from "d3-color";
 
-export default function highlightFade(color) {
-  const fadedColor = d3Color(color);
+export default function highlightFade(baseColor) {
+  const fadedColor = color(baseColor);
   fadedColor.opacity = 0.3;
   return fadedColor.toString();
 }

--- a/src/utils/highlightFade.js
+++ b/src/utils/highlightFade.js
@@ -2,6 +2,6 @@ import { color } from "d3-color";
 
 export default function highlightFade(baseColor) {
   const fadedColor = color(baseColor);
-  fadedColor.opacity = 0.3;
+  fadedColor.opacity = 0.45;
   return fadedColor.toString();
 }

--- a/src/utils/highlightFade.js
+++ b/src/utils/highlightFade.js
@@ -1,0 +1,7 @@
+import { color as d3Color } from "d3-color";
+
+export default function highlightFade(color) {
+  const fadedColor = d3Color(color);
+  fadedColor.opacity = 0.3;
+  return fadedColor.toString();
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,7 @@ export { default as formatDemographicValue } from "./formatDemographicValue";
 export { default as getDataWithPct } from "./getDataWithPct";
 export { default as getDimensionalBreakdown } from "./getDimensionalBreakdown";
 export { default as getSiteTitle } from "./getSiteTitle";
+export { default as highlightFade } from "./highlightFade";
 export { default as hoverColor } from "./hoverColor";
 export { default as judicialDistrictTotals } from "./judicialDistrictTotals";
 export { default as locationTotals } from "./locationTotals";


### PR DESCRIPTION
## Description of the change

Hovering on a chart legend now highlights the corresponding mark in the related chart (or charts, in the case of collections of related proportional bar charts for demographic breakdowns). 

In addition, most charts have a new hover and highlight style; rather than darkening the target mark slightly, we fade all of the non-target marks significantly. This provides greater contrast with less color distortion. All charts, whether or not they have legends, now employ this style. (The exception is district maps, which already employed a different hover style; I have left those as is.)

![legend highlight](https://user-images.githubusercontent.com/5385319/92650465-65cfe000-f2a1-11ea-992b-83f2e077d6d6.gif)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #173 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
