### PR TITLE
Fix lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-simple-import-sort": "^5.0.3",
     "husky": ">=4",
-    "lint-staged": ">=10",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5"
   },
@@ -29,13 +28,5 @@
     "hooks": {
       "pre-commit": "yarn workspaces run lint-staged"
     }
-  },
-  "lint-staged": {
-    "**.{ts,tsx}": [
-      "bash -c tsc",
-      "eslint --fix"
-    ],
-    "**.{js,jsx}": "eslint --fix",
-    "**.json": "prettier --write"
   }
 }

--- a/public-dashboard-client/package.json
+++ b/public-dashboard-client/package.json
@@ -53,7 +53,8 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "jest-date-mock": "^1.0.8"
+    "jest-date-mock": "^1.0.8",
+    "lint-staged": ">=10"
   },
   "browserslist": {
     "production": [
@@ -70,5 +71,9 @@
   },
   "resolutions": {
     "styled-components": "^5"
+  },
+  "lint-staged": {
+    "**.{js,jsx}": "eslint --fix",
+    "**.json": "prettier --write"
   }
 }

--- a/spotlight-api/package.json
+++ b/spotlight-api/package.json
@@ -24,6 +24,11 @@
     "morgan": "^1.10.0"
   },
   "devDependencies": {
+    "lint-staged": ">=10",
     "nodemon": "^2.0.4"
+  },
+  "lint-staged": {
+    "**.{js}": "eslint --fix",
+    "**.json": "prettier --write"
   }
 }

--- a/spotlight-client/package.json
+++ b/spotlight-client/package.json
@@ -31,7 +31,8 @@
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
-    "eslint-import-resolver-typescript": "^2.3.0"
+    "eslint-import-resolver-typescript": "^2.3.0",
+    "lint-staged": ">=10"
   },
   "browserslist": {
     "production": [
@@ -46,5 +47,13 @@
       "last 1 safari version",
       "ie 11"
     ]
+  },
+  "lint-staged": {
+    "**.{ts,tsx}": [
+      "bash -c tsc",
+      "eslint --fix"
+    ],
+    "**.{js,jsx}": "eslint --fix",
+    "**.json": "prettier --write"
   }
 }


### PR DESCRIPTION
## Description of the change

husky and lint-staged are a bit finicky about how they are used inside of a monorepo since they interact with both your npm package and your git repo, and after a few lint errors slipped through to CI I realized that the linters weren't actually running properly inside the husky pre-commit hook. Pushing the lint-staged configuration down to the individual packages, as recommended [here](https://github.com/sudo-suhas/lint-staged-multi-pkg) (and referenced from the official lint-staged docs), should fix this. It makes for a bit more redundant configuration but it doesn't really seem like there's a better alternative!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #239 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
