### PR TITLE
Windowed view for population over time

### DIFF
--- a/src/chart-wrapper/ChartWrapper.js
+++ b/src/chart-wrapper/ChartWrapper.js
@@ -26,6 +26,14 @@ const ChartWrapper = styled.div`
     .xyframe-matte {
       fill: ${(props) => props.theme.colors.background};
     }
+
+    .xybrush {
+      .selection {
+        fill: ${(props) => props.theme.colors.timeWindowFill};
+        fill-opacity: 0.2;
+        stroke: ${(props) => props.theme.colors.timeWindowStroke};
+      }
+    }
   }
 `;
 

--- a/src/chart-wrapper/ChartWrapper.js
+++ b/src/chart-wrapper/ChartWrapper.js
@@ -22,6 +22,10 @@ const ChartWrapper = styled.div`
       fill: ${(props) => props.theme.colors.heading};
       font-size: 16px;
     }
+
+    .xyframe-matte {
+      fill: ${(props) => props.theme.colors.background};
+    }
   }
 `;
 

--- a/src/controls/Dropdown.js
+++ b/src/controls/Dropdown.js
@@ -130,14 +130,16 @@ export default function Dropdown({
             <MenuPopover>
               <DropdownMenu>
                 <MenuItems>
-                  {options.map((option) => (
-                    <MenuItem
-                      key={option.id}
-                      onSelect={() => setCurrentOptionId(option.id)}
-                    >
-                      {option.label}
-                    </MenuItem>
-                  ))}
+                  {options
+                    .filter((option) => !option.hidden)
+                    .map((option) => (
+                      <MenuItem
+                        key={option.id}
+                        onSelect={() => setCurrentOptionId(option.id)}
+                      >
+                        {option.label}
+                      </MenuItem>
+                    ))}
                 </MenuItems>
               </DropdownMenu>
             </MenuPopover>
@@ -153,7 +155,7 @@ export default function Dropdown({
               onChange={(event) => setCurrentOptionId(event.target.value)}
             >
               {options.map((opt) => (
-                <option key={opt.id} value={opt.id}>
+                <option key={opt.id} value={opt.id} hidden={opt.hidden}>
                   {opt.label}
                 </option>
               ))}

--- a/src/controls/TwoYearRangeControl.js
+++ b/src/controls/TwoYearRangeControl.js
@@ -14,7 +14,7 @@ const TwoYearRangeControl = ({ onChange, value }) => {
         { id: "10", label: "10 years" },
         { id: "5", label: "5 years" },
         { id: "1", label: "1 year" },
-        { id: CUSTOM_ID, label: "Custom" },
+        { id: CUSTOM_ID, label: "Custom", hidden: true },
       ]}
       selectedId={value}
     />

--- a/src/controls/TwoYearRangeControl.js
+++ b/src/controls/TwoYearRangeControl.js
@@ -1,0 +1,33 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Dropdown from "./Dropdown";
+
+export const CUSTOM_ID = "custom";
+
+const TwoYearRangeControl = ({ onChange, value }) => {
+  return (
+    <Dropdown
+      label="Range"
+      onChange={onChange}
+      options={[
+        { id: "20", label: "20 years" },
+        { id: "10", label: "10 years" },
+        { id: "5", label: "5 years" },
+        { id: "1", label: "1 year" },
+        { id: CUSTOM_ID, label: "Custom" },
+      ]}
+      selectedId={value}
+    />
+  );
+};
+
+TwoYearRangeControl.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string,
+};
+
+TwoYearRangeControl.defaultProps = {
+  value: undefined,
+};
+
+export default TwoYearRangeControl;

--- a/src/controls/shared.js
+++ b/src/controls/shared.js
@@ -28,4 +28,5 @@ export const ControlValue = styled(PillValue)``;
 export const DropdownOptionType = PropTypes.shape({
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  hidden: PropTypes.bool,
 });

--- a/src/detail-page/DetailPage.js
+++ b/src/detail-page/DetailPage.js
@@ -14,6 +14,7 @@ import {
   TOTAL_KEY,
 } from "../constants";
 import { DimensionControl, MonthControl, LocationControl } from "../controls";
+import TwoYearRangeControl from "../controls/TwoYearRangeControl";
 import { HeadingTitle, HeadingDescription } from "../heading";
 import { THEME } from "../theme";
 
@@ -107,6 +108,7 @@ function DetailSection({
   showLocationControl,
   locationControlLabel,
   showMonthControl,
+  showTimeRangeControl,
   otherControls,
   stickyOffset,
   VizComponent,
@@ -118,6 +120,8 @@ function DetailSection({
   // a viz component that wants to use months will be responsible
   // for parsing its data and updating this value
   const [monthList, setMonthList] = useState();
+
+  const [timeRangeId, setTimeRangeId] = useState();
 
   let initialLocationList;
   if (showLocationControl && vizData.locations) {
@@ -153,6 +157,12 @@ function DetailSection({
                 {showMonthControl && monthList && (
                   <MonthControl months={monthList} onChange={setMonth} />
                 )}
+                {showTimeRangeControl && (
+                  <TwoYearRangeControl
+                    onChange={setTimeRangeId}
+                    value={timeRangeId}
+                  />
+                )}
                 {
                   // we need both a flag and data to enable location control
                   showLocationControl && locationList && (
@@ -183,7 +193,14 @@ function DetailSection({
           >
             <VizComponent
               data={vizData}
-              {...{ dimension, month, locationId, setMonthList }}
+              {...{
+                dimension,
+                locationId,
+                month,
+                setMonthList,
+                setTimeRangeId,
+                timeRangeId,
+              }}
               onLocationClick={setLocationId}
             />
           </ErrorBoundary>
@@ -199,6 +216,7 @@ DetailSection.propTypes = {
   showDimensionControl: PropTypes.bool,
   showMonthControl: PropTypes.bool,
   showLocationControl: PropTypes.bool,
+  showTimeRangeControl: PropTypes.bool,
   locationControlLabel: PropTypes.string,
   otherControls: PropTypes.node,
   stickyOffset: PropTypes.number,
@@ -212,6 +230,7 @@ DetailSection.defaultProps = {
   showDimensionControl: false,
   showMonthControl: false,
   showLocationControl: false,
+  showTimeRangeControl: false,
   locationControlLabel: "Location",
   otherControls: null,
   stickyOffset: 0,

--- a/src/page-parole/PageParole.js
+++ b/src/page-parole/PageParole.js
@@ -77,6 +77,7 @@ export default function PageParole() {
         </>
       ),
       showDimensionControl: true,
+      showTimeRangeControl: true,
       VizComponent: VizPopulationOverTime,
       vizData: {
         populationOverTime: apiData.supervision_population_by_month_by_demographics.filter(

--- a/src/page-prison/PagePrison.js
+++ b/src/page-prison/PagePrison.js
@@ -64,6 +64,7 @@ export default function PagePrison() {
         </>
       ),
       showDimensionControl: true,
+      showTimeRangeControl: true,
       VizComponent: VizPopulationOverTime,
       vizData: {
         populationOverTime:

--- a/src/page-probation/PageProbation.js
+++ b/src/page-probation/PageProbation.js
@@ -71,6 +71,7 @@ export default function PageProbation() {
         </>
       ),
       showDimensionControl: true,
+      showTimeRangeControl: true,
       VizComponent: VizPopulationOverTime,
       vizData: {
         populationOverTime: apiData.supervision_population_by_month_by_demographics.filter(

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -125,6 +125,8 @@ export const defaultTheme = {
     },
     sliderThumb: darkGreen,
     statistic: black,
+    timeWindowFill: charcoal,
+    timeWindowStroke: brightGreen,
     tooltipBackground: black,
     violationReasons: assignDataVizColors(
       Array.from(VIOLATION_COUNT_KEYS.keys())
@@ -187,6 +189,7 @@ const northDakotaTheme = {
       selected: ndColors.brandOrange,
     },
     sliderThumb: ndColors.brandTeal,
+    timeWindowStroke: ndColors.brandOrange,
   },
 };
 

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -179,8 +179,10 @@ export default function VizPopulationOverTime({
 
 VizPopulationOverTime.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  defaultRangeStart: PropTypes.instanceOf(Date).isRequired,
+  defaultRangeStart: PropTypes.instanceOf(Date),
   setTimeRangeId: PropTypes.func.isRequired,
 };
 
-VizPopulationOverTime.defaultProps = {};
+VizPopulationOverTime.defaultProps = {
+  defaultRangeStart: undefined,
+};

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -65,8 +65,15 @@ export default function VizPopulationOverTime({
 
   useEffect(() => {
     if (defaultRangeStart) {
+      // maintain sanity here by requiring start to precede end
+      const thisMonth = startOfMonth(new Date());
+      if (defaultRangeStart > thisMonth) {
+        throw new RangeError(
+          "Start of time range must precede the current month."
+        );
+      }
       setDateRangeStart(defaultRangeStart);
-      setDateRangeEnd(startOfMonth(new Date()));
+      setDateRangeEnd(thisMonth);
     }
   }, [defaultRangeStart]);
 

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -1,3 +1,4 @@
+import useBreakpoint from "@w11r/use-breakpoint";
 import { scaleTime } from "d3-scale";
 import { isEqual, format, startOfMonth } from "date-fns";
 import PropTypes from "prop-types";
@@ -12,7 +13,7 @@ import { formatAsNumber, getDataWithPct, highlightFade } from "../utils";
 import ColorLegend from "../color-legend";
 import { CUSTOM_ID } from "../controls/TwoYearRangeControl";
 
-const MARGIN = { bottom: 40, left: 56, right: 8, top: 8 };
+const MARGIN = { bottom: 65, left: 56, right: 8, top: 8 };
 
 const Wrapper = styled.div``;
 
@@ -37,7 +38,8 @@ const ChartWrapper = styled(BaseChartWrapper)`
 
     .axis.x {
       text.axis-label {
-        transform: rotate(-45deg);
+        text-anchor: end;
+        transform: translate(6px, -14px) rotate(-45deg);
       }
     }
   }
@@ -59,6 +61,7 @@ export default function VizPopulationOverTime({
   const [highlighted, setHighlighted] = useState();
   const [dateRangeStart, setDateRangeStart] = useState();
   const [dateRangeEnd, setDateRangeEnd] = useState();
+  const { isMobile } = useBreakpoint();
 
   useEffect(() => {
     if (defaultRangeStart) {
@@ -118,8 +121,10 @@ export default function VizPopulationOverTime({
                   },
                   {
                     orient: "bottom",
-                    tickFormat: (time) => format(time, "y"),
+                    tickFormat: (time) =>
+                      time.getDate() === 1 ? format(time, "MMM y") : null,
                     tickLineGenerator: () => null,
+                    ticks: isMobile ? 5 : 10,
                   },
                 ]}
                 baseMarkProps={BASE_MARK_PROPS}
@@ -150,6 +155,7 @@ export default function VizPopulationOverTime({
                     }
                   },
                   margin: { ...MARGIN, bottom: 0 },
+                  size: [width, 80],
                   xBrushable: true,
                   xBrushExtent: [dateRangeStart, dateRangeEnd],
                   yBrushable: false,

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -10,6 +10,7 @@ import ResponsiveTooltipController from "../responsive-tooltip-controller";
 import { THEME } from "../theme";
 import { formatAsNumber, getDataWithPct, highlightFade } from "../utils";
 import ColorLegend from "../color-legend";
+import { CUSTOM_ID } from "../controls/TwoYearRangeControl";
 
 const MARGIN = { bottom: 40, left: 56, right: 8, top: 8 };
 
@@ -53,7 +54,7 @@ const BASE_MARK_PROPS = {
 export default function VizPopulationOverTime({
   data,
   defaultRangeStart,
-  overrideDefaultRange,
+  setTimeRangeId,
 }) {
   const [highlighted, setHighlighted] = useState();
   const [dateRangeStart, setDateRangeStart] = useState();
@@ -141,7 +142,7 @@ export default function VizPopulationOverTime({
                     const [start, end] = brushExtent || [];
                     if (start && end) {
                       if (isNewRange({ start, end })) {
-                        overrideDefaultRange();
+                        setTimeRangeId(CUSTOM_ID);
                       }
 
                       setDateRangeStart(new Date(start));
@@ -179,7 +180,7 @@ export default function VizPopulationOverTime({
 VizPopulationOverTime.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   defaultRangeStart: PropTypes.instanceOf(Date).isRequired,
-  overrideDefaultRange: PropTypes.func.isRequired,
+  setTimeRangeId: PropTypes.func.isRequired,
 };
 
 VizPopulationOverTime.defaultProps = {};

--- a/src/viz-population-over-time/VizPopulationOverTimeContainer.js
+++ b/src/viz-population-over-time/VizPopulationOverTimeContainer.js
@@ -15,8 +15,10 @@ import VizPopulationOverTime from "./VizPopulationOverTime";
 const EXPECTED_MONTHS = 240; // 20 years
 
 export default function VizPopulationOverTimeContainer({
-  data: { populationOverTime, selectedTimeRange, ...passThruProps },
+  data: { populationOverTime },
   dimension,
+  timeRangeId,
+  ...passThruProps
 }) {
   const dataForDimension = useMemo(() => {
     if (!dimension) return null;
@@ -58,18 +60,18 @@ export default function VizPopulationOverTimeContainer({
   }, [dataForDimension, dimension]);
 
   const defaultRangeStart = useMemo(() => {
-    if (selectedTimeRange === "custom") return undefined;
+    if (!timeRangeId || timeRangeId === "custom") return undefined;
 
     const thisMonth = startOfMonth(new Date());
     const diff = {
-      years: Number(selectedTimeRange),
+      years: Number(timeRangeId),
       // make the range start-exclusive to correct for an off-by-one error
       months: -1,
     };
     return sub(thisMonth, diff);
-  }, [selectedTimeRange]);
+  }, [timeRangeId]);
 
-  if (!dimension) return null;
+  if (!dimension || !timeRangeId) return null;
 
   return (
     <VizPopulationOverTime
@@ -83,11 +85,12 @@ export default function VizPopulationOverTimeContainer({
 VizPopulationOverTimeContainer.propTypes = {
   data: PropTypes.shape({
     populationOverTime: PropTypes.arrayOf(PropTypes.object).isRequired,
-    selectedTimeRange: PropTypes.string.isRequired,
   }).isRequired,
+  timeRangeId: PropTypes.string,
   dimension: PropTypes.string,
 };
 
 VizPopulationOverTimeContainer.defaultProps = {
   dimension: undefined,
+  timeRangeId: undefined,
 };

--- a/src/viz-population-over-time/VizPopulationOverTimeContainer.js
+++ b/src/viz-population-over-time/VizPopulationOverTimeContainer.js
@@ -1,5 +1,5 @@
 import { ascending } from "d3-array";
-import { parseISO } from "date-fns";
+import { parseISO, startOfMonth, sub } from "date-fns";
 import PropTypes from "prop-types";
 import React, { useMemo } from "react";
 import { THEME } from "../theme";
@@ -15,7 +15,7 @@ import VizPopulationOverTime from "./VizPopulationOverTime";
 const EXPECTED_MONTHS = 240; // 20 years
 
 export default function VizPopulationOverTimeContainer({
-  data: { populationOverTime },
+  data: { populationOverTime, selectedTimeRange, ...passThruProps },
   dimension,
 }) {
   const dataForDimension = useMemo(() => {
@@ -57,9 +57,27 @@ export default function VizPopulationOverTimeContainer({
     );
   }, [dataForDimension, dimension]);
 
+  const defaultRangeStart = useMemo(() => {
+    if (selectedTimeRange === "custom") return undefined;
+
+    const thisMonth = startOfMonth(new Date());
+    const diff = {
+      years: Number(selectedTimeRange),
+      // make the range start-exclusive to correct for an off-by-one error
+      months: -1,
+    };
+    return sub(thisMonth, diff);
+  }, [selectedTimeRange]);
+
   if (!dimension) return null;
 
-  return <VizPopulationOverTime data={chartData} />;
+  return (
+    <VizPopulationOverTime
+      data={chartData}
+      defaultRangeStart={defaultRangeStart}
+      {...passThruProps}
+    />
+  );
 }
 
 VizPopulationOverTimeContainer.propTypes = {

--- a/src/viz-population-over-time/VizPopulationOverTimeContainer.js
+++ b/src/viz-population-over-time/VizPopulationOverTimeContainer.js
@@ -1,0 +1,75 @@
+import { ascending } from "d3-array";
+import { parseISO } from "date-fns";
+import PropTypes from "prop-types";
+import React, { useMemo } from "react";
+import { THEME } from "../theme";
+import { addEmptyMonthsToData, recordIsTotalByDimension } from "../utils";
+import {
+  DEMOGRAPHIC_UNKNOWN,
+  DIMENSION_MAPPINGS,
+  DIMENSION_DATA_KEYS,
+  TOTAL_KEY,
+} from "../constants";
+import VizPopulationOverTime from "./VizPopulationOverTime";
+
+const EXPECTED_MONTHS = 240; // 20 years
+
+export default function VizPopulationOverTimeContainer({
+  data: { populationOverTime },
+  dimension,
+}) {
+  const dataForDimension = useMemo(() => {
+    if (!dimension) return null;
+    return populationOverTime.filter(recordIsTotalByDimension(dimension));
+  }, [dimension, populationOverTime]);
+
+  const chartData = useMemo(() => {
+    if (!dimension) return null;
+
+    return (
+      Array.from(DIMENSION_MAPPINGS.get(dimension))
+        // don't need to include unknown in this chart;
+        // they are minimal to nonexistent in historical data and make the legend confusing
+        .filter(([value]) => value !== DEMOGRAPHIC_UNKNOWN)
+        .map(([value, label]) => ({
+          label,
+          color:
+            value === TOTAL_KEY
+              ? THEME.colors.populationTimeseriesTotal
+              : THEME.colors[dimension][value],
+          coordinates: addEmptyMonthsToData({
+            dataPoints: dataForDimension.filter((record) =>
+              value === TOTAL_KEY
+                ? true
+                : record[DIMENSION_DATA_KEYS[dimension]] === value
+            ),
+            monthCount: EXPECTED_MONTHS,
+            valueKey: "population_count",
+            emptyValue: "0",
+            dateField: "population_date",
+          })
+            .map((record) => ({
+              time: parseISO(record.population_date),
+              population: Number(record.population_count),
+            }))
+            .sort((a, b) => ascending(a.time, b.time)),
+        }))
+    );
+  }, [dataForDimension, dimension]);
+
+  if (!dimension) return null;
+
+  return <VizPopulationOverTime data={chartData} />;
+}
+
+VizPopulationOverTimeContainer.propTypes = {
+  data: PropTypes.shape({
+    populationOverTime: PropTypes.arrayOf(PropTypes.object).isRequired,
+    selectedTimeRange: PropTypes.string.isRequired,
+  }).isRequired,
+  dimension: PropTypes.string,
+};
+
+VizPopulationOverTimeContainer.defaultProps = {
+  dimension: undefined,
+};

--- a/src/viz-population-over-time/index.js
+++ b/src/viz-population-over-time/index.js
@@ -1,1 +1,1 @@
-export { default } from "./VizPopulationOverTime";
+export { default } from "./VizPopulationOverTimeContainer";


### PR DESCRIPTION
## Description of the change

Allows you to "zoom in" to smaller time windows in the population over time charts, using a combination of pre-defined windows controlled in a dropdown menu and brush-and-link interaction for selecting arbitrary windows. (This feature is native to Semiotic so this was mostly a matter of state management.)

<img width="1196" alt="Screen Shot 2020-09-24 at 1 31 23 PM" src="https://user-images.githubusercontent.com/5385319/94198902-ddd70200-fe6c-11ea-8f3f-9e12aed23567.png">

Some random non-obvious things to note: 

- Semiotic's "minimap" frame didn't seem to handle the responsive width feature well, so I switched the chart component to explicitly measuring its container size with `react-measure`. (This involved some re-indenting so I would recommend hiding whitespace changes when viewing the diff.)
- I switched the chart back to JS animations instead of CSS transitions. This allows for animated transitions to new time windows, which we couldn't really do with CSS since it involves actually redrawing the area `path` elements. The performance actually seems fine, so I don't think that feature was doing much for us anyway.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #203 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
