### PR TITLE
Patch missing data with zeroes in population over time charts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,19 +21,17 @@ jobs:
 
       - name: Lint
         run: yarn run lint
-  # uncomment to enable running in CI
-  # it is disabled for now because our use of untracked test data files breaks it
-  # test-js:
-  #   name: test JS
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: actions/setup-node@v1.1.0
-  #       with:
-  #         node-version: "10.x"
-  #     # https://github.com/marketplace/actions/yarn-install-cache
-  #     - uses: c-hive/gha-yarn-cache@v1
-  #     - name: Install Dependencies
-  #       run: yarn install
-  #     - name: Test
-  #       run: yarn run test
+  test-js:
+    name: test JS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1.1.0
+        with:
+          node-version: "10.x"
+      # https://github.com/marketplace/actions/yarn-install-cache
+      - uses: c-hive/gha-yarn-cache@v1
+      - name: Install Dependencies
+        run: yarn install
+      - name: Test
+        run: yarn run test

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": ">=4",
+    "jest-date-mock": "^1.0.8",
     "lint-staged": ">=10",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5"

--- a/server/core/demo_data/supervision_population_by_month_by_demographics.json
+++ b/server/core/demo_data/supervision_population_by_month_by_demographics.json
@@ -137,8 +137,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "40", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "45", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "37", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "61", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "72", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "110", "population_date": "2000-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "175", "population_date": "2000-12-01", "supervision_type": "PAROLE"}
@@ -163,8 +162,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "36", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "42", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "34", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "35", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "21", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "56", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "66", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "102", "population_date": "2001-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "177", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
@@ -176,8 +174,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "38", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "44", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "37", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "70", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "107", "population_date": "2001-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "170", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
@@ -189,8 +186,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "37", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "42", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "34", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "36", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "21", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "57", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "67", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "103", "population_date": "2001-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "176", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
@@ -202,8 +198,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "38", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "44", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "37", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "69", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "107", "population_date": "2001-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "183", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
@@ -215,8 +210,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "40", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "45", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "37", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "61", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "72", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "111", "population_date": "2001-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "176", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
@@ -228,8 +222,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "38", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "44", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "37", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "69", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "107", "population_date": "2001-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "167", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
@@ -241,8 +234,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "36", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "41", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "34", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "35", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "21", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "56", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "66", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "101", "population_date": "2001-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "179", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
@@ -254,8 +246,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "39", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "44", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "60", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "71", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "108", "population_date": "2001-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "178", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
@@ -267,8 +258,7 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "AMERICAN_INDIAN_ALASKAN_NATIVE", "population_count": "39", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "44", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "37", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
+{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "70", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "108", "population_date": "2001-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "186", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
@@ -281,7 +271,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "46", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "38", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "39", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "73", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "113", "population_date": "2001-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "181", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
@@ -294,7 +283,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "45", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "37", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "71", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "110", "population_date": "2001-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "192", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
@@ -307,7 +295,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "47", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "39", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "40", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "24", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "76", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "116", "population_date": "2001-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "190", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
@@ -320,7 +307,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "47", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "38", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "40", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "24", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "75", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "115", "population_date": "2002-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "175", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
@@ -333,7 +319,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "43", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "35", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "37", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "69", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "106", "population_date": "2002-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "182", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
@@ -346,7 +331,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "45", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "37", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "72", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "110", "population_date": "2002-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "187", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
@@ -359,7 +343,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "46", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "38", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "39", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "74", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "113", "population_date": "2002-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "172", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
@@ -372,7 +355,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "43", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "35", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "36", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "21", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "68", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "104", "population_date": "2002-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "180", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
@@ -385,7 +367,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "45", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "36", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "38", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "22", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "71", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "109", "population_date": "2002-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "184", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
@@ -398,7 +379,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "46", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "37", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "39", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "73", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "111", "population_date": "2002-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "188", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
@@ -411,7 +391,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "46", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "38", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "39", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "23", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "74", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "114", "population_date": "2002-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "190", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
@@ -424,7 +403,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "47", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "38", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "40", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "24", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "75", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "115", "population_date": "2002-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "217", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
@@ -437,7 +415,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "54", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "44", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "46", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "27", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "86", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "131", "population_date": "2002-10-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "214", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
@@ -450,7 +427,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "53", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "43", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "45", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "26", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "84", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "130", "population_date": "2002-11-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "222", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
@@ -463,7 +439,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "55", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "45", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "47", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "27", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "88", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "134", "population_date": "2002-12-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "214", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
@@ -476,7 +451,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "53", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "43", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "45", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "26", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "84", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "130", "population_date": "2003-01-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "214", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
@@ -489,7 +463,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "53", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "43", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "45", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "26", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "84", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "130", "population_date": "2003-02-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "241", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
@@ -502,7 +475,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "60", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "49", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "51", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "30", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "95", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "146", "population_date": "2003-03-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "258", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
@@ -515,7 +487,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "64", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "52", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "54", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "32", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "102", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "156", "population_date": "2003-04-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "288", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
@@ -528,7 +499,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "71", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "58", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "60", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "36", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "114", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "174", "population_date": "2003-05-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "281", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
@@ -541,7 +511,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "70", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "57", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "35", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "111", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "170", "population_date": "2003-06-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "285", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
@@ -554,7 +523,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "70", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "58", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "60", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "35", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "112", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "173", "population_date": "2003-07-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "309", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
@@ -567,7 +535,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "76", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "62", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "65", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "38", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "122", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "187", "population_date": "2003-08-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "281", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
@@ -580,7 +547,6 @@
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "BLACK", "population_count": "70", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "HISPANIC", "population_count": "57", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "WHITE", "population_count": "59", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
-{"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "OTHER", "population_count": "35", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "MALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "111", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "FEMALE", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "170", "population_date": "2003-09-01", "supervision_type": "PAROLE"}
 {"state_code": "US_ND", "gender": "ALL", "age_bucket": "ALL", "race_or_ethnicity": "ALL", "population_count": "281", "population_date": "2003-10-01", "supervision_type": "PAROLE"}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,3 +5,5 @@
 import "@testing-library/jest-dom/extend-expect";
 // Jest may require this for e.g. regenerator runtime
 import "react-app-polyfill/stable";
+// lets us control date in test environment for date-dependent features
+import "jest-date-mock";

--- a/src/utils/addEmptyMonthsToData.js
+++ b/src/utils/addEmptyMonthsToData.js
@@ -1,18 +1,36 @@
 import { subMonths, eachMonthOfInterval } from "date-fns";
+
 /**
  * Returns a new list of data points consisting of the given data points and new
  * data points appended for any month in the last `monthCount` number of months
  * that is missing data, where the value for the `valueKey` property is `emptyValue`.
- * NOTE: copied and lightly adapted from pulse-dashboard
+ * If `dateField` is passed, all values of that key should be ISO 8601 date strings.
+ * If `extraFields` is passed, it should be an object whose properties will be included
+ * in all appended records.
+ * Originally adapted from pulse-dashboard.
  */
 export default function addEmptyMonthsToData({
   dataPoints,
   monthCount,
   valueKey,
   emptyValue,
+  dateField,
+  extraFields,
 }) {
+  // dateSource must be an array of {year: number, month: number (1-indexed)}
+  let dateSource = dataPoints;
+
+  // if we have been given a date field, extract year and month from it
+  if (dateField) {
+    dateSource = dataPoints.map((record) => {
+      const dateString = record[dateField];
+      const [year, month] = dateString.split("-").map(Number);
+      return { year, month };
+    });
+  }
+
   const representedMonths = {};
-  dataPoints.forEach(({ year, month }) => {
+  dateSource.forEach(({ year, month }) => {
     if (!representedMonths[year]) {
       representedMonths[year] = {};
     }
@@ -28,10 +46,17 @@ export default function addEmptyMonthsToData({
     // months are 1-indexed in our data source
     const month = monthDate.getMonth() + 1;
     if (!representedMonths[year] || !representedMonths[year][month]) {
-      const monthData = {
-        year: year.toString(),
-        month: month.toString(),
-      };
+      const monthData = { ...extraFields };
+
+      // if we read from date field, write to date field
+      if (dateField) {
+        monthData[dateField] = `${year}-${`${month}`.padStart(2, "0")}-01`;
+      } else {
+        Object.assign(monthData, {
+          year: year.toString(),
+          month: month.toString(),
+        });
+      }
       monthData[valueKey] = emptyValue;
       newDataPoints.push(monthData);
     }

--- a/src/utils/addEmptyMonthsToData.js
+++ b/src/utils/addEmptyMonthsToData.js
@@ -4,9 +4,7 @@ import { subMonths, eachMonthOfInterval } from "date-fns";
  * Returns a new list of data points consisting of the given data points and new
  * data points appended for any month in the last `monthCount` number of months
  * that is missing data, where the value for the `valueKey` property is `emptyValue`.
- * If `dateField` is passed, all values of that key should be ISO 8601 date strings.
- * If `extraFields` is passed, it should be an object whose properties will be included
- * in all appended records.
+ * If `dateField` is passed, all values of that key should be Date objects.
  * Originally adapted from pulse-dashboard.
  */
 export default function addEmptyMonthsToData({
@@ -15,7 +13,6 @@ export default function addEmptyMonthsToData({
   valueKey,
   emptyValue,
   dateField,
-  extraFields,
 }) {
   // dateSource must be an array of {year: number, month: number (1-indexed)}
   let dateSource = dataPoints;
@@ -46,7 +43,7 @@ export default function addEmptyMonthsToData({
     // months are 1-indexed in our data source
     const month = monthDate.getMonth() + 1;
     if (!representedMonths[year] || !representedMonths[year][month]) {
-      const monthData = { ...extraFields };
+      const monthData = {};
 
       // if we read from date field, write to date field
       if (dateField) {

--- a/src/utils/addEmptyMonthsToData.test.js
+++ b/src/utils/addEmptyMonthsToData.test.js
@@ -1,0 +1,129 @@
+import { advanceTo, clear } from "jest-date-mock";
+import addEmptyMonthsToData from "./addEmptyMonthsToData";
+
+describe("function", () => {
+  // mocking Date because this function always operates relative to the current day
+  const mockToday = new Date(2020, 2, 15);
+  beforeEach(() => {
+    advanceTo(mockToday);
+  });
+  afterEach(() => clear());
+
+  test("patches missing records with proper year and month", () => {
+    // note that data are not in chronological order; it shouldn't matter
+    const missingRecords = [
+      {
+        year: "2020",
+        month: "2",
+        test_metric: "0",
+      },
+      {
+        year: "2019",
+        month: "11",
+        test_metric: "0",
+      },
+    ];
+    const dataWithGaps = [
+      {
+        year: "2020",
+        month: "1",
+        test_metric: "3",
+      },
+      {
+        year: "2019",
+        month: "12",
+        test_metric: "5",
+      },
+      {
+        year: "2020",
+        month: "3",
+        test_metric: "8",
+      },
+    ];
+
+    const patchedData = addEmptyMonthsToData({
+      dataPoints: dataWithGaps,
+      monthCount: 5,
+      valueKey: "test_metric",
+      emptyValue: "0",
+    });
+
+    const expectedData = [...dataWithGaps, ...missingRecords];
+
+    // complete but not sorted!
+    expect(patchedData).toEqual(expect.arrayContaining(expectedData));
+    // no extraneous items
+    expect(patchedData.length).toEqual(expectedData.length);
+  });
+
+  test("patches data with missing exact dates", () => {
+    // note that data are not in chronological order; it shouldn't matter
+    const missingRecords = [
+      {
+        metric_date: "2020-02-01",
+        test_metric: "0",
+      },
+      {
+        metric_date: "2019-11-01",
+        test_metric: "0",
+      },
+    ];
+    const dataWithGaps = [
+      {
+        metric_date: "2020-01-01",
+        test_metric: "3",
+      },
+      {
+        metric_date: "2019-12-01",
+        test_metric: "5",
+      },
+      {
+        metric_date: "2020-03-01",
+        test_metric: "8",
+      },
+    ];
+
+    const patchedData = addEmptyMonthsToData({
+      dataPoints: dataWithGaps,
+      monthCount: 5,
+      valueKey: "test_metric",
+      emptyValue: "0",
+      dateField: "metric_date",
+    });
+
+    const expectedData = [...dataWithGaps, ...missingRecords];
+
+    // complete but not sorted!
+    expect(patchedData).toEqual(expect.arrayContaining(expectedData));
+    // no extraneous items
+    expect(patchedData.length).toEqual(expectedData.length);
+  });
+
+  test("includes extra fields in patched records", () => {
+    const extraFields = {
+      important_extra_field: "blerg",
+      additional_important_extra_field: "also blerg",
+    };
+    const dataWithGaps = [
+      {
+        year: "2020",
+        month: "3",
+        test_metric: "8",
+        ...extraFields,
+      },
+    ];
+
+    const patchedData = addEmptyMonthsToData({
+      dataPoints: dataWithGaps,
+      monthCount: 5,
+      valueKey: "test_metric",
+      emptyValue: "0",
+      extraFields,
+    });
+
+    expect(patchedData.length).toEqual(5);
+    patchedData.forEach((record) => {
+      expect(record).toEqual(expect.objectContaining(extraFields));
+    });
+  });
+});

--- a/src/utils/addEmptyMonthsToData.test.js
+++ b/src/utils/addEmptyMonthsToData.test.js
@@ -98,32 +98,4 @@ describe("function", () => {
     // no extraneous items
     expect(patchedData.length).toEqual(expectedData.length);
   });
-
-  test("includes extra fields in patched records", () => {
-    const extraFields = {
-      important_extra_field: "blerg",
-      additional_important_extra_field: "also blerg",
-    };
-    const dataWithGaps = [
-      {
-        year: "2020",
-        month: "3",
-        test_metric: "8",
-        ...extraFields,
-      },
-    ];
-
-    const patchedData = addEmptyMonthsToData({
-      dataPoints: dataWithGaps,
-      monthCount: 5,
-      valueKey: "test_metric",
-      emptyValue: "0",
-      extraFields,
-    });
-
-    expect(patchedData.length).toEqual(5);
-    patchedData.forEach((record) => {
-      expect(record).toEqual(expect.objectContaining(extraFields));
-    });
-  });
 });

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -9,6 +9,7 @@ import BaseChartWrapper from "../chart-wrapper";
 import ResponsiveTooltipController from "../responsive-tooltip-controller";
 import { THEME } from "../theme";
 import {
+  addEmptyMonthsToData,
   formatAsNumber,
   getDataWithPct,
   highlightFade,
@@ -22,6 +23,7 @@ import {
 } from "../constants";
 import ColorLegend from "../color-legend";
 
+const EXPECTED_MONTHS = 240; // 20 years
 const MARGIN = { bottom: 40, left: 56, right: 8, top: 8 };
 
 const Wrapper = styled.div``;
@@ -57,7 +59,6 @@ const ChartWrapper = styled(BaseChartWrapper)`
   }
 `;
 
-const getRecordDate = (record) => parseISO(record.population_date);
 const getDateLabel = (date) => format(date, "MMM d y");
 
 export default function VizPopulationOverTime({
@@ -85,14 +86,19 @@ export default function VizPopulationOverTime({
             value === TOTAL_KEY
               ? THEME.colors.populationTimeseriesTotal
               : THEME.colors[dimension][value],
-          coordinates: dataForDimension
-            .filter((record) =>
+          coordinates: addEmptyMonthsToData({
+            dataPoints: dataForDimension.filter((record) =>
               value === TOTAL_KEY
                 ? true
                 : record[DIMENSION_DATA_KEYS[dimension]] === value
-            )
+            ),
+            monthCount: EXPECTED_MONTHS,
+            valueKey: "population_count",
+            emptyValue: "0",
+            dateField: "population_date",
+          })
             .map((record) => ({
-              time: getRecordDate(record),
+              time: parseISO(record.population_date),
               population: Number(record.population_count),
             }))
             .sort((a, b) => ascending(a.time, b.time)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,6 +7351,11 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
+jest-date-mock@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/jest-date-mock/-/jest-date-mock-1.0.8.tgz#13468c0352c5a3614c6b356dbc6b88eb37d9e0b3"
+  integrity sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==
+
 jest-diff@^24.0.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"


### PR DESCRIPTION
## Description of the change

We already had a function for filling in gaps in monthly data; this updates it to handle records with exact dates as well as year+month aggregates, then applies it to the data for the population-over-time charts. This functionality is most evident on the Parole page (against staging data, but also against demo data because I introduced some missing rows to that fixture for verification purposes).

I wrote a test for said function before refactoring it, bringing us to a grand total of one (1) automated test for this application! In celebration I have re-enabled CI runs for Jest.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #202

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
