### PR TITLE
Limit unnecessary CI jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,26 +1,9 @@
-name: "Build Status"
-
+name: "Test Coverage"
 on:
-  - push
   - pull_request
-
 jobs:
-  lint-public-dashboard:
-    name: Lint Public Dashboard
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: public-dashboard-client
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install --frozen-lockfile
-      - run: yarn lint
   test-public-dashboard:
-    name: Test Public Dashboard
+    name: Public Dashboard Test Coverage
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -40,22 +23,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
           path-to-lcov: public-dashboard-client/coverage/lcov.info
-  lint-spotlight-client:
-    name: Lint Spotlight Client
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: spotlight-client
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install --frozen-lockfile
-      - run: yarn lint
   test-spotlight-client:
-    name: Test Spotlight Client
+    name: Spotlight Client Test Coverage
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -75,20 +44,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
           path-to-lcov: spotlight-client/coverage/lcov.info
-  lint-spotlight-api:
-    name: Lint Spotlight API
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: spotlight-api
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install --frozen-lockfile
-      - run: yarn lint
   finish-coveralls:
     name: Finish Coveralls
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,10 @@
 name: "Test Coverage"
 on:
-  - pull_request
+  pull_request:
+  # make sure we also keep master coverage up to date for comparisons
+  push:
+    branches:
+      - master
 jobs:
   test-public-dashboard:
     name: Public Dashboard Test Coverage

--- a/.github/workflows/public-dashboard-client.yml
+++ b/.github/workflows/public-dashboard-client.yml
@@ -1,0 +1,32 @@
+name: "Public Dashboard Client"
+on:
+  push:
+    paths:
+      - "public-dashboard-client/**"
+defaults:
+  run:
+    working-directory: public-dashboard-client
+jobs:
+  lint:
+    name: Lint Public Dashboard Client
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+  test:
+    name: Test Public Dashboard Client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn test

--- a/.github/workflows/spotlight-api.yml
+++ b/.github/workflows/spotlight-api.yml
@@ -1,0 +1,20 @@
+name: "Spotlight API"
+on:
+  push:
+    paths:
+      - "spotlight-api/**"
+defaults:
+  run:
+    working-directory: spotlight-api
+jobs:
+  lint:
+    name: Lint Spotlight API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint

--- a/.github/workflows/spotlight-client.yml
+++ b/.github/workflows/spotlight-client.yml
@@ -1,0 +1,34 @@
+name: "Spotlight Client"
+on:
+  push:
+    paths:
+      - "spotlight-client/**"
+defaults:
+  run:
+    working-directory: public-dashboard-client
+jobs:
+  lint-spotlight-client:
+    name: Lint Spotlight Client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+  test-spotlight-client:
+    name: Test Spotlight Client
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: spotlight-client
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains npm packages related to our Spotlight data publishing product, as well as some shared configuration and tooling that involves multiple packages.
 
-![Build Status](https://github.com/Recidiviz/public-dashboard/workflows/Build%20Status/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/public-dashboard/badge.svg?branch=master)](https://coveralls.io/github/Recidiviz/public-dashboard?branch=master)
+![Spotlight Client](https://github.com/Recidiviz/public-dashboard/workflows/Spotlight%20Client/badge.svg) ![Spotlight API](https://github.com/Recidiviz/public-dashboard/workflows/Spotlight%20API/badge.svg) ![Public Dashboard Client](https://github.com/Recidiviz/public-dashboard/workflows/Public%20Dashboard%20Client/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/public-dashboard/badge.svg?branch=master)](https://coveralls.io/github/Recidiviz/public-dashboard?branch=master)
 
 ## Packages in this repository
 

--- a/public-dashboard-client/README.md
+++ b/public-dashboard-client/README.md
@@ -2,6 +2,8 @@
 
 This package is a React client application for the original Spotlight public dashboard website (North Dakota only). It was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+![Public Dashboard Client](https://github.com/Recidiviz/public-dashboard/workflows/Public%20Dashboard%20Client/badge.svg)
+
 ## Development
 
 ### Getting set up

--- a/spotlight-api/README.md
+++ b/spotlight-api/README.md
@@ -2,6 +2,8 @@
 
 This package is a Node/Express server application that provides a thin API backend for clients consuming public metrics from the Recidiviz data pipeline.
 
+![Spotlight API](https://github.com/Recidiviz/public-dashboard/workflows/Spotlight%20API/badge.svg)
+
 ## Development
 
 ### Getting set up

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -2,6 +2,8 @@
 
 This package is a React client application for the next-generation Spotlight public data publishing website (not yet launched). It was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) and is written in [TypeScript](https://www.typescriptlang.org/docs).
 
+![Spotlight Client](https://github.com/Recidiviz/public-dashboard/workflows/Spotlight%20Client/badge.svg)
+
 ## Development
 
 ### Getting set up


### PR DESCRIPTION
## Description of the change

Not a terribly urgent change but something that has been bugging me since converting this to a monorepo: we were running the same set of CI checks for both pushes to a branch and pull requests, which could be noisy and trigger various CI steps that were redundant and/or irrelevant (e.g. running linter and tests for a package that has no changes; as a bonus, doing it twice when pushing to an open PR) 

Github Actions [doesn't really let you](https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662) de-duplicate `push` and `pull_request` events on the same commit, but we can do a decent job of it with some manual reconfiguration: 

- run per-package `lint` and `test` actions on every `push` event, if changes were made within a given package's directory
- run all packages' `test --coverage` actions on `pull_request` actions (and `push` actions on `master`) for coverage reports. This is necessary because Coveralls metrics apply to the entire repo, and because the Coveralls bot won't comment on pull requests unless you use the `pull_request` event.

This setup will still alert you to lint or test failures before opening a pull request (which I find pretty useful). It eliminates irrelevant jobs pretty much entirely, but there is still some redundancy: tests for changed packages will be run twice (but only once with coverage and Coveralls integration) once a pull request has been opened (and when it is merged).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
