### PR TITLE
Locality filter component

### DIFF
--- a/spotlight-client/src/DemographicFilterSelect/DemographicFilterSelect.test.tsx
+++ b/spotlight-client/src/DemographicFilterSelect/DemographicFilterSelect.test.tsx
@@ -31,6 +31,7 @@ const testMetadataMapping = {
 
 function getTestMetric() {
   return createMetricMapping({
+    localityLabelMapping: undefined,
     metadataMapping: testMetadataMapping,
     tenantId: testTenantId,
   }).get(testMetricId) as HistoricalPopulationBreakdownMetric;

--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
@@ -1,0 +1,96 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import createMetricMapping from "../contentModels/createMetricMapping";
+import type PopulationBreakdownByLocationMetric from "../contentModels/PopulationBreakdownByLocationMetric";
+import contentFixture from "../contentModels/__fixtures__/tenant_content_exhaustive";
+import { reactImmediately } from "../testUtils";
+import LocalityFilterSelect from "./LocalityFilterSelect";
+
+const testTenantId = "US_ND";
+const testMetricId = "ProbationPopulationCurrent";
+const testMetadataMapping = {
+  [testMetricId]: contentFixture.metrics[testMetricId],
+};
+
+// judicial districts present in backend fixture
+const expectedLocalities = [
+  { id: "ALL", label: "All Districts" },
+  { id: "EAST_CENTRAL", label: "East Central" },
+  { id: "NORTH_CENTRAL", label: "North Central" },
+  { id: "NORTHEAST", label: "Northeast" },
+  { id: "NORTHEAST_CENTRAL", label: "Northeast Central" },
+  { id: "NORTHWEST", label: "Northwest" },
+  { id: "SOUTH_CENTRAL", label: "South Central" },
+  { id: "SOUTHEAST", label: "Southeast" },
+  { id: "SOUTHWEST", label: "Southwest" },
+  { id: "OTHER", label: "Other" },
+];
+
+function getTestMetric() {
+  return createMetricMapping({
+    localityLabelMapping: {
+      Probation: { label: "Judicial District", entries: expectedLocalities },
+    },
+    metadataMapping: testMetadataMapping,
+    tenantId: testTenantId,
+  }).get(testMetricId) as PopulationBreakdownByLocationMetric;
+}
+
+test("has expected options", () => {
+  const metric = getTestMetric();
+  render(<LocalityFilterSelect metric={metric} />);
+
+  const menuButton = screen.getByRole("button", {
+    name: "Judicial District All Districts",
+  });
+  fireEvent.click(menuButton);
+
+  const options = screen.getAllByRole("option");
+
+  expect(options.length).toBe(expectedLocalities.length);
+
+  options.forEach((option, index) =>
+    expect(option).toHaveTextContent(expectedLocalities[index].label)
+  );
+});
+
+test("changes demographic filter", () => {
+  const metric = getTestMetric();
+  render(<LocalityFilterSelect metric={metric} />);
+
+  const menuButton = screen.getByRole("button", {
+    name: "Judicial District All Districts",
+  });
+
+  expectedLocalities.forEach((expectedLocality) => {
+    // open the menu
+    fireEvent.click(menuButton);
+
+    const option = screen.getByRole("option", { name: expectedLocality.label });
+    fireEvent.click(option);
+
+    reactImmediately(() => {
+      expect(metric.localityId).toBe(expectedLocality.id);
+      expect(menuButton).toHaveTextContent(expectedLocality.label);
+    });
+  });
+
+  expect.hasAssertions();
+});

--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
@@ -1,0 +1,53 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { action } from "mobx";
+import { observer } from "mobx-react-lite";
+import React from "react";
+import type PopulationBreakdownByLocationMetric from "../contentModels/PopulationBreakdownByLocationMetric";
+import type SentenceTypeByLocationMetric from "../contentModels/SentenceTypeByLocationMetric";
+import type SupervisionSuccessRateDemographicsMetric from "../contentModels/SupervisionSuccessRateDemographicsMetric";
+import type SupervisionSuccessRateMonthlyMetric from "../contentModels/SupervisionSuccessRateMonthlyMetric";
+import { Dropdown } from "../UiLibrary";
+
+type LocalityFilterSelectProps = {
+  metric:
+    | PopulationBreakdownByLocationMetric
+    | SentenceTypeByLocationMetric
+    | SupervisionSuccessRateMonthlyMetric
+    | SupervisionSuccessRateDemographicsMetric;
+};
+
+const LocalityFilterSelect: React.FC<LocalityFilterSelectProps> = ({
+  metric,
+}) => {
+  const onChange = action("change locality filter", (newFilter: string) => {
+    // eslint-disable-next-line no-param-reassign
+    metric.localityId = newFilter;
+  });
+
+  return (
+    <Dropdown
+      label={metric.localityLabels.label}
+      onChange={onChange}
+      options={metric.localityLabels.entries}
+      selectedId={metric.localityId}
+    />
+  );
+};
+
+export default observer(LocalityFilterSelect);

--- a/spotlight-client/src/LocalityFilterSelect/index.ts
+++ b/spotlight-client/src/LocalityFilterSelect/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export { default } from "./LocalityFilterSelect";

--- a/spotlight-client/src/SystemNarrativePage/__fixtures__/contentSource.ts
+++ b/spotlight-client/src/SystemNarrativePage/__fixtures__/contentSource.ts
@@ -81,6 +81,34 @@ const content: TenantContent = {
       ],
     },
   },
