### PR TITLE
fix bug in calculating default time window

### DIFF
--- a/src/viz-population-over-time/VizPopulationOverTimeContainer.js
+++ b/src/viz-population-over-time/VizPopulationOverTimeContainer.js
@@ -1,5 +1,5 @@
 import { ascending } from "d3-array";
-import { parseISO, startOfMonth, sub } from "date-fns";
+import { formatISO, parseISO, startOfMonth, sub } from "date-fns";
 import PropTypes from "prop-types";
 import React, { useMemo } from "react";
 import { THEME } from "../theme";
@@ -29,7 +29,9 @@ export default function VizPopulationOverTimeContainer({
     // if the current month is completely missing from data, we will assume it is
     // actually missing due to reporting lag. But if any record contains it, we will
     // assume that it should be replaced with an empty record when it is missing
-    const thisMonth = startOfMonth(new Date()).toDateString();
+    const thisMonth = formatISO(startOfMonth(new Date()), {
+      representation: "date",
+    });
     return populationOverTime.some(
       (record) => record.population_date === thisMonth
     );


### PR DESCRIPTION
## Description of the change

Fixes a silly mistake — I wasn't converting the current month's `Date` object to a proper ISO date string, so the check to see if it was included in the metric data was always failing. (Was not obvious before in E2E testing because the current month was still missing when the last PR went up!)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #214 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
