### PR TITLE
Statistic and Proportional Bar components

### DIFF
--- a/spotlight-client/src/App.tsx
+++ b/spotlight-client/src/App.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { RouteComponentProps, Router } from "@reach/router";
+import { setup as setupBreakpoints } from "@w11r/use-breakpoint";
 import { rem } from "polished";
 import React from "react";
 import { HelmetProvider } from "react-helmet-async";
@@ -33,6 +34,12 @@ import SiteFooter from "./SiteFooter";
 import SiteNavigation from "./SiteNavigation";
 import StoreProvider from "./StoreProvider";
 import TooltipMobile from "./TooltipMobile";
+import { breakpoints } from "./UiLibrary";
+
+// set custom breakpoints for media queries
+setupBreakpoints({
+  breakpoints,
+});
 
 /**
  * Helps with nesting; all it does is render its children.

--- a/spotlight-client/src/GlobalStyles/GlobalStyles.tsx
+++ b/spotlight-client/src/GlobalStyles/GlobalStyles.tsx
@@ -48,7 +48,7 @@ const GlobalStyles: React.FC = () => {
       <Helmet>
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;600;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
         <link

--- a/spotlight-client/src/Statistic/Statistic.test.tsx
+++ b/spotlight-client/src/Statistic/Statistic.test.tsx
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,10 +15,24 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export { default as animation } from "./animation";
-export { default as breakpoints } from "./breakpoints";
-export { default as Chevron } from "./Chevron";
-export { default as colors } from "./colors";
-export { default as Dropdown } from "./Dropdown";
-export * from "./typography";
-export { default as zIndex } from "./zIndex";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import Statistic from "./Statistic";
+
+const maxSize = 96;
+const minSize = 32;
+
+test("has value and label", () => {
+  render(<Statistic value={10} label="things" {...{ maxSize, minSize }} />);
+  expect(screen.getByRole("figure")).toHaveTextContent("10things");
+});
+
+test("has no label", () => {
+  render(<Statistic value="99%" {...{ maxSize, minSize }} />);
+  expect(screen.getByRole("figure")).toHaveTextContent("99%");
+});
+
+test("no data", () => {
+  render(<Statistic {...{ maxSize, minSize }} />);
+  expect(screen.getByRole("figure")).toHaveTextContent("No data");
+});

--- a/spotlight-client/src/Statistic/Statistic.tsx
+++ b/spotlight-client/src/Statistic/Statistic.tsx
@@ -1,0 +1,63 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { rem } from "polished";
+import React from "react";
+import styled from "styled-components/macro";
+import { colors, fluidFontSizeStyles, typefaces } from "../UiLibrary";
+
+const StatisticsWrapper = styled.figure``;
+
+const ValueWrapper = styled.div<{ minSize: number; maxSize: number }>`
+  color: ${colors.text};
+  font: ${typefaces.display};
+  line-height: 100%;
+  letter-spacing: -0.07em;
+
+  ${(props) => fluidFontSizeStyles(props.minSize, props.maxSize)}
+`;
+
+const LabelWrapper = styled.figcaption`
+  color: ${colors.caption};
+  font-size: ${rem(16)};
+  font-weight: 500;
+  letter-spacing: -0.01;
+  line-height: 1.5;
+`;
+
+type StatisticProps = {
+  value?: string | number;
+  label?: string;
+  maxSize: number;
+  minSize: number;
+};
+
+const Statistic: React.FC<StatisticProps> = ({
+  label,
+  maxSize,
+  minSize,
+  value = "No data",
+}) => {
+  return (
+    <StatisticsWrapper>
+      <ValueWrapper {...{ maxSize, minSize }}>{value}</ValueWrapper>
+      {label && <LabelWrapper>{label}</LabelWrapper>}
+    </StatisticsWrapper>
+  );
+};
+
+export default Statistic;

--- a/spotlight-client/src/Statistic/index.ts
+++ b/spotlight-client/src/Statistic/index.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,10 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export { default as animation } from "./animation";
-export { default as breakpoints } from "./breakpoints";
-export { default as Chevron } from "./Chevron";
-export { default as colors } from "./colors";
-export { default as Dropdown } from "./Dropdown";
-export * from "./typography";
-export { default as zIndex } from "./zIndex";
+export { default } from "./Statistic";

--- a/spotlight-client/src/UiLibrary/breakpoints.ts
+++ b/spotlight-client/src/UiLibrary/breakpoints.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,10 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export { default as animation } from "./animation";
-export { default as breakpoints } from "./breakpoints";
-export { default as Chevron } from "./Chevron";
-export { default as colors } from "./colors";
-export { default as Dropdown } from "./Dropdown";
-export * from "./typography";
-export { default as zIndex } from "./zIndex";
+/**
+ * these are overrides to defaults in @w11r/use-breakpoint
+ */
+export default {
+  mobile: [320, 767],
+  tablet: [768, 1023],
+  desktop: [1024, 1279],
+  xl: [1280, 10000],
+};