+  localities: {
+    Sentencing: {
+      label: "sentencing locality",
+      entries: [
+        {
+          id: "sentencing a",
+          label: "sentencing A",
+        },
+        {
+          id: "sentencing b",
+          label: "sentencing B",
+        },
+      ],
+    },
+    Parole: {
+      label: "parole locality",
+      entries: [
+        {
+          id: "parole a",
+          label: "parole A",
+        },
+        {
+          id: "parole b",
+          label: "parole B",
+        },
+      ],
+    },
+  },
 };
 
 export default content;

--- a/spotlight-client/src/constants.ts
+++ b/spotlight-client/src/constants.ts
@@ -19,6 +19,8 @@ export const ERROR_MESSAGES = {
   auth0Configuration: "No Auth0 configuration found.",
   unauthorized: "You do not have permission to view this content.",
   noMetricData: "Unable to retrieve valid data for this metric.",
+  noLocalityLabels:
+    "Unable to create Metric because locality labels are missing",
 };
 
 export const NAV_BAR_HEIGHT = 80;

--- a/spotlight-client/src/contentApi/sources/us_nd.ts
+++ b/spotlight-client/src/contentApi/sources/us_nd.ts
@@ -17,6 +17,20 @@
 
 import { TenantContent } from "../types";
 
+// localities for both sentencing and probation
+const judicialDistricts = [
+  { id: "ALL", label: "All Districts" },
+  { id: "EAST_CENTRAL", label: "East Central" },
+  { id: "NORTH_CENTRAL", label: "North Central" },
+  { id: "NORTHEAST", label: "Northeast" },
+  { id: "NORTHEAST_CENTRAL", label: "Northeast Central" },
+  { id: "NORTHWEST", label: "Northwest" },
+  { id: "SOUTH_CENTRAL", label: "South Central" },
+  { id: "SOUTHEAST", label: "Southeast" },
+  { id: "SOUTHWEST", label: "Southwest" },
+  { id: "OTHER", label: "Other" },
+];
+
 const content: TenantContent = {
   name: "North Dakota",
   description:
@@ -325,6 +339,58 @@ const content: TenantContent = {
             '<a href="https://www.behavioralhealth.nd.gov/addiction/FTR-old" >Free Through Recovery (FTR)</a> is a community based behavioral health program designed to increase recovery support services to individuals involved with the criminal justice system who have behavioral health concerns. The map below shows the number of people enrolled in the FTR program today.',
           metricTypeId: "ParoleProgrammingCurrent",
         },
+      ],
+    },
+  },
+  localities: {
+    Sentencing: {
+      label: "Judicial District",
+      entries: judicialDistricts,
+    },
+    Prison: {
+      label: "Facility",
+      entries: [
+        { id: "ALL", label: "All Facilities" },
+        { id: "BTC", label: "Bismarck Transition Center" },
+        { id: "DWCRC", label: "Dakota Women's Correctional" },
+        { id: "FTPFAR", label: "Fargo-Female Transition Program" },
+        { id: "MTPFAR", label: "Fargo-Male Transition Program" },
+        { id: "GFC", label: "Grand Forks County Correctional" },
+        { id: "JRCC", label: "James River Correctional Center" },
+        { id: "LRRP", label: "Lake Region Residential Reentry Center" },
+        { id: "FTPMND", label: "Mandan-Female Transition Program" },
+        { id: "MTPMND", label: "Mandan-Male Transition Program" },
+        { id: "MRCC", label: "Missouri River Correctional" },
+        { id: "NDSP", label: "North Dakota State Penitentiary" },
+        { id: "TRC", label: "Tompkins Rehabilitation And Corrections Center" },
+      ],
+    },
+    Probation: {
+      label: "Judicial District",
+      entries: judicialDistricts,
+    },
+    Parole: {
+      label: "Office",
+      entries: [
+        { label: "All Offices", id: "ALL" },
+        { label: "Beulah", id: "16" },
+        { label: "Bismarck", id: "1" },
+        { label: "Bottineau", id: "14" },
+        { label: "Central Office", id: "17" },
+        { label: "Devils Lake", id: "6" },
+        { label: "Dickinson", id: "11" },
+        { label: "Fargo", id: "4" },
+        { label: "Grafton", id: "12" },
+        { label: "Grand Forks", id: "5" },
+        { label: "Jamestown", id: "2" },
+        { label: "Mandan", id: "13" },
+        { label: "Minot", id: "3" },
+        { label: "Oakes", id: "15" },
+        { label: "Rolla", id: "8" },
+        { label: "Wahpeton", id: "7" },
+        { label: "Washburn", id: "9" },
+        { label: "Watford City", id: "18" },
+        { label: "Williston", id: "10" },
       ],
     },
   },

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -20,6 +20,11 @@ export type NamedEntity = {
   description: string;
 };
 
