### PR TITLE
version bumps for recidivism release

### DIFF
--- a/public-dashboard-client/package.json
+++ b/public-dashboard-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "public-dashboard-client",
   "description": "A public-facing dashboard to help educate citizens and build accountability",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "repository": "git@github.com:Recidiviz/public-dashboard.git",
   "author": "Recidiviz <team@recidiviz.org>",

--- a/spotlight-api/package.json
+++ b/spotlight-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spotlight-api",
   "description": "Backend for serving data to Spotlight dashboard",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "repository": "git@github.com:Recidiviz/public-dashboard.git",
   "author": "Recidiviz <team@recidiviz.org>",


### PR DESCRIPTION
## Description of the change

Prod release for the recidivism involves both `spotlight-api` and `public-dashboard-client`, so both package versions are bumped. 

This is the first release we have done since converting this to a monorepo so the process will be:
- do final QA on the build from this branch
- deploy release builds directly from this branch (draft releases have already been created for [Spotlight API](https://github.com/Recidiviz/public-dashboard/releases/tag/spotlight-api%401.4.0) and [Public Dashboard Client](https://github.com/Recidiviz/public-dashboard/releases/tag/public-dashboard-client%401.4.0))
- publish those releases
- merge this PR (and maybe do not delete the branch? I am not 100% sure what Github will do about a release tag on a deleted branch but we'll find out! will be important to keep the release commit around in case we need to roll back)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)
- [x] Production release

## Related issues

approvals via Recidiviz/zenhub-tasks#122

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
