### PR TITLE
Allow current month to be missing from timeseries data

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -97,7 +97,9 @@ export const Tooltip = ({ title, records }) => {
             <TooltipValue>
               {typeof value === "number" ? formatAsNumber(value) : value}
             </TooltipValue>
-            {pct !== undefined && <TooltipPct>{formatAsPct(pct)}</TooltipPct>}
+            {pct !== undefined && !Number.isNaN(pct) && (
+              <TooltipPct>{formatAsPct(pct)}</TooltipPct>
+            )}
           </TooltipRecord>
         ))}
       </TooltipRecordList>

--- a/src/utils/addEmptyMonthsToData.test.js
+++ b/src/utils/addEmptyMonthsToData.test.js
@@ -1,6 +1,13 @@
 import { advanceTo, clear } from "jest-date-mock";
 import addEmptyMonthsToData from "./addEmptyMonthsToData";
 
+const verifyResult = ({ expectedData, patchedData }) => {
+  // complete but not sorted!
+  expect(patchedData).toEqual(expect.arrayContaining(expectedData));
+  // no extraneous items
+  expect(patchedData.length).toEqual(expectedData.length);
+};
+
 describe("function", () => {
   // mocking Date because this function always operates relative to the current day
   const mockToday = new Date(2020, 2, 15);
@@ -50,10 +57,7 @@ describe("function", () => {
 
     const expectedData = [...dataWithGaps, ...missingRecords];
 
-    // complete but not sorted!
-    expect(patchedData).toEqual(expect.arrayContaining(expectedData));
-    // no extraneous items
-    expect(patchedData.length).toEqual(expectedData.length);
+    verifyResult({ expectedData, patchedData });
   });
 
   test("patches data with missing exact dates", () => {
@@ -93,9 +97,93 @@ describe("function", () => {
 
     const expectedData = [...dataWithGaps, ...missingRecords];
 
-    // complete but not sorted!
-    expect(patchedData).toEqual(expect.arrayContaining(expectedData));
-    // no extraneous items
-    expect(patchedData.length).toEqual(expectedData.length);
+    verifyResult({ expectedData, patchedData });
+  });
+
+  test("patches the current month", () => {
+    const dataWithGaps = [
+      {
+        year: "2019",
+        month: "11",
+        test_metric: "0",
+      },
+      {
+        year: "2019",
+        month: "12",
+        test_metric: "5",
+      },
+      {
+        year: "2020",
+        month: "1",
+        test_metric: "3",
+      },
+    ];
+
+    const missingRecords = [
+      {
+        year: "2020",
+        month: "2",
+        test_metric: "0",
+      },
+      {
+        year: "2020",
+        month: "3",
+        test_metric: "0",
+      },
+    ];
+
+    const patchedData = addEmptyMonthsToData({
+      dataPoints: dataWithGaps,
+      monthCount: 4,
+      valueKey: "test_metric",
+      emptyValue: "0",
+      includeCurrentMonth: true,
+    });
+
+    const expectedData = [...dataWithGaps, ...missingRecords];
+
+    verifyResult({ expectedData, patchedData });
+  });
+
+  test("does not patch current month", () => {
+    const dataWithGaps = [
+      {
+        year: "2019",
+        month: "11",
+        test_metric: "0",
+      },
+      {
+        year: "2019",
+        month: "12",
+        test_metric: "5",
+      },
+      {
+        year: "2020",
+        month: "1",
+        test_metric: "3",
+      },
+      // month immediately preceding the current month is missing;
+      // we do want that to be patched when it happens
+    ];
+
+    const missingRecords = [
+      {
+        year: "2020",
+        month: "2",
+        test_metric: "0",
+      },
+    ];
+
+    const patchedData = addEmptyMonthsToData({
+      dataPoints: dataWithGaps,
+      monthCount: 4,
+      valueKey: "test_metric",
+      emptyValue: "0",
+      includeCurrentMonth: false,
+    });
+
+    const expectedData = [...dataWithGaps, ...missingRecords];
+
+    verifyResult({ expectedData, patchedData });
   });
 });

--- a/src/viz-population-over-time/VizPopulationOverTime.js
+++ b/src/viz-population-over-time/VizPopulationOverTime.js
@@ -1,6 +1,6 @@
 import useBreakpoint from "@w11r/use-breakpoint";
 import { scaleTime } from "d3-scale";
-import { isEqual, format, startOfMonth } from "date-fns";
+import { isEqual, format } from "date-fns";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
 import Measure from "react-measure";
@@ -55,6 +55,7 @@ const BASE_MARK_PROPS = {
 
 export default function VizPopulationOverTime({
   data,
+  defaultRangeEnd,
   defaultRangeStart,
   setTimeRangeId,
 }) {
@@ -66,16 +67,15 @@ export default function VizPopulationOverTime({
   useEffect(() => {
     if (defaultRangeStart) {
       // maintain sanity here by requiring start to precede end
-      const thisMonth = startOfMonth(new Date());
-      if (defaultRangeStart > thisMonth) {
+      if (defaultRangeStart > defaultRangeEnd) {
         throw new RangeError(
           "Start of time range must precede the current month."
         );
       }
       setDateRangeStart(defaultRangeStart);
-      setDateRangeEnd(thisMonth);
+      setDateRangeEnd(defaultRangeEnd);
     }
-  }, [defaultRangeStart]);
+  }, [defaultRangeEnd, defaultRangeStart]);
 
   const isNewRange = useCallback(
     ({ start, end }) => {
@@ -192,6 +192,7 @@ export default function VizPopulationOverTime({
 
 VizPopulationOverTime.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  defaultRangeEnd: PropTypes.instanceOf(Date).isRequired,
   defaultRangeStart: PropTypes.instanceOf(Date),
   setTimeRangeId: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description of the change

Implements special case handling for missing data in the current month. This affects the population-over-time charts as well as the supervision success rate charts, both of which exhibited the same bug described below and in the related ticket.

The current month is a special case for imputing missing data: the default assumption should be that it is excluded from the reporting window due to reporting lag, whereas for other months the default assumption should be to replace it with a zero value. This was fortuitously noticed today, though in practice the reporting lag could actually be more than one day after a new month begins, if nightly exports are interrupted for some reason.

The special case handling is applied when there are no records whatsoever for the current month. In cases where there are partial records (i.e. some breakdowns are present but not others), we still assume that the missing records are in fact zeroes. This also means that we cannot naively assume that the current month is always included in the chart component; instead we inspect the data source to detect this special case and then pass an explicit end month. (If we don't do this, the brush area will be drawn incorrectly, which messes up both the chart and the predefined ranges from the dropdown.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #209

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