+export type LocalityLabels = {
+  label: string;
+  entries: { id: string; label: string }[];
+};
+
 // ============================
 // Tenant types
 
@@ -43,6 +48,11 @@ export type TenantContent = NamedEntity & {
   };
   systemNarratives: {
     [key in SystemNarrativeTypeId]?: SystemNarrativeContent;
+  };
+  // this is optional because it is possible (though unlikely)
+  // to not have any metrics that actually need it
+  localities?: {
+    [key in SystemNarrativeTypeId]?: LocalityLabels;
   };
 };
 

--- a/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
+++ b/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
@@ -89,6 +89,7 @@ const getMetric = async () => {
     tenantId: "US_ND",
     defaultDemographicView: "total",
     defaultLocalityId: undefined,
+    localityLabels: undefined,
     dataTransformer: mockTransformer,
     sourceFileName: mockSourceFileName,
   });

--- a/spotlight-client/src/contentModels/Metric.test.ts
+++ b/spotlight-client/src/contentModels/Metric.test.ts
@@ -25,10 +25,12 @@ import { reactImmediately } from "../testUtils";
 import createMetricMapping from "./createMetricMapping";
 
 const testTenantId = "US_ND";
-const testMetadataMapping = retrieveContent({ tenantId: testTenantId }).metrics;
+const allTestContent = retrieveContent({ tenantId: testTenantId });
+const testMetadataMapping = allTestContent.metrics;
 
 const getTestMapping = () =>
   createMetricMapping({
+    localityLabelMapping: allTestContent.localities,
     metadataMapping: testMetadataMapping,
     tenantId: testTenantId,
   });

--- a/spotlight-client/src/contentModels/Metric.ts
+++ b/spotlight-client/src/contentModels/Metric.ts
@@ -24,7 +24,7 @@ import {
 } from "mobx";
 import { DataSeries } from "../charts/types";
 import { ERROR_MESSAGES } from "../constants";
