### PR TITLE
Improve population timeseries hover interactions

### DIFF
--- a/src/responsive-tooltip-controller/ResponsiveTooltipController.js
+++ b/src/responsive-tooltip-controller/ResponsiveTooltipController.js
@@ -29,6 +29,7 @@ export default function ResponsiveTooltipController({
   pieceHoverAnnotation,
   render,
   setHighlighted,
+  customHoverBehavior,
 }) {
   const infoPanelDispatch = useInfoPanelDispatch();
   const infoPanelState = useInfoPanelState();
@@ -103,6 +104,7 @@ export default function ResponsiveTooltipController({
     if (setHighlighted) {
       setHighlighted(d);
     }
+    if (customHoverBehavior) customHoverBehavior(d);
   };
 
   if (render) {
@@ -131,6 +133,7 @@ ResponsiveTooltipController.propTypes = {
   pieceHoverAnnotation: PropTypes.bool,
   render: PropTypes.func,
   setHighlighted: PropTypes.func,
+  customHoverBehavior: PropTypes.func,
 };
 
 ResponsiveTooltipController.defaultProps = {
@@ -140,4 +143,5 @@ ResponsiveTooltipController.defaultProps = {
   pieceHoverAnnotation: undefined,
   render: undefined,
   setHighlighted: undefined,
+  customHoverBehavior: undefined,
 };


### PR DESCRIPTION
## Description of the change

Implements a new hover behavior for population over time charts that moves smoothly along the time axis and makes the hover targets more consistent and predictable.

By default Semiotic creates a hover target for each point, which results in some kind of weird behavior for stacked area charts — the targets are oriented along the center of each area, which is not a very intuitive spot and can make some points harder to target than others, particularly when the curves get steep. This hover behavior is unfortunately not configurable. After exploring a few options for overriding it that did not perform well, I found that the best solution was to cheat it by overlaying a second, invisible Semiotic "frame" with a flattened dataset that would produce only one data point (and thus one hover target) per month. Those hover targets now take up the entire chart height, making it very easy to brush your cursor back and forth and have the tooltip smoothly follow.

I also now have the tooltip "switching sides" as your cursor gets closer to the right edge of the chart, to prevent it overflowing or getting crushed against the edge of the page. (This only applies to this chart for the moment but there is the potential to generalize it to others. Not going to bloat this PR with that change though.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #208 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