--- a/spotlight-client/src/UiLibrary/colors.ts
+++ b/spotlight-client/src/UiLibrary/colors.ts
@@ -45,6 +45,7 @@ export default {
   caption: pinePale,
   chartAxis: pine,
   chartGridLine: pinePale,
+  chartNoData: gray,
   dataViz: Array.from(dataVizColorMap.values()),
   dataVizNamed: dataVizColorMap,
   footerBackground: pineDark,

--- a/spotlight-client/src/UiLibrary/typography.ts
+++ b/spotlight-client/src/UiLibrary/typography.ts
@@ -15,7 +15,38 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export default {
+import { rem } from "polished";
+import { breakpoints } from ".";
+
+export const typefaces = {
   body: "'Libre Franklin', sans-serif",
   display: "'Libre Baskerville', serif",
 };
+
+const [mobileMin] = breakpoints.mobile;
+const [desktopMin] = breakpoints.desktop;
+
+/**
+ * Implements fluid typography technique to scale text size
+ * by viewport from min to max
+ * @see <https://css-tricks.com/simplified-fluid-typography/>
+ */
+export function fluidFontSizeStyles(
+  minFontSize: number,
+  maxFontSize: number
+): string {
+  return `
+    font-size: ${rem(minFontSize)};
+
+    @media screen and (min-width: ${mobileMin}px) {
+      font-size: calc(
+        ${rem(minFontSize)} + ${rem(maxFontSize - minFontSize)} *
+          ((100vw - ${rem(mobileMin)}) / ${desktopMin - mobileMin})
+      );
+    }
+
+    @media screen and (min-width: ${desktopMin}px) {
+      font-size: ${rem(maxFontSize)};
+    }
+  `;
+}

--- a/spotlight-client/src/VizHistoricalPopulationBreakdown/VizHistoricalPopulationBreakdown.test.tsx
+++ b/spotlight-client/src/VizHistoricalPopulationBreakdown/VizHistoricalPopulationBreakdown.test.tsx
@@ -15,15 +15,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { advanceTo, clear } from "jest-date-mock";
 import { runInAction } from "mobx";
 import React from "react";
 import VizHistoricalPopulationBreakdown from ".";
 import HistoricalPopulationBreakdownMetric from "../contentModels/HistoricalPopulationBreakdownMetric";
 import DataStore from "../DataStore";
-import StoreProvider from "../StoreProvider";
-import { reactImmediately } from "../testUtils";
+import { reactImmediately, renderWithStore } from "../testUtils";
 
 let metric: HistoricalPopulationBreakdownMetric;
 
@@ -53,16 +52,12 @@ afterEach(() => {
 });
 
 test("loading", () => {
-  render(<VizHistoricalPopulationBreakdown metric={metric} />, {
-    wrapper: StoreProvider,
-  });
+  renderWithStore(<VizHistoricalPopulationBreakdown metric={metric} />);
   expect(screen.getByText(/loading/i)).toBeVisible();
 });
 
 test("renders total", async () => {
-  render(<VizHistoricalPopulationBreakdown metric={metric} />, {
-    wrapper: StoreProvider,
-  });
+  renderWithStore(<VizHistoricalPopulationBreakdown metric={metric} />);
 
   await waitFor(() => {
     expect(
@@ -85,9 +80,7 @@ test("renders total", async () => {
 });
 
 test("plots demographic categories", async () => {
-  render(<VizHistoricalPopulationBreakdown metric={metric} />, {
-    wrapper: StoreProvider,
-  });
+  renderWithStore(<VizHistoricalPopulationBreakdown metric={metric} />);
 
   const menuButton = screen.getByRole("button", {
     name: "View Total",

--- a/spotlight-client/src/charts/ProportionalBar.test.tsx
+++ b/spotlight-client/src/charts/ProportionalBar.test.tsx
@@ -1,0 +1,108 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { renderWithStore } from "../testUtils";
+import ProportionalBar from "./ProportionalBar";
+
+test("renders data", () => {
+  const testData = [
+    { label: "thing 1", color: "red", value: 10 },
+    { label: "thing 2", color: "blue", value: 51 },
+  ];
+  const title = "Testing";
+
+  renderWithStore(
+    <ProportionalBar data={testData} height={100} title={title} />
+  );
+
+  const viz = screen.getByRole("group", {
+    name: `${testData.length} bars in a bar chart`,
+  });
+  expect(viz).toBeVisible();
+
+  testData.forEach((record) => {
+    const mark = within(viz).getByRole("img", {
+      // TODO: what would happen if we used bar width instead? (probably ... something bad)
+      // this label is not amazingly informative but it's what Semiotic gives us
+      name: `${title} bar value ${record.value}`,
+    });
+    expect(mark).toBeVisible();
+    expect(mark).toHaveStyle(`fill: ${record.color}`);
+  });
+});
+
+test("chart with no data", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const testData: any[] = [];
+  const title = "Testing";
+
+  renderWithStore(
+    <ProportionalBar data={testData} height={100} title={title} />
+  );
+
+  expect(screen.getByText(`${title}, No Data`)).toBeVisible();
+  expect(screen.queryByRole("group")).not.toBeInTheDocument();
+});
+
+test("highlighting", async () => {
+  const testData = [
+    { label: "thing 1", color: "red", value: 10 },
+    { label: "thing 2", color: "blue", value: 51 },
+  ];
+  const title = "Testing";
+  const mockHighlight = jest.fn();
+
+  const { rerender } = renderWithStore(
+    <ProportionalBar
+      data={testData}
+      height={100}
+      title={title}
+      setHighlighted={mockHighlight}
+    />
+  );
+
+  // hovering over the legend should trigger the external highlight function
+  fireEvent.mouseOver(screen.getByText(testData[0].label));
+  expect(mockHighlight.mock.calls[0][0]).toEqual({ label: testData[0].label });
+
+  // hovering over the chart should not
+  fireEvent.mouseOver(
+    screen.getByRole("img", { name: `${title} bar value ${testData[1].value}` })
+  );
+  expect(mockHighlight.mock.calls.length).toBe(1);
+
+  // externally controlled highlight state
+  const unHighlightedBar = screen.getByRole("img", {
+    name: `${title} bar value ${testData[0].value}`,
+  });
+  expect(unHighlightedBar).toHaveStyle(`fill: ${testData[0].color}`);
+  rerender(
+    <ProportionalBar
+      data={testData}
+      height={100}
+      title={title}
+      setHighlighted={mockHighlight}
+      highlighted={testData[1]}
+    />
+  );
+  // color change is animated by JS
+  await waitFor(() =>
+    expect(unHighlightedBar).not.toHaveStyle(`fill: ${testData[0].color}`)
+  );
+});

--- a/spotlight-client/src/charts/ProportionalBar.test.tsx
+++ b/spotlight-client/src/charts/ProportionalBar.test.tsx
@@ -38,7 +38,6 @@ test("renders data", () => {
 
   testData.forEach((record) => {
     const mark = within(viz).getByRole("img", {
-      // TODO: what would happen if we used bar width instead? (probably ... something bad)
       // this label is not amazingly informative but it's what Semiotic gives us
       name: `${title} bar value ${record.value}`,
     });

--- a/spotlight-client/src/charts/ProportionalBar.tsx
+++ b/spotlight-client/src/charts/ProportionalBar.tsx
@@ -1,0 +1,154 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { sum } from "d3-array";
+import React, { useState } from "react";
+import OrdinalFrame from "semiotic/lib/OrdinalFrame";
+import styled from "styled-components/macro";
+import { ValuesType } from "utility-types";
+import MeasureWidth from "../MeasureWidth";
+import { animation, colors, zIndex } from "../UiLibrary";
+import ColorLegend from "./ColorLegend";
+import ResponsiveTooltipController from "./ResponsiveTooltipController";
+import { ItemToHighlight } from "./types";
+import { getDataWithPct, highlightFade } from "./utils";
+
+const ProportionalBarContainer = styled.figure`
+  height: 100%;
+  width: 100%;
+`;
+
+const ProportionalBarChartWrapper = styled.div`
+  background: ${colors.chartNoData};
+  height: 100%;
+  position: relative;
+  z-index: ${zIndex.base + 1};
+
+  .ProportionalBarChart__segment {
+    stroke: ${colors.background};
+    stroke-width: 2;
+  }
+`;
+
+const ProportionalBarMetadata = styled.figcaption`
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding-top: 4px;
+  width: 100%;
+  z-index: ${zIndex.base};
+`;
+
+const ProportionalBarTitle = styled.div`
+  flex: 0 1 auto;
+  font-size: 12px;
+  margin-right: 15px;
+`;
+
+const ProportionalBarLegendWrapper = styled.div`
+  /*
+    setting a non-auto basis lets the legend try to wrap internally
+    before the container wraps the entire legend to its own line
+  */
+  flex: 1 1 0;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+type ProportionalBarProps = {
+  data: { label: string; color: string; value: number }[];
+  height: number;
+  highlighted?: ItemToHighlight;
+  setHighlighted?: (item?: ItemToHighlight) => void;
+  showLegend?: boolean;
+  title: string;
+};
+
+export default function ProportionalBar({
+  data,
+  height,
+  highlighted: externalHighlighted,
+  setHighlighted: setExternalHighlighted,
+  showLegend = true,
+  title,
+}: ProportionalBarProps): React.ReactElement {
+  const [localHighlighted, setLocalHighlighted] = useState<ItemToHighlight>();
+
+  const dataWithPct = getDataWithPct(data);
+  const noData = data.length === 0 || sum(data.map(({ value }) => value)) === 0;
+
+  const highlighted = localHighlighted || externalHighlighted;
+
+  return (
+    <MeasureWidth>
+      {({ measureRef, width }) => (
+        <ProportionalBarContainer ref={measureRef}>
+          <ProportionalBarChartWrapper>
+            <ResponsiveTooltipController
+              pieceHoverAnnotation
+              // we don't ever want mark hover to affect other charts
+              // so it can only control the local highlight state
+              setHighlighted={setLocalHighlighted}
+            >
+              <OrdinalFrame
+                baseMarkProps={{
+                  transitionDuration: { fill: animation.defaultDuration },
+                }}
+                data={dataWithPct}
+                margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
+                // returning a static value here groups them all in a single column
+                // TODO: could we also accomplish this with dynamic width and get better labels?
+                oAccessor={() => title}
+                pieceClass="ProportionalBarChart__segment"
+                projection="horizontal"
+                rAccessor="value"
+                renderKey="label"
+                size={[width, height]}
+                style={(d: ValuesType<ProportionalBarProps["data"]>) => ({
+                  fill:
+                    highlighted && highlighted.label !== d.label
+                      ? highlightFade(d.color)
+                      : d.color,
+                })}
+                // TODO: can we give this chart a title for better accessibility?
+                type="bar"
+              />
+            </ResponsiveTooltipController>
+          </ProportionalBarChartWrapper>
+          <ProportionalBarMetadata>
+            <ProportionalBarTitle>
+              {title}
+              {noData && ", No Data"}
+            </ProportionalBarTitle>
+            {showLegend && (
+              <ProportionalBarLegendWrapper>
+                <ColorLegend
+                  highlighted={highlighted}
+                  items={data}
+                  // legend may cover multiple charts in some layouts,
+                  // so it prefers the external highlight when present
+                  setHighlighted={setExternalHighlighted || setLocalHighlighted}
+                />
+              </ProportionalBarLegendWrapper>
+            )}
+          </ProportionalBarMetadata>
+        </ProportionalBarContainer>
+      )}
+    </MeasureWidth>
+  );
+}

--- a/spotlight-client/src/charts/ProportionalBar.tsx
+++ b/spotlight-client/src/charts/ProportionalBar.tsx
@@ -112,7 +112,6 @@ export default function ProportionalBar({
                 data={dataWithPct}
                 margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
                 // returning a static value here groups them all in a single column
-                // TODO: could we also accomplish this with dynamic width and get better labels?
                 oAccessor={() => title}
                 pieceClass="ProportionalBarChart__segment"
                 projection="horizontal"
@@ -125,7 +124,7 @@ export default function ProportionalBar({
                       ? highlightFade(d.color)
                       : d.color,
                 })}
-                // TODO: can we give this chart a title for better accessibility?
+                title={title}
                 type="bar"
               />
             </ResponsiveTooltipController>

--- a/spotlight-client/src/charts/index.ts
+++ b/spotlight-client/src/charts/index.ts
@@ -15,6 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-// eslint-disable-next-line import/prefer-default-export
+export { default as ProportionalBar } from "./ProportionalBar";
 export { default as WindowedTimeSeries } from "./WindowedTimeSeries";
 export * from "./WindowedTimeSeries";

--- a/spotlight-client/src/testUtils.tsx
+++ b/spotlight-client/src/testUtils.tsx
@@ -20,11 +20,12 @@ import {
   createMemorySource,
   LocationProvider,
 } from "@reach/router";
-import { render } from "@testing-library/react";
+import { render, RenderResult } from "@testing-library/react";
 import React from "react";
 import { autorun } from "mobx";
 import waitForLocalhost from "wait-for-localhost";
 import App from "./App";
+import StoreProvider from "./StoreProvider";
 
 export function waitForTestServer(): Promise<void> {
   return waitForLocalhost({ path: "/health", port: 3002 });
@@ -58,4 +59,14 @@ export function renderNavigableApp({ route = "/" } = {}): {
     // tests can use history object to simulate navigation in a browser
     history,
   };
+}
+
+/**
+ * Renders the provided component in a StoreProvider
+ * for components that expect to access data stores
+ */
+export function renderWithStore(ui: React.ReactElement): RenderResult {
+  return render(ui, {
+    wrapper: StoreProvider,
+  });
 }


### PR DESCRIPTION
## Description of the change

Not much to see here ... these are adapted mostly as-is from v1 with some light Typescript conversion. For consistency I am now using our MeasureWidth component instead of the Semiotic `responsiveWidth` feature for the chart, but otherwise it is functionally identical. 

Not used anywhere in the UI yet but I did add some tests at least. For reference, this is what they looked like in v1:

![Screen Shot 2021-01-27 at 1 45 19 PM](https://user-images.githubusercontent.com/5385319/106058392-09315e00-60a6-11eb-88ad-6b88155d6751.png)

This unblocks the population sections at the top of every page, which is a larger chunk of work that will follow in the next PR. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #297, closes #298 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