-import { TenantId } from "../contentApi/types";
+import { LocalityLabels, TenantId } from "../contentApi/types";
 import {
   fetchMetrics,
   RawMetricData,
@@ -45,6 +45,9 @@ export type BaseMetricConstructorOptions<RecordFormat extends MetricRecord> = {
     ? DemographicView
     : undefined;
   defaultLocalityId: RecordFormat extends LocalityFields ? string : undefined;
+  localityLabels: RecordFormat extends LocalityFields
+    ? LocalityLabels
+    : undefined;
 };
 
 /**
@@ -87,6 +90,10 @@ export default abstract class Metric<RecordFormat extends MetricRecord> {
   // filter properties
   localityId: RecordFormat extends LocalityFields ? string : undefined;
 
+  localityLabels: RecordFormat extends LocalityFields
+    ? LocalityLabels
+    : undefined;
+
   demographicView: RecordFormat extends DemographicFields
     ? DemographicView
     : undefined;
@@ -100,6 +107,7 @@ export default abstract class Metric<RecordFormat extends MetricRecord> {
     dataTransformer,
     defaultDemographicView,
     defaultLocalityId,
+    localityLabels,
   }: BaseMetricConstructorOptions<RecordFormat>) {
     makeObservable(this, {
       allRecords: observable.ref,
@@ -123,6 +131,7 @@ export default abstract class Metric<RecordFormat extends MetricRecord> {
 
     // initialize filters
     this.localityId = defaultLocalityId;
+    this.localityLabels = localityLabels;
     this.demographicView = defaultDemographicView;
   }
 

--- a/spotlight-client/src/contentModels/Metric.ts
+++ b/spotlight-client/src/contentModels/Metric.ts
@@ -112,6 +112,7 @@ export default abstract class Metric<RecordFormat extends MetricRecord> {
     makeObservable(this, {
       allRecords: observable.ref,
       demographicView: observable,
+      localityId: observable,
       error: observable,
       populateAllRecords: action,
       isLoading: observable,

--- a/spotlight-client/src/contentModels/Tenant.ts
+++ b/spotlight-client/src/contentModels/Tenant.ts
@@ -81,6 +81,7 @@ function getMetricsForTenant(
   tenantId: TenantId
 ) {
   return createMetricMapping({
+    localityLabelMapping: allTenantContent.localities,
     metadataMapping: allTenantContent.metrics,
     tenantId,
   });

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -198,6 +198,60 @@ const content: DeepRequired<TenantContent> = {
       ],
     },
   },
+  localities: {
+    Sentencing: {
+      label: "sentencing locality",
+      entries: [
+        {
+          id: "sentencing a",
+          label: "sentencing A",
+        },
+        {
+          id: "sentencing b",
+          label: "sentencing B",
+        },
+      ],
+    },
+    Prison: {
+      label: "prison locality",
+      entries: [
+        {
+          id: "prison a",
+          label: "prison A",
+        },
+        {
+          id: "prison b",
+          label: "prison B",
+        },
+      ],
+    },
+    Probation: {
+      label: "probation locality",
+      entries: [
+        {
+          id: "probation a",
+          label: "probation A",
+        },
+        {
+          id: "probation b",
+          label: "probation B",
+        },
+      ],
+    },
+    Parole: {
+      label: "parole locality",
+      entries: [
+        {
+          id: "parole a",
+          label: "parole A",
+        },
+        {
+          id: "parole b",
+          label: "parole B",
+        },
+      ],
+    },
+  },
 };
 
 export default content;

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
@@ -77,6 +77,47 @@ const content: TenantContent = {
       ],
     },
   },
+  localities: {
+    Sentencing: {
+      label: "sentencing locality",
+      entries: [
+        {
+          id: "sentencing a",
+          label: "sentencing A",
+        },
+        {
+          id: "sentencing b",
+          label: "sentencing B",
+        },
+      ],
+    },
+    Prison: {
+      label: "prison locality",
+      entries: [
+        {
+          id: "prison a",
+          label: "prison A",
+        },
+        {
+          id: "prison b",
+          label: "prison B",
+        },
+      ],
+    },
+    Parole: {
+      label: "parole locality",
+      entries: [
+        {
+          id: "parole a",
+          label: "parole A",
+        },
+        {
+          id: "parole b",
+          label: "parole B",
+        },
+      ],
+    },
+  },
 };
 
 export default content;

--- a/spotlight-client/src/contentModels/createMetricMapping.ts
+++ b/spotlight-client/src/contentModels/createMetricMapping.ts
@@ -93,7 +93,7 @@ export default function createMetricMapping({
             ...metadata,
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
-            defaultLocalityId: NOFILTER_KEY,
+            defaultLocalityId: TOTAL_KEY,
             localityLabels: localityLabelMapping.Sentencing,
             dataTransformer: sentencePopulationCurrent,
             sourceFileName: "sentence_type_by_district_by_demographics",
@@ -127,7 +127,7 @@ export default function createMetricMapping({
             ...metadata,
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
-            defaultLocalityId: NOFILTER_KEY,
+            defaultLocalityId: TOTAL_KEY,
             localityLabels: localityLabelMapping.Prison,
             dataTransformer: prisonPopulationCurrent,
             sourceFileName:
@@ -145,7 +145,7 @@ export default function createMetricMapping({
             ...metadata,
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
-            defaultLocalityId: NOFILTER_KEY,
+            defaultLocalityId: TOTAL_KEY,
             localityLabels: localityLabelMapping.Probation,
             dataTransformer: probationPopulationCurrent,
             sourceFileName:
@@ -163,7 +163,7 @@ export default function createMetricMapping({
             ...metadata,
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
-            defaultLocalityId: NOFILTER_KEY,
+            defaultLocalityId: TOTAL_KEY,
             localityLabels: localityLabelMapping.Parole,
             dataTransformer: parolePopulationCurrent,
             sourceFileName:

--- a/spotlight-client/src/contentModels/createMetricMapping.ts
+++ b/spotlight-client/src/contentModels/createMetricMapping.ts
@@ -50,8 +50,10 @@ import SentenceTypeByLocationMetric from "./SentenceTypeByLocationMetric";
 import SupervisionSuccessRateDemographicsMetric from "./SupervisionSuccessRateDemographicsMetric";
 import SupervisionSuccessRateMonthlyMetric from "./SupervisionSuccessRateMonthlyMetric";
 import { NOFILTER_KEY, TOTAL_KEY } from "../metricsApi/utils";
+import { ERROR_MESSAGES } from "../constants";
 
 type MetricMappingFactoryOptions = {
+  localityLabelMapping: TenantContent["localities"];
   metadataMapping: TenantContent["metrics"];
   tenantId: TenantId;
 };
@@ -62,6 +64,7 @@ type MetricMappingFactoryOptions = {
  * type guarding on the part of consumers.
  */
 export default function createMetricMapping({
+  localityLabelMapping,
   metadataMapping,
   tenantId,
 }: MetricMappingFactoryOptions): MetricMapping {
@@ -81,6 +84,9 @@ export default function createMetricMapping({
     // allowing for 1:1 correspondence between the ID and the typed Metric instance.
     switch (metricType) {
       case "SentencePopulationCurrent":
+        if (!localityLabelMapping?.Sentencing)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new PopulationBreakdownByLocationMetric({
@@ -88,12 +94,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Sentencing,
             dataTransformer: sentencePopulationCurrent,
             sourceFileName: "sentence_type_by_district_by_demographics",
           })
         );
         break;
       case "SentenceTypesCurrent":
+        if (!localityLabelMapping?.Sentencing)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new SentenceTypeByLocationMetric({
@@ -101,12 +111,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Sentencing,
             dataTransformer: sentenceTypesCurrent,
             sourceFileName: "sentence_type_by_district_by_demographics",
           })
         );
         break;
       case "PrisonPopulationCurrent":
+        if (!localityLabelMapping?.Prison)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new PopulationBreakdownByLocationMetric({
@@ -114,6 +128,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Prison,
             dataTransformer: prisonPopulationCurrent,
             sourceFileName:
               "incarceration_population_by_facility_by_demographics",
@@ -121,6 +136,9 @@ export default function createMetricMapping({
         );
         break;
       case "ProbationPopulationCurrent":
+        if (!localityLabelMapping?.Probation)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new PopulationBreakdownByLocationMetric({
@@ -128,6 +146,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Probation,
             dataTransformer: probationPopulationCurrent,
             sourceFileName:
               "supervision_population_by_district_by_demographics",
@@ -135,6 +154,9 @@ export default function createMetricMapping({
         );
         break;
       case "ParolePopulationCurrent":
+        if (!localityLabelMapping?.Parole)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new PopulationBreakdownByLocationMetric({
@@ -142,6 +164,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: NOFILTER_KEY,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Parole,
             dataTransformer: parolePopulationCurrent,
             sourceFileName:
               "supervision_population_by_district_by_demographics",
@@ -156,6 +179,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: prisonPopulationHistorical,
             sourceFileName: "incarceration_population_by_month_by_demographics",
           })
@@ -169,6 +193,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: probationPopulationHistorical,
             sourceFileName: "supervision_population_by_month_by_demographics",
           })
@@ -182,12 +207,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: parolePopulationHistorical,
             sourceFileName: "supervision_population_by_month_by_demographics",
           })
         );
         break;
       case "ProbationProgrammingCurrent":
+        if (!localityLabelMapping?.Probation)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new ProgramParticipationCurrentMetric({
@@ -195,12 +224,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: undefined,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Probation,
             dataTransformer: probationProgramParticipationCurrent,
             sourceFileName: "active_program_participation_by_region",
           })
         );
         break;
       case "ParoleProgrammingCurrent":
+        if (!localityLabelMapping?.Parole)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new ProgramParticipationCurrentMetric({
@@ -208,12 +241,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: undefined,
             defaultLocalityId: NOFILTER_KEY,
+            localityLabels: localityLabelMapping.Parole,
             dataTransformer: paroleProgramParticipationCurrent,
             sourceFileName: "active_program_participation_by_region",
           })
         );
         break;
       case "ProbationSuccessHistorical":
+        if (!localityLabelMapping?.Probation)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new SupervisionSuccessRateMonthlyMetric({
@@ -221,12 +258,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: undefined,
             defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Probation,
             dataTransformer: probationSuccessRateMonthly,
             sourceFileName: "supervision_success_by_month",
           })
         );
         break;
       case "ParoleSuccessHistorical":
+        if (!localityLabelMapping?.Parole)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new SupervisionSuccessRateMonthlyMetric({
@@ -234,12 +275,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: undefined,
             defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Parole,
             dataTransformer: paroleSuccessRateMonthly,
             sourceFileName: "supervision_success_by_month",
           })
         );
         break;
       case "ProbationSuccessAggregate":
