### PR TITLE
Data models and routing for "system overview" narratives

### DIFF
--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -114,7 +114,7 @@ describe("navigation", () => {
 
   test("narratives page", () => {
     expect.hasAssertions();
-    const targetPath = "/us-nd/narratives";
+    const targetPath = "/us-nd/collections";
     const lookupArgs = ["heading", { name: "Collections", level: 1 }] as const;
 
     return verifyWithNavigation({ targetPath, lookupArgs });
@@ -122,7 +122,7 @@ describe("navigation", () => {
 
   test("single narrative page", () => {
     expect.hasAssertions();
-    const targetPath = "/us-nd/narratives/prison";
+    const targetPath = "/us-nd/collections/prison";
     const lookupArgs = [
       "heading",
       {

--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -120,6 +120,20 @@ describe("navigation", () => {
     return verifyWithNavigation({ targetPath, lookupArgs });
   });
 
+  test("single narrative page", () => {
+    expect.hasAssertions();
+    const targetPath = "/us-nd/narratives/prison";
+    const lookupArgs = [
+      "heading",
+      {
+        name: testContent.systemNarratives.Prison?.title,
+        level: 1,
+      },
+    ] as const;
+
+    return verifyWithNavigation({ targetPath, lookupArgs });
+  });
+
   test("nav bar", async () => {
     const dataPortalLabel = "Explore";
     const narrativesLabel = "Collections";

--- a/spotlight-client/src/App.tsx
+++ b/spotlight-client/src/App.tsx
@@ -23,7 +23,8 @@ import GlobalStyles from "./GlobalStyles";
 import PageExplore from "./PageExplore";
 import PageHome from "./PageHome";
 import PageMetric from "./PageMetric";
-import PageNarrativeHome from "./PageNarrativeHome";
+import PageNarrative from "./PageNarrative";
+import PageNarrativeList from "./PageNarrativeList";
 import PageNotFound from "./PageNotFound";
 import PageTenant from "./PageTenant";
 import { DataPortalSlug, NarrativesSlug } from "./routerUtils/types";
@@ -59,7 +60,8 @@ const App: React.FC = () => {
                   <PageNotFound default />
                 </PassThroughPage>
                 <PassThroughPage path={`/${NarrativesSlug}`}>
-                  <PageNarrativeHome path="/" />
+                  <PageNarrativeList path="/" />
+                  <PageNarrative path="/:narrativeTypeId" />
                 </PassThroughPage>
                 <PageNotFound default />
               </PassThroughPage>

--- a/spotlight-client/src/DataStore/RootStore.ts
+++ b/spotlight-client/src/DataStore/RootStore.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { Auth0ClientOptions } from "@auth0/auth0-spa-js";
+import { computed, makeObservable } from "mobx";
 import TenantStore from "./TenantStore";
 import UserStore from "./UserStore";
 
@@ -47,6 +48,8 @@ export default class RootStore {
   userStore: UserStore;
 
   constructor() {
+    makeObservable(this, { tenant: computed });
+
     this.tenantStore = new TenantStore({ rootStore: this });
 
     this.userStore = new UserStore({
@@ -54,5 +57,9 @@ export default class RootStore {
       isAuthRequired: isAuthEnabled(),
       rootStore: this,
     });
+  }
+
+  get tenant(): TenantStore["currentTenant"] {
+    return this.tenantStore.currentTenant;
   }
 }

--- a/spotlight-client/src/PageExplore/PageExplore.tsx
+++ b/spotlight-client/src/PageExplore/PageExplore.tsx
@@ -24,7 +24,7 @@ import withRouteSync from "../withRouteSync";
 import getUrlForResource from "../routerUtils/getUrlForResource";
 
 const PageExplore: React.FC<RouteComponentProps> = () => {
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   return (
     <article>

--- a/spotlight-client/src/PageMetric/PageMetric.tsx
+++ b/spotlight-client/src/PageMetric/PageMetric.tsx
@@ -25,7 +25,7 @@ import withRouteSync from "../withRouteSync";
 type PageMetricProps = RouteComponentProps & { metricTypeId?: MetricTypeId };
 
 const PageMetric: React.FC<PageMetricProps> = ({ metricTypeId }) => {
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   // if this component is used properly as a route component,
   // this should never be true;

--- a/spotlight-client/src/PageNarrative/PageNarrative.tsx
+++ b/spotlight-client/src/PageNarrative/PageNarrative.tsx
@@ -27,7 +27,7 @@ type PageNarrativeProps = RouteComponentProps & {
 };
 
 const PageNarrative: React.FC<PageNarrativeProps> = ({ narrativeTypeId }) => {
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   // if this component is used properly as a route component,
   // this should never be true;

--- a/spotlight-client/src/PageNarrative/PageNarrative.tsx
+++ b/spotlight-client/src/PageNarrative/PageNarrative.tsx
@@ -16,13 +16,35 @@
 // =============================================================================
 
 import { RouteComponentProps } from "@reach/router";
+import { observer } from "mobx-react-lite";
 import React from "react";
+import { SystemNarrativeTypeId } from "../contentApi/types";
+import { useDataStore } from "../StoreProvider";
 import withRouteSync from "../withRouteSync";
 
-const PageNarrativeHome: React.FC<RouteComponentProps> = () => (
-  <article>
-    <h1>Collections</h1>
-  </article>
-);
+type PageNarrativeProps = RouteComponentProps & {
+  narrativeTypeId?: SystemNarrativeTypeId;
+};
 
-export default withRouteSync(PageNarrativeHome);
+const PageNarrative: React.FC<PageNarrativeProps> = ({ narrativeTypeId }) => {
+  const tenant = useDataStore().tenantStore.currentTenant;
+
+  // if this component is used properly as a route component,
+  // this should never be true;
+  // if it is, something has gone very wrong
+  if (!narrativeTypeId) {
+    throw new Error("missing narrativeTypeId");
+  }
+
+  // tenant may be briefly undefined on initial page load
+  const narrative = tenant?.systemNarratives[narrativeTypeId];
+
+  return (
+    <article>
+      <h1>{narrative?.title}</h1>
+      <p>{narrative?.introduction}</p>
+    </article>
+  );
+};
+
+export default withRouteSync(observer(PageNarrative));

--- a/spotlight-client/src/PageNarrative/index.ts
+++ b/spotlight-client/src/PageNarrative/index.ts
@@ -15,4 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export { default } from "./PageNarrativeHome";
+export { default } from "./PageNarrative";

--- a/spotlight-client/src/PageNarrativeList/PageNarrativeList.tsx
+++ b/spotlight-client/src/PageNarrativeList/PageNarrativeList.tsx
@@ -1,0 +1,62 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { Link, RouteComponentProps } from "@reach/router";
+import { observer } from "mobx-react-lite";
+import React from "react";
+import { SystemNarrativeTypeIdList } from "../contentApi/types";
+import getUrlForResource from "../routerUtils/getUrlForResource";
+import { useDataStore } from "../StoreProvider";
+import withRouteSync from "../withRouteSync";
+
+const PageNarrativeList: React.FC<RouteComponentProps> = () => {
+  const tenant = useDataStore().tenantStore.currentTenant;
+
+  const systemNarratives = tenant?.systemNarratives;
+
+  return (
+    <article>
+      <h1>Collections</h1>
+      {tenant && systemNarratives && Object.keys(systemNarratives).length > 0 && (
+        <section>
+          <h2>system overview</h2>
+          <ul>
+            {SystemNarrativeTypeIdList.map((id) => {
+              const narrative = systemNarratives[id];
+              return (
+                narrative && (
+                  <li key={id}>
+                    <Link
+                      to={getUrlForResource({
+                        page: "narrative",
+                        params: { tenantId: tenant.id, narrativeTypeId: id },
+                      })}
+                    >
+                      {narrative.title}
+                    </Link>
+                  </li>
+                )
+              );
+            })}
+          </ul>
+        </section>
+      )}
+    </article>
+  );
+};
+
+export default withRouteSync(observer(PageNarrativeList));

--- a/spotlight-client/src/PageNarrativeList/PageNarrativeList.tsx
+++ b/spotlight-client/src/PageNarrativeList/PageNarrativeList.tsx
@@ -24,7 +24,7 @@ import { useDataStore } from "../StoreProvider";
 import withRouteSync from "../withRouteSync";
 
 const PageNarrativeList: React.FC<RouteComponentProps> = () => {
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   const systemNarratives = tenant?.systemNarratives;
 

--- a/spotlight-client/src/PageNarrativeList/index.ts
+++ b/spotlight-client/src/PageNarrativeList/index.ts
@@ -15,24 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import {
-  MetricTypeId,
-  SystemNarrativeTypeId,
-  TenantId,
-} from "../contentApi/types";
-
-export type RouteParams = {
-  // these should match paths as defined in App.tsx
-  tenantId?: string;
-  metricTypeId?: string;
-  narrativeTypeId?: string;
-};
-
-export type NormalizedRouteParams = {
-  tenantId?: TenantId;
-  metricTypeId?: MetricTypeId;
-  narrativeTypeId?: SystemNarrativeTypeId;
-};
-
-export const DataPortalSlug = "explore";
-export const NarrativesSlug = "narratives";
+export { default } from "./PageNarrativeList";

--- a/spotlight-client/src/PageTenant/PageTenant.tsx
+++ b/spotlight-client/src/PageTenant/PageTenant.tsx
@@ -26,7 +26,7 @@ type PageTenantProps = RouteComponentProps & { tenantId?: TenantId };
 
 const PageTenant: React.FC<PageTenantProps> = () => {
   // tenant may be briefly undefined during initial page load
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   return (
     <article>

--- a/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
+++ b/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
@@ -122,7 +122,7 @@ const SiteNavigation: React.FC = () => {
             <Link
               getProps={getNavLinkProps({ matchPartial: true })}
               to={getUrlForResource({
-                page: "narratives",
+                page: "narrative list",
                 params: { tenantId: tenant.id },
               })}
             >

--- a/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
+++ b/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
@@ -81,7 +81,7 @@ function getNavLinkProps({ matchPartial }: { matchPartial: boolean }) {
 }
 
 const SiteNavigation: React.FC = () => {
-  const tenant = useDataStore().tenantStore.currentTenant;
+  const { tenant } = useDataStore();
 
   return (
     <NavContainer>

--- a/spotlight-client/src/contentApi/sources/us_nd.ts
+++ b/spotlight-client/src/contentApi/sources/us_nd.ts
@@ -24,177 +24,308 @@ const content: TenantContent = {
   collections: {
     Sentencing: {
       name: "Sentencing",
-      description:
-        "When someone is convicted of a crime, they receive a sentence that is meant to correspond with facts, circumstances and the severity of the offense and the offender, to provide retribution to the victim and set a course for rehabilitation. The data below gives an overview of sentences for people who enter the North Dakota corrections system – that is, people who are sentenced to serve time in prison or on supervised probation.",
+      description: "description TK",
     },
     Prison: {
       name: "Prison",
-      description:
-        "People sentenced for a Class A misdemeanor or greater offense may serve their sentence in a DOCR prison or contract facility. Prisons run programming to help residents work towards rehabilitation and successful reentry.",
+      description: "description TK",
     },
     Probation: {
       name: "Probation",
-      description:
-        "Probation refers to adults whom the courts place on supervision in the community in lieu of or in addition to incarceration. In North Dakota, probation is managed by the Department of Corrections and Rehabilitation (DOCR).",
+      description: "description TK",
     },
     Parole: {
       name: "Parole",
-      description:
-        "Parole is a period of supervised release after prison. Releases from prison to parole are granted by the parole board. People on parole must regularly check in with their parole officer, who ensures that they are following all the requirements of the release. If these expectations are violated, the person’s parole may be revoked.",
+      description: "description TK",
     },
   },
   metrics: {
     SentencePopulationCurrent: {
-      name: "Who is being sentenced?",
-      description:
-        "After being convicted of a Class A misdemeanor or greater offense by a district court, a person may be sentenced to time in prison or probation, at which point they come under the jurisdiction of the Department of Corrections and Rehabilitation (DOCR). These charts show everyone currently involved with the North Dakota DOCR.",
+      name: "Sentenced Population",
+      description: "description TK",
       methodology:
         "This includes all individuals that are currently incarcerated, on parole, or on probation in North Dakota.",
       mapCaption: "Judicial districts in North Dakota",
     },
     SentenceTypesCurrent: {
-      name: "What types of sentences do people receive?",
-      description:
-        "Sentences that lead to individuals coming under DOCR jurisdiction fall broadly into two categories: Probation and Incarceration.",
+      name: "Sentence Types",
+      description: "description TK",
       methodology:
         "Incarceration includes any sentence that begins with a period of incarceration in a ND DOCR facility. Probation includes any sentence that begins with a period of probation under the supervision of a ND DOCR probation officer. <p>Of note, individuals’ current status (incarcerated or on supervision) may differ from their sentence category (incarceration or probation). Individuals now on parole after being incarcerated are still counted in the incarceration sentence category. Individuals who have had their probation revoked and are now in prison are likewise included in the probation sentence category because their sentence was first to probation.</p><p>It is possible for an individual to be serving both incarceration and probation sentences simultaneously. These individuals are counted in the “Both” category.</p>",
     },
     PrisonPopulationCurrent: {
-      name: "Who is in custody?",
-      description:
-        "The North Dakota Department of Corrections and Rehabilitation (DOCR) runs a number of different facilities and contracts with facilities across the state.",
+      name: "Current Prison Population",
+      description: "description TK",
       methodology:
         "This includes all individuals that are currently incarcerated in a ND DOCR facility. It does not include individuals incarcerated in county jails nor individuals currently serving their prison sentence in the community through the Community Placement Program.",
       mapCaption:
         "Facilities housing individuals under legal and physical custody of the ND DOCR",
     },
     PrisonPopulationHistorical: {
-      name: "How has the incarcerated population changed over time?",
-      description:
-        "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the prison population. Changes in sentence lengths, revocations from community supervision, etc. may also contribute to the rise and fall of this number.",
+      name: "Historical Prison Population",
+      description: "description TK",
       methodology:
         "This chart shows the number of people that were incarcerated in a ND DOCR facility on the first day of each month over the last 20 years. It does not include individuals incarcerated in county jails nor individuals serving their prison sentence in the community through the Community Placement Program.",
     },
     PrisonAdmissionReasonsCurrent: {
-      name: "How did they get there?",
-      description:
-        "There are many possible paths for someone to come to prison. “New Admission” represents someone being incarcerated for the first time as part of their sentence. “Revocation” represents when someone on probation or parole is sent to (or back to) prison.",
+      name: "Reason for Incarceration",
+      description: "description TK",
       methodology:
         "This shows the original reason for admission for all individuals currently incarcerated in a ND DOCR facility. When an individual is admitted to a state prison, the reason for the admission is documented by prison officials. These categories are pulled from that documentation.",
     },
     PrisonStayLengthAggregate: {
-      name: "How long are they there?",
-      description:
-        "Each person in prison has a court-decided sentence determining their maximum length of stay. The actual time that someone stays in prison can be reduced through good behavior credits and parole (discretionary decision by Parole Board). While North Dakota requires those convicted of violent offenses to remain in prison for at least 85 percent of their sentence, most people serve less time in prison than their maximum length of stay.",
+      name: "Length of Prison Stay",
+      description: "description TK",
       methodology:
         "This graph shows how long (in years) individuals spent in prison prior to their first official release for a specific sentence. It includes individuals released in the past 3 years who, prior to release, were serving a new sentence of incarceration or were incarcerated due to revocation of probation. It excludes individuals incarcerated due to revocation of parole. Individuals released from prison for a reason other than completion of sentence, commutation of sentence, parole, or death are also excluded. Of note, this graph does include time spent in the Community Placement Program prior to release as part of time served. Individuals serving life sentences will only be included upon their death.",
     },
     PrisonReleaseTypeAggregate: {
-      name: "Where do they go from there?",
-      description:
-        "Once released, the DOCR’s goal is to help citizens successfully reintegrate into their communities. In most cases, formerly incarcerated people will be placed on community parole or probation supervision.",
+      name: "Placement After Prison",
+      description: "description TK",
       methodology:
         "This includes all individuals released in the last 3 years, including releases directly from the Community Placement Program. When an individual is released from a state prison, the reason for the release is documented by prison officials. These categories are pulled from that documentation. Facility release reasons that do not typically correlate with an end to the period of incarceration, such as transfers between facilities, are not shown here.",
     },
     PrisonRecidivismRateHistorical: {
-      name: "How many people end up back in prison?",
-      description:
-        "After release from prison, a significant proportion of formerly incarcerated folks end up back in prison. This is typically termed “recidivism.” The below graph shows recidivism as reincarceration; that is, the proportion of individuals who are incarcerated again at some point after their release.",
+      name: "Cumulative Recidivism Rates",
+      description: "description TK",
       methodology:
         "This chart shows reincarceration recidivism rates, which is the proportion of individuals released from a ND DOCR facility that return to a ND DOCR facility at some point in the future. The releases are grouped by the calendar year in which the release occurred, and the rates are calculated as the percentage of the people released that have returned to incarceration after each year since the release. Individuals are included in the release cohort if they were released for serving their sentence or were conditionally released onto supervision. Admissions to incarceration for new court commitments or due to revocations of supervision are counted as instances of reincarceration recidivism.",
     },
     PrisonRecidivismRateSingleFollowupHistorical: {
-      name: "How has the recidivism rate changed over time?",
-      description:
-        "We can also observe the recidivism rate over time for a given number of years after original release.",
+      name: "Recidivism Rates Over Time",
+      description: "description TK",
       methodology:
         "This chart shows the reincarceration recidivism rate for a set number years since the release, for the 10 most recent release cohorts.",
     },
     ProbationPopulationCurrent: {
-      name: "Who is on probation?",
-      description:
-        "Judges may sentence people to a period of probation for a Class A misdemeanor crime or greater. Probation can be either a suspended sentence in which the judge has decided on a carceral sentence but has declined to carry it out unless the defendant does not successfully complete a period of probation supervision, or a deferred sentence, in which the defendant has an opportunity for the crime to be recorded as “dismissed” on the criminal record.",
+      name: "Current Probation Population",
+      description: "description TK",
       methodology:
         "This visualization counts people currently on probation in North Dakota.",
       mapCaption: "Judicial districts in North Dakota",
     },
     ProbationPopulationHistorical: {
-      name: "How has the probation population changed over time?",
-      description:
-        "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the probation population. Changes in probation sentence lengths, etc. may also contribute to the rise and fall of this number.",
+      name: "Historical Probation Population",
+      description: "description TK",
       methodology:
         "This chart shows the number of people that were on probation in North Dakota on the first day of each month over the last 20 years.",
     },
     ProbationSuccessHistorical: {
-      name: "What happens after probation?",
-      description:
-        "After probation, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful probation completion has changed over time.",
+      name: "Historical Probation Completion Rates",
+      description: "description TK",
       methodology:
         "This chart looks at the percent of people projected to complete probation in a given month who have successfully completed probation by the end of that month.<p>Probation is considered successfully completed if the individual is discharged from probation positively or if a probation period expires. Unsuccessful completion of probation occurs when probation ends due to absconsion, revocation, or negative termination. Deaths, suspensions, and terminations marked as “other” are excluded from these calculations because they are neither successful nor unsuccessful.</p><p>Individuals whose probation is terminated prior to their projected completion month are counted in the month in which their probation is scheduled to complete, while individuals who have not yet completed probation by their projected completion date are excluded. For example, if 15 people are projected to complete probation in 12 months, 5 are revoked this month, 3 are discharged early in 8 months, 2 complete parole in 12 months, and 5 do not complete probation, the completion rate in 12 months will be 50%, as 10 of the people projected to complete probation will have actually completed probation, 5 of them successfully.</p>",
     },
     ProbationSuccessAggregate: {
-      name: "Aggregate probation completion rates",
-      description:
-        "After probation, a person may be successfully discharged or revoked to prison. Take a look at how the overall rate of successful probation completion varies by demographic.",
+      name: "Aggregate Probation Completion Rates",
+      description: "description TK",
       methodology:
         "The summary completion rates are calculated by taking the total number of people originally projected to complete probation in the past 3 years who have completed probation for a positive or negative reason, then determining the percent of these people for whom the reason was positive. Viewing by a demographic category does the same, but groups by race, age, or gender. Filtering to a given district looks only at success rates of individuals under the jurisdiction of that judicial district.",
     },
     ProbationRevocationsAggregate: {
-      name: "Why do revocations happen?",
-      description:
-        "Revocations happen when a person on probation violates a condition of their supervision or commits a new crime. In North Dakota, probation revocations fall into one of three categories: technical violation, new offense, and absconsion.",
+      name: "Reasons for Probation Revocation",
+      description: "description TK",
       methodology:
         "This chart counts people who were incarcerated in a DOCR facility within the last 3 years because their probation was revoked. Revocations are included based on the date that the person was admitted to a DOCR facility because their probation was revoked, not the date of the probation case closure or causal violation or offense.<p>Revocation admissions are linked to supervision cases closed via revocation within 90 days of the admission. Each individual is counted once, even if they had multiple violation reasons or revocation proceedings from multiple supervision cases. If an individual had their probation revoked multiple times in the last 3 years, the most recent revocation is counted. When an individual does have multiple violation types leading to revocation, only the most severe violation is displayed. New offenses are considered more severe than absconsions, which are considered more severe than technical violations. Violations of “Unknown Type” indicate individuals who were admitted to prison for a supervision revocation where the violation that caused the revocation cannot yet be determined. Revocation admissions without a supervision case closed via revocation in the 90 day window will always be considered of “Unknown Type”.</p><p>Individuals occasionally serve probation and parole sentences simultaneously. For revoked individuals in this situation, their revocation admission is categorized as either a probation or a parole revocation, depending on who authorized the revocation admission (the parole board for parole revocations or the sentencing judge for probation revocations). This chart counts only individuals with probation revocation admissions. Individuals on both parole and probation with a parole revocation admission are included in the parole page.</p>",
     },
     ProbationProgrammingCurrent: {
-      name: "Free Through Recovery program",
-      description:
-        '<a href="https://www.behavioralhealth.nd.gov/addiction/FTR-old" >Free Through Recovery (FTR)</a> is a community based behavioral health program designed to increase recovery support services to individuals involved with the criminal justice system who have behavioral health concerns. The map below shows the number of people enrolled in the FTR program today.',
+      name: "Free Through Recovery Program Participation in Probation",
+      description: "description TK",
       methodology:
         "This chart counts the total number of people on probation who are actively enrolled in Free Through Recovery (FTR). Free Through Recovery is run jointly with the Department of Health and Human Services (DHS): as a result, FTR enrollment is aggregated into the 8 DHS service regions of the provider locations at which individuals are enrolled.",
     },
     ParolePopulationCurrent: {
-      name: "Who is on parole?",
-      description:
-        "Parole is granted to people in prison with a track record of good behavior as a way to complete their sentences in their communities.",
+      name: "Current Parole Population",
+      description: "description TK",
       methodology:
         "This visualization counts people currently on parole in North Dakota.",
       mapCaption: "Parole offices in North Dakota",
     },
     ParolePopulationHistorical: {
-      name: "How has the parole population changed over time?",
-      description:
-        "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the parole population. Changes in parole sentence lengths, earlier releases from prison, etc. may also contribute to the rise and fall of this number.",
+      name: "Historical Parole Population",
+      description: "description TK",
       methodology:
         "This chart shows the number of people that were on parole in North Dakota on the first day of each month over the last 20 years.",
     },
     ParoleSuccessHistorical: {
-      name: "What happens after parole?",
-      description:
-        "After parole, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful parole completion has changed over time, and how the overall rate of successful parole completion varies by demographic.",
+      name: "Historical Parole Completion Rates",
+      description: "description TK",
       methodology:
         "This chart looks at the percent of people projected to complete parole in a given month who have successfully completed parole by the end of that month.<p>Parole is considered successfully completed if an individual is discharged from parole positively or if a parole period expires. Unsuccessful completions of parole occur when the parole ends due to absconsion, a revocation, or a negative termination. Deaths, suspensions, and terminations marked as “other” are excluded from these calculations because they are neither successful nor unsuccessful.</p><p>Individuals whose parole is terminated prior to their projected completion month are counted in the month in which their parole is scheduled to complete, while individuals who have not yet completed parole by their projected completion date are excluded. For example, if 15 people are projected to complete parole in 12 months, 5 are revoked this month, 3 are discharged early in 8 months, 2 complete parole in 12 months, and 5 do not complete parole, the completion rate in 12 months will be 50%, as 10 of the people projected to complete parole will have actually completed parole, 5 of them successfully.</p>",
     },
     ParoleSuccessAggregate: {
-      name: "Aggregate parole completion rates",
-      description:
-        "After parole, a person may be successfully discharged or revoked to prison. Take a look at how the overall rate of successful parole completion varies by demographic.",
+      name: "Aggregate Parole Completion Rates",
+      description: "description TK",
       methodology:
         "The summary completion rates are calculated by taking the total number of people originally projected to complete parole in the past 3 years who have completed parole for a positive or negative reason, then determining the percent of these people for whom the reason was positive. Viewing by a demographic category does the same, but groups by race, age, or gender. Filtering to a given office looks only at success rates of individuals who were supervised in that office.",
     },
     ParoleRevocationsAggregate: {
-      name: "Why do revocations happen?",
-      description:
-        "Revocations happen when a person on parole violates a condition of their supervision or commits a new crime. In North Dakota, parole revocations fall into one of three categories: technical violation, new offense, and absconsion.",
+      name: "Reasons for Parole Revocation",
+      description: "description TK",
       methodology:
         "This chart counts people who were incarcerated in a DOCR facility within the last 3 years because their parole was revoked. Revocations are included based on the date that the person was admitted to a DOCR facility because their parole was revoked, not the date of the parole case closure or causal violation or offense.<p>Revocation admissions are linked to parole cases closed via revocation within 90 days of the admission. Each individual is counted once, even if they had multiple violation reasons or revocation proceedings from multiple supervision cases. If an individual has had their parole revoked multiple times in the last 3 years, the most recent revocation is counted. When an individual does have multiple violation types leading to revocation, only the most severe violation is displayed. New offenses are considered more severe than absconsions, which are considered more severe than technical violations. Violations of “Unknown Type” indicate individuals who were admitted to prison for a supervision revocation where the violation that caused the revocation cannot yet be determined. Revocation admissions without a supervision case closed via revocation in the 90 day window will always be considered of “Unknown Type”.</p><p>Individuals occasionally serve probation and parole sentences simultaneously. For revoked individuals in this situation, their revocation admission is categorized as either a probation or a parole revocation, depending on who authorized the revocation admission (the parole board for parole revocations or the sentencing judge for probation revocations). This chart counts only individuals with parole revocation admissions. Individuals on both parole and probation with a probation revocation admission are included in the probation page.</p>",
     },
     ParoleProgrammingCurrent: {
-      name: "Free Through Recovery program",
-      description:
-        '<a href="https://www.behavioralhealth.nd.gov/addiction/FTR-old" >Free Through Recovery (FTR)</a> is a community based behavioral health program designed to increase recovery support services to individuals involved with the criminal justice system who have behavioral health concerns. The map below shows the number of people enrolled in the FTR program today.',
+      name: "Free Through Recovery Program Participation in Parole",
+      description: "description TK",
       methodology:
         "This chart counts the total number of people on parole who are actively enrolled in Free Through Recovery (FTR). Free Through Recovery is run jointly with the Department of Health and Human Services (DHS): as a result, FTR enrollment is aggregated into the 8 DHS service regions of the provider locations at which individuals are enrolled.",
+    },
+  },
+  systemNarratives: {
+    Sentencing: {
+      title: "Sentencing",
+      introduction:
+        "When someone is convicted of a crime, they receive a sentence that is meant to correspond with facts, circumstances and the severity of the offense and the offender, to provide retribution to the victim and set a course for rehabilitation. The data below gives an overview of sentences for people who enter the North Dakota corrections system — that is, people who are sentenced to serve time in prison or on supervised probation.",
+      sections: [
+        {
+          title: "Who is being sentenced?",
+          body:
+            "After being convicted of a Class A misdemeanor or greater offense by a district court, a person may be sentenced to time in prison or probation, at which point they come under the jurisdiction of the Department of Corrections and Rehabilitation (DOCR). These charts show everyone currently involved with the North Dakota DOCR.",
+          metricTypeId: "SentencePopulationCurrent",
+        },
+        {
+          title: "What types of sentences do people receive?",
+          body:
+            "Sentences that lead to individuals coming under DOCR jurisdiction fall broadly into two categories: Probation and Incarceration.",
+          metricTypeId: "SentenceTypesCurrent",
+        },
+      ],
+    },
+    Prison: {
+      title: "Prison",
+      introduction:
+        "People sentenced for a Class A misdemeanor or greater offense may serve their sentence in a DOCR prison or contract facility. Prisons run programming to help residents work towards rehabilitation and successful reentry.",
+      sections: [
+        {
+          metricTypeId: "PrisonPopulationCurrent",
+          title: "Who is in custody?",
+          body:
+            "The North Dakota Department of Corrections and Rehabilitation (DOCR) runs a number of different facilities and contracts with facilities across the state.",
+        },
+        {
+          metricTypeId: "PrisonPopulationHistorical",
+          title: "How has the incarcerated population changed over time?",
+          body:
+            "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the prison population. Changes in sentence lengths, revocations from community supervision, etc. may also contribute to the rise and fall of this number.",
+        },
+        {
+          metricTypeId: "PrisonAdmissionReasonsCurrent",
+          title: "How did they get there?",
+          body:
+            "There are many possible paths for someone to come to prison. “New Admission” represents someone being incarcerated for the first time as part of their sentence. “Revocation” represents when someone on probation or parole is sent to (or back to) prison.",
+        },
+        {
+          metricTypeId: "PrisonStayLengthAggregate",
+          title: "How long are they there?",
+          body:
+            "Each person in prison has a court-decided sentence determining their maximum length of stay. The actual time that someone stays in prison can be reduced through good behavior credits and parole (discretionary decision by Parole Board). While North Dakota requires those convicted of violent offenses to remain in prison for at least 85 percent of their sentence, most people serve less time in prison than their maximum length of stay.",
+        },
+        {
+          metricTypeId: "PrisonReleaseTypeAggregate",
+          title: "Where do they go from there?",
+          body:
+            "Once released, the DOCR’s goal is to help citizens successfully reintegrate into their communities. In most cases, formerly incarcerated people will be placed on community parole or probation supervision.",
+        },
+        {
+          metricTypeId: "PrisonRecidivismRateHistorical",
+          title: "How many people end up back in prison?",
+          body:
+            "After release from prison, a significant proportion of formerly incarcerated folks end up back in prison. This is typically termed “recidivism.” The below graph shows recidivism as reincarceration; that is, the proportion of individuals who are incarcerated again at some point after their release.",
+        },
+        {
+          metricTypeId: "PrisonRecidivismRateSingleFollowupHistorical",
+          title: "How has the recidivism rate changed over time?",
+          body:
+            "We can also observe the recidivism rate over time for a given number of years after original release.",
+        },
+      ],
+    },
+    Probation: {
+      title: "Probation",
+      introduction:
+        "Probation refers to adults whom the courts place on supervision in the community in lieu of or in addition to incarceration. In North Dakota, probation is managed by the Department of Corrections and Rehabilitation (DOCR).",
+      sections: [
+        {
+          title: "Who is on probation?",
+          body:
+            "Judges may sentence people to a period of probation for a Class A misdemeanor crime or greater. Probation can be either a suspended sentence in which the judge has decided on a carceral sentence but has declined to carry it out unless the defendant does not successfully complete a period of probation supervision, or a deferred sentence, in which the defendant has an opportunity for the crime to be recorded as “dismissed” on the criminal record.",
+          metricTypeId: "ProbationPopulationCurrent",
+        },
+        {
+          title: "How has the probation population changed over time?",
+          body:
+            "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the probation population. Changes in probation sentence lengths, etc. may also contribute to the rise and fall of this number.",
+          metricTypeId: "ProbationPopulationHistorical",
+        },
+        {
+          title: "What happens after probation?",
+          body:
+            "After probation, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful probation completion has changed over time.",
+          metricTypeId: "ProbationSuccessHistorical",
+        },
+        {
+          title: "Aggregate probation completion rates",
+          body:
+            "After probation, a person may be successfully discharged or revoked to prison. Take a look at how the overall rate of successful probation completion varies by demographic.",
+          metricTypeId: "ProbationSuccessAggregate",
+        },
+        {
+          title: "Why do revocations happen?",
+          body:
+            "Revocations happen when a person on probation violates a condition of their supervision or commits a new crime. In North Dakota, probation revocations fall into one of three categories: technical violation, new offense, and absconsion.",
+          metricTypeId: "ProbationRevocationsAggregate",
+        },
+        {
+          title: "Free Through Recovery program",
+          body:
+            '<a href="https://www.behavioralhealth.nd.gov/addiction/FTR-old" >Free Through Recovery (FTR)</a> is a community based behavioral health program designed to increase recovery support services to individuals involved with the criminal justice system who have behavioral health concerns. The map below shows the number of people enrolled in the FTR program today.',
+          metricTypeId: "ProbationProgrammingCurrent",
+        },
+      ],
+    },
+    Parole: {
+      title: "Parole",
+      introduction:
+        "Parole is a period of supervised release after prison. Releases from prison to parole are granted by the parole board. People on parole must regularly check in with their parole officer, who ensures that they are following all the requirements of the release. If these expectations are violated, the person’s parole may be revoked.",
+      sections: [
+        {
+          title: "Who is on parole?",
+          body:
+            "Parole is granted to people in prison with a track record of good behavior as a way to complete their sentences in their communities.",
+          metricTypeId: "ParolePopulationCurrent",
+        },
+        {
+          title: "How has the parole population changed over time?",
+          body:
+            "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the parole population. Changes in parole sentence lengths, earlier releases from prison, etc. may also contribute to the rise and fall of this number.",
+          metricTypeId: "ParolePopulationHistorical",
+        },
+        {
+          title: "What happens after parole?",
+          body:
+            "After parole, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful parole completion has changed over time, and how the overall rate of successful parole completion varies by demographic.",
+          metricTypeId: "ParoleSuccessHistorical",
+        },
+        {
+          title: "Aggregate parole completion rates",
+          body:
+            "After parole, a person may be successfully discharged or revoked to prison. Take a look at how the overall rate of successful parole completion varies by demographic.",
+          metricTypeId: "ParoleSuccessAggregate",
+        },
+        {
+          title: "Why do revocations happen?",
+          body:
+            "Revocations happen when a person on parole violates a condition of their supervision or commits a new crime. In North Dakota, parole revocations fall into one of three categories: technical violation, new offense, and absconsion.",
+          metricTypeId: "ParoleRevocationsAggregate",
+        },
+        {
+          title: "Free Through Recovery program",
+          body:
+            '<a href="https://www.behavioralhealth.nd.gov/addiction/FTR-old" >Free Through Recovery (FTR)</a> is a community based behavioral health program designed to increase recovery support services to individuals involved with the criminal justice system who have behavioral health concerns. The map below shows the number of people enrolled in the FTR program today.',
+          metricTypeId: "ParoleProgrammingCurrent",
+        },
+      ],
     },
   },
 };

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -41,6 +41,9 @@ export type TenantContent = NamedEntity & {
     ProbationPopulationCurrent?: PopulationCurrentContent;
     ParolePopulationCurrent?: PopulationCurrentContent;
   };
+  systemNarratives: {
+    [key in SystemNarrativeTypeId]?: SystemNarrativeContent;
+  };
 };
 
 // ============================
@@ -54,7 +57,7 @@ export const CollectionTypeIdList = [
 ] as const;
 export type CollectionTypeId = typeof CollectionTypeIdList[number];
 
-export type CollectionContent = NamedEntity;
+type CollectionContent = NamedEntity;
 
 // ============================
 // Metric types
@@ -87,6 +90,31 @@ export function isMetricTypeId(x: string): x is MetricTypeId {
   return MetricTypeIdList.includes(x as MetricTypeId);
 }
 
-export type MetricContent = NamedEntity & { methodology: string };
+type MetricContent = NamedEntity & { methodology: string };
 
 type PopulationCurrentContent = MetricContent & { mapCaption: string };
+
+// ============================
+// Narrative types
+export const SystemNarrativeTypeIds = [
+  "Prison",
+  "Probation",
+  "Parole",
+  "Sentencing",
+] as const;
+export type SystemNarrativeTypeId = typeof SystemNarrativeTypeIds[number];
+export function isSystemNarrativeTypeId(x: string): x is SystemNarrativeTypeId {
+  return SystemNarrativeTypeIds.includes(x as SystemNarrativeTypeId);
+}
+
+type SystemNarrativeSection = {
+  title: string;
+  body: string;
+  metricTypeId: MetricTypeId;
+};
+
+type SystemNarrativeContent = {
+  title: string;
+  introduction: string;
+  sections: SystemNarrativeSection[];
+};

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -56,6 +56,9 @@ export const CollectionTypeIdList = [
   "Parole",
 ] as const;
 export type CollectionTypeId = typeof CollectionTypeIdList[number];
+export function isCollectionTypeId(x: string): x is CollectionTypeId {
+  return CollectionTypeIdList.includes(x as CollectionTypeId);
+}
 
 type CollectionContent = NamedEntity;
 
@@ -96,15 +99,15 @@ type PopulationCurrentContent = MetricContent & { mapCaption: string };
 
 // ============================
 // Narrative types
-export const SystemNarrativeTypeIds = [
+export const SystemNarrativeTypeIdList = [
   "Prison",
   "Probation",
   "Parole",
   "Sentencing",
 ] as const;
-export type SystemNarrativeTypeId = typeof SystemNarrativeTypeIds[number];
+export type SystemNarrativeTypeId = typeof SystemNarrativeTypeIdList[number];
 export function isSystemNarrativeTypeId(x: string): x is SystemNarrativeTypeId {
-  return SystemNarrativeTypeIds.includes(x as SystemNarrativeTypeId);
+  return SystemNarrativeTypeIdList.includes(x as SystemNarrativeTypeId);
 }
 
 type SystemNarrativeSection = {
@@ -113,7 +116,7 @@ type SystemNarrativeSection = {
   metricTypeId: MetricTypeId;
 };
 
-type SystemNarrativeContent = {
+export type SystemNarrativeContent = {
   title: string;
   introduction: string;
   sections: SystemNarrativeSection[];

--- a/spotlight-client/src/contentModels/Metric.ts
+++ b/spotlight-client/src/contentModels/Metric.ts
@@ -110,7 +110,7 @@ export default class Metric<RecordFormat extends AnyRecord> {
       name: false,
       tenantId: false,
       // in practice, collections should not change once we are done
-      // boostrapping them (which is done right after instantiation);
+      // bootstrapping them (which is done right after instantiation);
       // no need to make them observable
       collections: false,
     });

--- a/spotlight-client/src/contentModels/SystemNarrative.ts
+++ b/spotlight-client/src/contentModels/SystemNarrative.ts
@@ -1,0 +1,66 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { SystemNarrativeContent } from "../contentApi/types";
+import { AnyMetric, isAnyMetric, MetricMapping } from "./types";
+
+type Section = { title: string; body: string; metric: AnyMetric };
+const isSection = (section: Section | undefined): section is Section =>
+  section !== undefined;
+
+type ConstructorArgs = {
+  title: string;
+  introduction: string;
+  sections: Section[];
+};
+
+export default class SystemNarrative {
+  readonly title: string;
+
+  readonly introduction: string;
+
+  readonly sections: Section[];
+
+  constructor({ title, introduction, sections }: ConstructorArgs) {
+    this.title = title;
+    this.introduction = introduction;
+    this.sections = sections;
+  }
+}
+
+export function createSystemNarrative({
+  content,
+  allMetrics,
+}: {
+  content: SystemNarrativeContent;
+  allMetrics: MetricMapping;
+}): SystemNarrative {
+  return new SystemNarrative({
+    title: content.title,
+    introduction: content.introduction,
+    sections: content.sections
+      .map(({ title, body, metricTypeId }) => {
+        const metric = allMetrics[metricTypeId];
+        if (isAnyMetric(metric)) {
+          return { title, body, metric };
+        }
+        return undefined;
+      })
+      // TODO: why isn't this type guard working?
+      .filter(isSection) as Section[],
+  });
+}

--- a/spotlight-client/src/contentModels/Tenant.test.ts
+++ b/spotlight-client/src/contentModels/Tenant.test.ts
@@ -16,7 +16,12 @@
 // =============================================================================
 
 import retrieveContent from "../contentApi/retrieveContent";
-import { CollectionTypeId, MetricTypeId } from "../contentApi/types";
+import {
+  isCollectionTypeId,
+  isMetricTypeId,
+  isSystemNarrativeTypeId,
+  MetricTypeId,
+} from "../contentApi/types";
 import Collection from "./Collection";
 import Metric from "./Metric";
 import { createTenant } from "./Tenant";
@@ -49,7 +54,7 @@ test.each([
 
   const tenant = createTenant({ tenantId: "US_ND" });
 
-  const expectedMetrics = Object.keys(fixture.metrics) as MetricTypeId[];
+  const expectedMetrics = Object.keys(fixture.metrics).filter(isMetricTypeId);
   expectedMetrics.forEach((metricId) =>
     expect(tenant.metrics[metricId]).toBeDefined()
   );
@@ -64,9 +69,9 @@ test.each([
 
   const tenant = createTenant({ tenantId: "US_ND" });
 
-  const expectedCollections = Object.keys(
-    fixture.collections
-  ) as CollectionTypeId[];
+  const expectedCollections = Object.keys(fixture.collections).filter(
+    isCollectionTypeId
+  );
   expectedCollections.forEach((id) => {
     const collection = tenant.collections.get(id);
     expect(collection).toBeDefined();
@@ -164,4 +169,24 @@ test("collections and metrics without content are excluded from mapping", () => 
   expect(sentenceMetric instanceof Metric).toBe(true);
   // @ts-expect-error: sentenceMetric is not undefined, we just tested it
   expect(sentenceMetric.collections.Sentencing).toBeUndefined();
+});
+
+test.each([
+  ["complete", exhaustiveFixture],
+  ["partial", partialFixture],
+])("tenant has %s system narratives", (type, fixture) => {
+  retrieveContentMock.mockReturnValue(fixture);
+
+  const tenant = createTenant({ tenantId: "US_ND" });
+
+  const expectedNarratives = Object.keys(tenant.systemNarratives).filter(
+    isSystemNarrativeTypeId
+  );
+  expectedNarratives.forEach((id) => {
+    const narrative = tenant.systemNarratives[id];
+    expect(narrative).toBeDefined();
+  });
+  expect(expectedNarratives.length).toBe(
+    Object.keys(tenant.systemNarratives).length
+  );
 });

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -152,6 +152,52 @@ const content: DeepRequired<TenantContent> = {
       methodology: "test ProbationSuccessAggregate methodology",
     },
   },
+  systemNarratives: {
+    Prison: {
+      title: "test prison narrative",
+      introduction: "test prison introduction",
+      sections: [
+        {
+          title: "test first prison section",
+          body: "test prison section copy",
+          metricTypeId: "PrisonPopulationCurrent",
+        },
+      ],
+    },
+    Probation: {
+      title: "test probation narrative",
+      introduction: "test probation introduction",
+      sections: [
+        {
+          title: "test first probation section",
+          body: "test probation section copy",
+          metricTypeId: "ProbationPopulationCurrent",
+        },
+      ],
+    },
+    Parole: {
+      title: "test parole narrative",
+      introduction: "test parole introduction",
+      sections: [
+        {
+          title: "test first parole section",
+          body: "test parole section copy",
+          metricTypeId: "ParolePopulationCurrent",
+        },
+      ],
+    },
+    Sentencing: {
+      title: "test sentencing narrative",
+      introduction: "test sentencing introduction",
+      sections: [
+        {
+          title: "test first sentencing section",
+          body: "test sentencing section copy",
+          metricTypeId: "SentencePopulationCurrent",
+        },
+      ],
+    },
+  },
 };
 
 export default content;

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
@@ -63,6 +63,20 @@ const content: TenantContent = {
       methodology: "test ParoleRevocationsAggregate methodology",
     },
   },
+  // this is an intentionally non-exhaustive set of narratives
+  systemNarratives: {
+    Parole: {
+      title: "test parole narrative",
+      introduction: "test parole introduction",
+      sections: [
+        {
+          title: "test first parole section",
+          body: "test parole section copy",
+          metricTypeId: "ParolePopulationCurrent",
+        },
+      ],
+    },
+  },
 };
 
 export default content;

--- a/spotlight-client/src/contentModels/types.ts
+++ b/spotlight-client/src/contentModels/types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { CollectionTypeId } from "../contentApi/types";
+import { CollectionTypeId, SystemNarrativeTypeId } from "../contentApi/types";
 import {
   DemographicsByCategoryRecord,
   HistoricalPopulationBreakdownRecord,
@@ -27,7 +27,8 @@ import {
   SupervisionSuccessRateDemographicsRecord,
 } from "../metricsApi";
 import type Collection from "./Collection";
-import type Metric from "./Metric";
+import Metric from "./Metric";
+import SystemNarrative from "./SystemNarrative";
 
 // =======================================
 // Collection types
@@ -50,6 +51,9 @@ export type AnyRecord =
   | SupervisionSuccessRateDemographicsRecord;
 
 export type AnyMetric = Metric<AnyRecord>;
+export function isAnyMetric(metric: unknown): metric is AnyMetric {
+  return metric instanceof Metric;
+}
 
 export type MetricMapping = {
   SentencePopulationCurrent?: Metric<PopulationBreakdownByLocationRecord>;
@@ -73,4 +77,11 @@ export type MetricMapping = {
   ParoleSuccessAggregate?: Metric<SupervisionSuccessRateDemographicsRecord>;
   ParoleRevocationsAggregate?: Metric<DemographicsByCategoryRecord>;
   ParoleProgrammingCurrent?: Metric<ProgramParticipationCurrentRecord>;
+};
+
+// =======================================
+// Narrative types
+// =======================================
+export type SystemNarrativeMapping = {
+  [key in SystemNarrativeTypeId]?: SystemNarrative;
 };

--- a/spotlight-client/src/routerUtils/getUrlForResource.ts
+++ b/spotlight-client/src/routerUtils/getUrlForResource.ts
@@ -33,7 +33,11 @@ type GetUrlOptions =
       page: "metric";
       params: Pick<RequiredParams, "tenantId" | "metricTypeId">;
     }
-  | { page: "narratives"; params: Pick<RequiredParams, "tenantId"> };
+  | { page: "narrative list"; params: Pick<RequiredParams, "tenantId"> }
+  | {
+      page: "narrative";
+      params: Pick<RequiredParams, "tenantId" | "narrativeTypeId">;
+    };
 
 /**
  * Creates a properly parameterized URL from the input options
@@ -50,9 +54,12 @@ function getUrlForResource(opts: GetUrlOptions): string {
       return `/${makeRouteParam(
         opts.params.tenantId
       )}/${DataPortalSlug}/${makeRouteParam(opts.params.metricTypeId)}`;
-    case "narratives":
+    case "narrative list":
       return `/${makeRouteParam(opts.params.tenantId)}/${NarrativesSlug}`;
-
+    case "narrative":
+      return `/${makeRouteParam(
+        opts.params.tenantId
+      )}/${NarrativesSlug}/${makeRouteParam(opts.params.narrativeTypeId)}`;
     default:
       assertNever(opts);
   }

--- a/spotlight-client/src/routerUtils/normalizeRouteParams.ts
+++ b/spotlight-client/src/routerUtils/normalizeRouteParams.ts
@@ -16,7 +16,12 @@
 // =============================================================================
 
 import { constantCase, pascalCase } from "change-case";
-import { isMetricTypeId, isTenantId } from "../contentApi/types";
+import { ValuesType } from "utility-types";
+import {
+  isMetricTypeId,
+  isSystemNarrativeTypeId,
+  isTenantId,
+} from "../contentApi/types";
 import { NormalizedRouteParams, RouteParams } from "./types";
 
 /**
@@ -25,18 +30,16 @@ import { NormalizedRouteParams, RouteParams } from "./types";
 export default function normalizeRouteParams(
   rawParams: RouteParams
 ): NormalizedRouteParams {
-  if (rawParams && typeof rawParams === "object") {
-    const { tenantId, metricTypeId } = rawParams as { [key: string]: unknown };
+  const { tenantId, metricTypeId, narrativeTypeId } = rawParams;
 
-    return {
-      tenantId: normalizeTenantId(tenantId),
-      metricTypeId: normalizeMetricTypeId(metricTypeId),
-    };
-  }
-  return {};
+  return {
+    tenantId: normalizeTenantId(tenantId),
+    metricTypeId: normalizeMetricTypeId(metricTypeId),
+    narrativeTypeId: normalizeNarrativeTypeId(narrativeTypeId),
+  };
 }
 
-function normalizeTenantId(rawParam: unknown) {
+function normalizeTenantId(rawParam: ValuesType<RouteParams>) {
   if (typeof rawParam === "string") {
     const normalizedString = constantCase(rawParam);
     if (isTenantId(normalizedString)) return normalizedString;
@@ -45,11 +48,20 @@ function normalizeTenantId(rawParam: unknown) {
   return undefined;
 }
 
-function normalizeMetricTypeId(rawParam: unknown) {
+function normalizeMetricTypeId(rawParam: ValuesType<RouteParams>) {
   if (typeof rawParam === "string") {
     const normalizedString = pascalCase(rawParam);
     if (isMetricTypeId(normalizedString)) return normalizedString;
     throw new Error(`unknown MetricTypeId: ${normalizedString}`);
+  }
+  return undefined;
+}
+
+function normalizeNarrativeTypeId(rawParam: ValuesType<RouteParams>) {
+  if (typeof rawParam === "string") {
+    const normalizedString = pascalCase(rawParam);
+    if (isSystemNarrativeTypeId(normalizedString)) return normalizedString;
+    throw new Error(`unknown narrative type id: ${normalizedString}`);
   }
   return undefined;
 }

--- a/spotlight-client/src/routerUtils/types.ts
+++ b/spotlight-client/src/routerUtils/types.ts
@@ -35,4 +35,4 @@ export type NormalizedRouteParams = {
 };
 
 export const DataPortalSlug = "explore";
-export const NarrativesSlug = "narratives";
+export const NarrativesSlug = "collections";

--- a/spotlight-client/src/withRouteSync/withRouteSync.tsx
+++ b/spotlight-client/src/withRouteSync/withRouteSync.tsx
@@ -47,6 +47,7 @@ const withRouteSync = <Props extends RouteComponentProps & RouteParams>(
         {...props}
         tenantId={normalizedProps.tenantId}
         metricTypeId={normalizedProps.metricTypeId}
+        narrativeTypeId={normalizedProps.narrativeTypeId}
       />
     );
   };


### PR DESCRIPTION
## Description of the change

This creates the content and models for the "system overview" narratives, which are analogous to the main pages from Spotlight v1, and plugs them into the routing and navigation system. 

Now that the scaffolding is all in place, this was pretty straightforward! Note that most of the content I had originally assigned to the Metrics and Collections is really more appropriate for these narratives (which did not really exist in the product requirements until about a week ago), so I mostly just moved that over. I tried to replace the metric titles with what was in the data portal mocks and sub in something sensible if there was nothing there, but none of that should be considered final at this point. (all of those "description" fields are now just placeholders because I don't have anything to put there, and I am frankly not even sure if we will wind up needing those fields at all; they don't appear in the latest iterations of the mocks, but we can worry about that later). 

In the future we will have to disambiguate between different kinds of narratives, which is why the routing-related code refers to "narrativeTypeId" more generically; within the data models though, we will want to keep them separate to make UI treatment easier; different groups of narratives are not likely to resemble one another in structure or presentation.

Also note that I renamed "PageNarrativeHome" to "PageNarrativeList", which seems to have confused the Github diffing elves. Sorry! 🧝🏻‍♂️ 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #275 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