+        if (!localityLabelMapping?.Probation)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new SupervisionSuccessRateDemographicsMetric({
@@ -247,12 +292,16 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Probation,
             dataTransformer: probationSuccessRateDemographics,
             sourceFileName: "supervision_success_by_period_by_demographics",
           })
         );
         break;
       case "ParoleSuccessAggregate":
+        if (!localityLabelMapping?.Parole)
+          throw new Error(ERROR_MESSAGES.noLocalityLabels);
+
         metricMapping.set(
           metricType,
           new SupervisionSuccessRateDemographicsMetric({
@@ -260,6 +309,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Parole,
             dataTransformer: paroleSuccessRateDemographics,
             sourceFileName: "supervision_success_by_period_by_demographics",
           })
@@ -273,6 +323,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: probationRevocationReasons,
             sourceFileName:
               "supervision_revocations_by_period_by_type_by_demographics",
@@ -287,6 +338,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: paroleRevocationReasons,
             sourceFileName:
               "supervision_revocations_by_period_by_type_by_demographics",
@@ -301,6 +353,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: prisonAdmissionReasons,
             sourceFileName: "incarceration_population_by_admission_reason",
           })
@@ -314,6 +367,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: prisonReleaseTypes,
             sourceFileName: "incarceration_releases_by_type_by_period",
           })
@@ -327,6 +381,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: recidivismRateAllFollowup,
             sourceFileName: "recidivism_rates_by_cohort_by_year",
           })
@@ -340,6 +395,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: recidivismRateConventionalFollowup,
             sourceFileName: "recidivism_rates_by_cohort_by_year",
           })
@@ -353,6 +409,7 @@ export default function createMetricMapping({
             tenantId,
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
+            localityLabels: undefined,
             dataTransformer: prisonStayLengths,
             sourceFileName: "incarceration_lengths_by_demographics",
           })


### PR DESCRIPTION
## Description of the change

Creates another `Dropdown` variant, this time for filtering charts by location. To customize location names (which we need to do, since the raw location IDs are generally not suitable for display) we have to add that configuration to the content object per tenant. This does that and then creates a thin wrapper around Dropdown, similar to what was done for the demographic filter. 

This isn't used anywhere in the UI yet but I did write some tests to put it through its paces. (Also added similar tests for the demographic filter component since it seemed like a good thing to have.) 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #299

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
