### PR TITLE
Sentence Types section

### DIFF
--- a/spotlight-client/src/DemographicFilterSelect/DemographicFilterSelect.tsx
+++ b/spotlight-client/src/DemographicFilterSelect/DemographicFilterSelect.tsx
@@ -21,6 +21,7 @@ import React from "react";
 import type DemographicsByCategoryMetric from "../contentModels/DemographicsByCategoryMetric";
 import type HistoricalPopulationBreakdownMetric from "../contentModels/HistoricalPopulationBreakdownMetric";
 import RecidivismRateMetric from "../contentModels/RecidivismRateMetric";
+import SentenceTypeByLocationMetric from "../contentModels/SentenceTypeByLocationMetric";
 import {
   DemographicView,
   DemographicViewList,
@@ -35,7 +36,8 @@ type DemographicFilterSelectProps = {
   metric:
     | HistoricalPopulationBreakdownMetric
     | DemographicsByCategoryMetric
-    | RecidivismRateMetric;
+    | RecidivismRateMetric
+    | SentenceTypeByLocationMetric;
 };
 
 const DemographicFilterSelect: React.FC<DemographicFilterSelectProps> = ({

--- a/spotlight-client/src/MetricVizMapper/MetricVizMapper.tsx
+++ b/spotlight-client/src/MetricVizMapper/MetricVizMapper.tsx
@@ -27,6 +27,8 @@ import VizDemographicsByCategory from "../VizDemographicsByCategory";
 import VizPrisonStayLengths from "../VizPrisonStayLengths";
 import RecidivismRateMetric from "../contentModels/RecidivismRateMetric";
 import VizRecidivismRateSingleFollowup from "../VizRecidivismRateSingleFollowup";
+import SentenceTypeByLocationMetric from "../contentModels/SentenceTypeByLocationMetric";
+import VizSentenceTypeByLocation from "../VizSentenceTypeByLocation";
 
 type MetricVizMapperProps = {
   metric: Metric<MetricRecord>;
@@ -49,6 +51,9 @@ const MetricVizMapper: React.FC<MetricVizMapperProps> = ({ metric }) => {
     if (metric.id === "PrisonRecidivismRateSingleFollowupHistorical") {
       return <VizRecidivismRateSingleFollowup metric={metric} />;
     }
+  }
+  if (metric instanceof SentenceTypeByLocationMetric) {
+    return <VizSentenceTypeByLocation metric={metric} />;
   }
   return <h3>Placeholder for {metric.name}</h3>;
 };

--- a/spotlight-client/src/Statistic/Statistic.tsx
+++ b/spotlight-client/src/Statistic/Statistic.tsx
@@ -19,9 +19,16 @@ import { rem } from "polished";
 import React from "react";
 import { animated, useTransition } from "react-spring/web.cjs";
 import styled from "styled-components/macro";
-import { colors, fluidFontSizeStyles, typefaces } from "../UiLibrary";
+import {
+  animation,
+  colors,
+  fluidFontSizeStyles,
+  typefaces,
+} from "../UiLibrary";
 
-const StatisticsWrapper = styled.figure``;
+const StatisticsWrapper = styled.figure`
+  position: relative;
+`;
 
 const Value = styled.div<{ minSize: number; maxSize: number }>`
   color: ${colors.text};
@@ -54,12 +61,7 @@ const Statistic: React.FC<StatisticProps> = ({
   minSize,
   value = "No data",
 }) => {
-  const transitions = useTransition(value, null, {
-    initial: { opacity: 1 },
-    from: { opacity: 0 },
-    enter: { opacity: 1 },
-    leave: { opacity: 0, position: "absolute" },
-  });
+  const transitions = useTransition(value, null, animation.crossFade);
   return (
     // figcaption does not seem to get consistently picked up as the accessible name,
     // so including it as a label here too for insurance

--- a/spotlight-client/src/UiLibrary/animation.ts
+++ b/spotlight-client/src/UiLibrary/animation.ts
@@ -16,7 +16,15 @@
 // =============================================================================
 
 const defaultDuration = 500;
+const crossFade = {
+  initial: { opacity: 1, top: 0 },
+  from: { opacity: 0 },
+  enter: { opacity: 1 },
+  leave: { opacity: 0, position: "absolute" },
+  config: { friction: 40, tension: 280 },
+} as const;
 
 export default {
   defaultDuration,
+  crossFade,
 };

--- a/spotlight-client/src/VizDemographicsByCategory/VizDemographicsByCategory.tsx
+++ b/spotlight-client/src/VizDemographicsByCategory/VizDemographicsByCategory.tsx
@@ -27,7 +27,7 @@ import DemographicsByCategoryMetric from "../contentModels/DemographicsByCategor
 import DemographicFilterSelect from "../DemographicFilterSelect";
 import FiltersWrapper from "../FiltersWrapper";
 import NoMetricData from "../NoMetricData";
-import { zIndex } from "../UiLibrary";
+import { animation, zIndex } from "../UiLibrary";
 
 const bubbleChartHeight = 325;
 
@@ -64,13 +64,7 @@ const VizDemographicsByCategory: React.FC<VizDemographicsByCategoryProps> = ({
   const chartTransitions = useTransition(
     { demographicView, dataSeries },
     (item) => item.demographicView,
-    {
-      initial: { opacity: 1 },
-      from: { opacity: 0 },
-      enter: { opacity: 1 },
-      leave: { opacity: 0, position: "absolute" },
-      config: { friction: 40, tension: 280 },
-    }
+    animation.crossFade
   );
 
   if (demographicView === "nofilter")
@@ -94,7 +88,7 @@ const VizDemographicsByCategory: React.FC<VizDemographicsByCategoryProps> = ({
             <animated.div style={chartContainerStyles}>
               {chartTransitions.map(({ item, key, props }) => (
                 <ChartWrapper key={key} ref={measureRef}>
-                  <animated.div style={{ ...props, top: 0 }}>
+                  <animated.div style={props}>
                     {
                       // for type safety we have to check this again
                       // but it should always be defined if we've gotten this far

--- a/spotlight-client/src/VizPrisonStayLengths/VizPrisonStayLengths.tsx
+++ b/spotlight-client/src/VizPrisonStayLengths/VizPrisonStayLengths.tsx
@@ -31,6 +31,7 @@ import DemographicFilterSelect from "../DemographicFilterSelect";
 import FiltersWrapper from "../FiltersWrapper";
 import { prisonStayLengthFields } from "../metricsApi";
 import NoMetricData from "../NoMetricData";
+import { animation } from "../UiLibrary";
 
 const ChartsWrapper = styled.div`
   position: relative;
@@ -81,13 +82,7 @@ const VizPrisonStayLengths: React.FC<VizPrisonStayLengthsProps> = ({
   const chartTransitions = useTransition(
     { demographicView, dataSeries },
     (item) => item.demographicView,
-    {
-      initial: { opacity: 1 },
-      from: { opacity: 0 },
-      enter: { opacity: 1 },
-      leave: { opacity: 0, position: "absolute" },
-      config: { friction: 40, tension: 280 },
-    }
+    animation.crossFade
   );
 
   if (demographicView === "nofilter")
@@ -109,9 +104,9 @@ const VizPrisonStayLengths: React.FC<VizPrisonStayLengthsProps> = ({
               filters={[<DemographicFilterSelect metric={metric} />]}
             />
             <animated.div style={chartContainerStyles}>
-              {chartTransitions.map(({ item, key, props }) => (
-                <ChartsWrapper key={key} ref={measureRef}>
-                  <animated.div style={{ ...props, top: 0 }}>
+              <ChartsWrapper ref={measureRef}>
+                {chartTransitions.map(({ item, key, props }) => (
+                  <animated.div key={key} style={props}>
                     {
                       // for type safety we have to check this again
                       // but it should always be defined if we've gotten this far
@@ -123,8 +118,8 @@ const VizPrisonStayLengths: React.FC<VizPrisonStayLengthsProps> = ({
                       )
                     }
                   </animated.div>
-                </ChartsWrapper>
-              ))}
+                ))}
+              </ChartsWrapper>
             </animated.div>
           </>
         )}

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
@@ -30,6 +30,7 @@ import RecidivismRateMetric from "../contentModels/RecidivismRateMetric";
 import DemographicFilterSelect from "../DemographicFilterSelect";
 import FiltersWrapper from "../FiltersWrapper";
 import NoMetricData from "../NoMetricData";
+import { animation } from "../UiLibrary";
 import FollowupPeriodFilterSelect from "./FollowupPeriodFilterSelect";
 
 const ChartsWrapper = styled.div`
@@ -79,13 +80,7 @@ const VizRecidivismRateSingleFollowup: React.FC<VizRecidivismRateSingleFollowupP
   const chartTransitions = useTransition(
     { demographicView, singleFollowupDemographics },
     (item) => item.demographicView,
-    {
-      initial: { opacity: 1 },
-      from: { opacity: 0 },
-      enter: { opacity: 1 },
-      leave: { opacity: 0, position: "absolute" },
-      config: { friction: 40, tension: 280 },
-    }
+    animation.crossFade
   );
 
   if (demographicView === "nofilter")
@@ -110,9 +105,9 @@ const VizRecidivismRateSingleFollowup: React.FC<VizRecidivismRateSingleFollowupP
               ]}
             />
             <animated.div style={chartContainerStyles}>
-              {chartTransitions.map(({ item, key, props }) => (
-                <ChartsWrapper key={key} ref={measureRef}>
-                  <animated.div style={{ ...props, top: 0 }}>
+              <ChartsWrapper ref={measureRef}>
+                {chartTransitions.map(({ item, key, props }) => (
+                  <animated.div key={key} style={props}>
                     {
                       // for type safety we have to check this again
                       // but it should always be defined if we've gotten this far
@@ -125,8 +120,8 @@ const VizRecidivismRateSingleFollowup: React.FC<VizRecidivismRateSingleFollowupP
                       )
                     }
                   </animated.div>
-                </ChartsWrapper>
-              ))}
+                ))}
+              </ChartsWrapper>
             </animated.div>
           </>
         )}

--- a/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
@@ -1,0 +1,258 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { rem, rgba } from "polished";
+import React, { useState } from "react";
+import NetworkFrame from "semiotic/lib/NetworkFrame";
+import { GenericObject } from "semiotic/lib/types/generalTypes";
+import { EdgeType } from "semiotic/lib/types/networkTypes";
+import styled from "styled-components/macro";
+import { $Keys } from "utility-types";
+import ResponsiveTooltipController from "../charts/ResponsiveTooltipController";
+import { formatAsNumber } from "../utils";
+import MeasureWidth from "../MeasureWidth";
+import { animation, colors, typefaces } from "../UiLibrary";
+
+const MARGIN = { top: 10, bottom: 10, left: 140, right: 140 };
+const MIN_WIDTH = 600;
+const NODE_WIDTH = 72;
+
+const ChartWrapper = styled.figure`
+  /*
+    labels have a tendency to overflow the bottom of this container;
+    this padding should ensure they have enough space to do so
+  */
+  padding-bottom: ${rem(80)};
+  position: relative;
+  width: 100%;
+`;
+
+const SOURCE_LABEL_X_OFFSET = `-${MARGIN.left + NODE_WIDTH / 2}`;
+
+const SOURCE_VALUE_SIZE = 48;
+
+const SourceValue = styled.text`
+  fill: ${colors.text};
+  font-family: ${typefaces.display};
+  font-size: ${rem(SOURCE_VALUE_SIZE)};
+  letter-spacing: -0.09em;
+`;
+
+const SOURCE_LABEL_SIZE = 16;
+
+const SourceLabel = styled.text`
+  fill: ${colors.text};
+  font-size: ${rem(SOURCE_LABEL_SIZE)};
+`;
+
+const TARGET_LABEL_PADDING = 8;
+const TargetLabel = styled.text`
+  fill: ${colors.text};
+  font-size: ${rem(16)};
+  text-anchor: start;
+  width: ${rem(MARGIN.right - TARGET_LABEL_PADDING)};
+`;
+/**
+ * This is a magic number based on the label's font size;
+ * workaround for lack of dominant-baseline support in IE
+ * to vertically center the text on origin
+ */
+const TARGET_LABEL_Y_OFFSET = 6;
+
+// because IE does not support CSS transforms on SVG elements (#182),
+// we need to render label translations as SVG attributes. These functions do that
+const getSourceValueTransform = (yOffset: number) => `translate(
+  ${SOURCE_LABEL_X_OFFSET},
+  ${-(yOffset - SOURCE_VALUE_SIZE)}
+)`;
+const getSourceLabelTransform = (
+  yOffset: number
+) => `translate(${SOURCE_LABEL_X_OFFSET},
+  ${-(yOffset - SOURCE_VALUE_SIZE - SOURCE_LABEL_SIZE - 8)}
+)`;
+// this one happens to not use a dynamic value at the moment but we'll leave it
+// as a function for consistency
+const getTargetLabelTransform = () =>
+  `translate(${
+    NODE_WIDTH / 2 + TARGET_LABEL_PADDING
+  }, ${TARGET_LABEL_Y_OFFSET})`;
+
+const baseColor = colors.dataViz[0];
+
+const sourceColors = {
+  Incarceration: rgba(baseColor, 0.9),
+  Probation: rgba(baseColor, 0.7),
+  Both: rgba(baseColor, 0.6),
+};
+
+const targetColor = rgba(baseColor, 0.5);
+
+const hoverColor = rgba(baseColor, 0.2);
+
+const Gradients = (
+  <>
+    <linearGradient id="incarcerationGradient">
+      <stop offset="0" stopColor={sourceColors.Incarceration} stopOpacity="1" />
+      <stop
+        offset="15%"
+        stopColor={sourceColors.Incarceration}
+        stopOpacity="0.8"
+      />
+      <stop offset="90%" stopColor={targetColor} stopOpacity="1" />
+    </linearGradient>
+    <linearGradient id="probationGradient">
+      <stop offset="0" stopColor={sourceColors.Probation} stopOpacity="1" />
+      <stop offset="15%" stopColor={sourceColors.Probation} stopOpacity="0.8" />
+      <stop offset="90%" stopColor={targetColor} stopOpacity="1" />
+    </linearGradient>
+    <linearGradient id="bothGradient">
+      <stop offset="0" stopColor={sourceColors.Both} stopOpacity="1" />
+      <stop offset="15%" stopColor={sourceColors.Both} stopOpacity="0.8" />
+      <stop offset="90%" stopColor={targetColor} stopOpacity="1" />
+    </linearGradient>
+  </>
+);
+
+const linksToTooltipProps = (d: GenericObject) => {
+  let links: { label: string; value: number; pct: number }[] = [];
+
+  if ((d.sourceLinks || []).length > 0) {
+    // the value key is picked up from the input data
+    links = d.sourceLinks.map((link: EdgeType & { value: number }) => ({
+      label: link.target?.id,
+      value: link.value,
+      pct: link.value / d.value,
+    }));
+  } else if ((d.targetLinks || []).length > 0) {
+    // the value key is picked up from the input data
+    links = d.targetLinks.map((link: EdgeType & { value: number }) => ({
+      label: link.source?.id,
+      value: link.value,
+      pct: link.value / d.value,
+    }));
+  }
+
+  return {
+    title: d.id,
+    records: links,
+  };
+};
+
+/**
+ * Creates a Sankey diagram that is specifically tailored to sentence type data,
+ * with sentence type on the left flowing to demographic categories on the right.
+ */
+export default function SingleStepSankey({
+  sources,
+  targets,
+  edges,
+}: {
+  sources: { id: string }[];
+  targets: { id: string }[];
+  edges: { source: string; target: string; value: number }[];
+}): React.ReactElement {
+  const [highlighted, setHighlighted] = useState<Record<string, unknown>>();
+
+  const renderNodeLabel = (d: GenericObject) => {
+    if (sources.find((source) => source.id === d.id)) {
+      const yOffset = d.y - d.y0;
+      return (
+        <>
+          <SourceValue transform={getSourceValueTransform(yOffset)}>
+            {formatAsNumber(d.value)}
+          </SourceValue>
+          <SourceLabel transform={getSourceLabelTransform(yOffset)}>
+            {d.id}
+          </SourceLabel>
+        </>
+      );
+    }
+    if (targets.find((target) => target.id === d.id)) {
+      return (
+        <TargetLabel transform={getTargetLabelTransform()}>{d.id}</TargetLabel>
+      );
+    }
+    return null;
+  };
+
+  const shouldFade = (d: GenericObject) => {
+    return (
+      highlighted &&
+      ((d.id && highlighted.id !== d.id) ||
+        // edges not connected to this node
+        (d.source &&
+          d.source.id !== highlighted.id &&
+          d.target &&
+          d.target.id !== highlighted.id))
+    );
+  };
+
+  return (
+    <MeasureWidth>
+      {({ measureRef, width }) => (
+        <ChartWrapper
+          ref={measureRef}
+          style={{
+            overflow: width < MIN_WIDTH ? "auto" : "visible",
+          }}
+        >
+          <ResponsiveTooltipController
+            getTooltipProps={linksToTooltipProps}
+            hoverAnnotation
+            setHighlighted={setHighlighted}
+          >
+            <NetworkFrame
+              additionalDefs={Gradients}
+              baseMarkProps={{
+                transitionDuration: {
+                  fill: animation.defaultDuration,
+                },
+              }}
+              edges={edges}
+              edgeStyle={(d) => {
+                return {
+                  fill: shouldFade(d)
+                    ? hoverColor
+                    : `url(#${d.source.id.toLowerCase()}Gradient)`,
+                };
+              }}
+              margin={MARGIN}
+              networkType={{
+                nodePaddingRatio: 0.1,
+                nodeWidth: NODE_WIDTH,
+                orient: "justify",
+                projection: "horizontal",
+                type: "sankey",
+              }}
+              nodes={[...sources, ...targets]}
+              nodeLabels={renderNodeLabel}
+              nodeStyle={(d) => ({
+                fill: shouldFade(d)
+                  ? hoverColor
+                  : // these ids should be the same because they come from our input,
+                    // and if not there is a fallback value
+                    sourceColors[d.id as $Keys<typeof sourceColors>] ||
+                    targetColor,
+              })}
+              size={[Math.max(width, MIN_WIDTH), 500]}
+            />
+          </ResponsiveTooltipController>
+        </ChartWrapper>
+      )}
+    </MeasureWidth>
+  );
+}

--- a/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
@@ -28,20 +28,22 @@ import { formatAsNumber } from "../utils";
 import MeasureWidth from "../MeasureWidth";
 import { animation, colors, typefaces } from "../UiLibrary";
 
+export const CHART_HEIGHT = 500;
+export const CHART_BOTTOM_PADDING = 80;
 const MARGIN = { top: 10, bottom: 10, left: 140 };
 /**
  * Adjust right margin based on label length
  */
 const getRightMargin = scaleLinear().domain([5, 15]).range([60, 140]);
-const MIN_WIDTH = 600;
 const NODE_WIDTH = 72;
 
 const ChartWrapper = styled.figure`
   /*
     labels have a tendency to overflow the bottom of this container;
-    this padding should ensure they have enough space to do so
+    this padding should ensure they have enough space to do so.
+    (px rather than rem for consistency with Semiotic)
   */
-  padding-bottom: ${rem(80)};
+  padding-bottom: ${CHART_BOTTOM_PADDING}px;
   position: relative;
   width: 100%;
 `;
@@ -253,7 +255,7 @@ export default function SingleStepSankey({
                       sourceColors[d.id as $Keys<typeof sourceColors>] ||
                       targetColor,
                 })}
-                size={[Math.max(width, MIN_WIDTH), 500]}
+                size={[width, CHART_HEIGHT]}
               />
             </ResponsiveTooltipController>
           )}

--- a/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/SentenceTypeChart.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { scaleLinear } from "d3-scale";
-import { rem, rgba } from "polished";
+import { rgba } from "polished";
 import React, { useState } from "react";
 import NetworkFrame from "semiotic/lib/NetworkFrame";
 import { GenericObject } from "semiotic/lib/types/generalTypes";
@@ -37,11 +37,14 @@ const MARGIN = { top: 10, bottom: 10, left: 140 };
 const getRightMargin = scaleLinear().domain([5, 15]).range([60, 140]);
 const NODE_WIDTH = 72;
 
+// NB: sizes in here are generally in px rather than rem,
+// for conformity with Semiotic and SVG, since we are going pretty deep
+// into the guts of this chart to tweak the layout
+
 const ChartWrapper = styled.figure`
   /*
     labels have a tendency to overflow the bottom of this container;
     this padding should ensure they have enough space to do so.
-    (px rather than rem for consistency with Semiotic)
   */
   padding-bottom: ${CHART_BOTTOM_PADDING}px;
   position: relative;
@@ -55,21 +58,21 @@ const SOURCE_VALUE_SIZE = 48;
 const SourceValue = styled.text`
   fill: ${colors.text};
   font-family: ${typefaces.display};
-  font-size: ${rem(SOURCE_VALUE_SIZE)};
-  letter-spacing: -0.09em;
+  font-size: ${SOURCE_VALUE_SIZE}px;
+  letter-spacing: -0.07em;
 `;
 
 const SOURCE_LABEL_SIZE = 16;
 
 const SourceLabel = styled.text`
   fill: ${colors.text};
-  font-size: ${rem(SOURCE_LABEL_SIZE)};
+  font-size: ${SOURCE_LABEL_SIZE}px;
 `;
 
 const TARGET_LABEL_PADDING = 8;
 const TargetLabel = styled.text`
   fill: ${colors.text};
-  font-size: ${rem(16)};
+  font-size: 16px;
   text-anchor: start;
 `;
 

--- a/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
@@ -1,0 +1,142 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { fireEvent, screen, within } from "@testing-library/react";
+import { runInAction, when } from "mobx";
+import React from "react";
+import SentenceTypeByLocationMetric from "../contentModels/SentenceTypeByLocationMetric";
+import DataStore from "../DataStore";
+import { getDemographicCategories } from "../demographics";
+import { reactImmediately, renderWithStore } from "../testUtils";
+import VizSentenceTypeByLocation from "./VizSentenceTypeByLocation";
+
+jest.mock("../MeasureWidth/MeasureWidth");
+
+let metric: SentenceTypeByLocationMetric;
+
+let originalFilters: {
+  demographicView: SentenceTypeByLocationMetric["demographicView"];
+};
+
+const sentenceTypes = ["Incarceration", "Probation", "Both"];
+
+async function verifySankey(categories: string[], labels: string[]) {
+  const chart = screen.getByRole("figure");
+
+  labels.forEach((label) => {
+    expect(within(chart).getByText(label)).toBeVisible();
+  });
+
+  const nodes = within(chart).getByRole("group", { name: "nodes" });
+  expect(nodes).toBeVisible();
+
+  const edges = within(chart).getByRole("group", { name: "edges" });
+  expect(edges).toBeVisible();
+
+  sentenceTypes.forEach((sentenceType) => {
+    expect(
+      // these are the only Semiotic labels we have to work with here
+      within(nodes).getByRole("img", { name: `Node ${sentenceType}` })
+    ).toBeVisible();
+    // label
+    expect(within(chart).getByText(sentenceType)).toBeVisible();
+
+    categories.forEach((category) => {
+      expect(
+        within(edges).getByRole("img", {
+          name: `connection from ${sentenceType} to ${category}`,
+        })
+      ).toBeVisible();
+      // label
+      expect(within(chart).getByText(category)).toBeVisible();
+    });
+  });
+  // unfortunately there isn't really any sensible way to inspect the size of nodes within JSDOM
+}
+
+beforeEach(() => {
+  runInAction(() => {
+    DataStore.tenantStore.currentTenantId = "US_ND";
+  });
+  reactImmediately(() => {
+    const metricToTest = DataStore.tenant?.metrics.get("SentenceTypesCurrent");
+    // it will be
+    if (metricToTest instanceof SentenceTypeByLocationMetric) {
+      metric = metricToTest;
+      originalFilters = {
+        demographicView: metric.demographicView,
+      };
+    }
+  });
+});
+
+afterEach(() => {
+  runInAction(() => {
+    DataStore.tenantStore.currentTenantId = undefined;
+    metric.demographicView = originalFilters.demographicView;
+  });
+});
+
+test("loading", () => {
+  renderWithStore(<VizSentenceTypeByLocation metric={metric} />);
+  expect(screen.getByText(/loading/i)).toBeVisible();
+});
+
+test("total chart", async () => {
+  const categories = ["Total"];
+
+  renderWithStore(<VizSentenceTypeByLocation metric={metric} />);
+
+  await when(() => !metric.isLoading);
+
+  await verifySankey(categories, ["6,193", "3,399", "2,056"]);
+});
+
+test.each([
+  ["Race or Ethnicity", getDemographicCategories("raceOrEthnicity")],
+  ["Gender", getDemographicCategories("gender")],
+  ["Age Group", getDemographicCategories("ageBucket")],
+])("%s charts", async (demographicLabel, categories) => {
+  renderWithStore(<VizSentenceTypeByLocation metric={metric} />);
+
+  await when(() => !metric.isLoading);
+
+  const menuButton = screen.getByRole("button", {
+    name: "View Total",
+  });
+  fireEvent.click(menuButton);
+  fireEvent.click(screen.getByRole("option", { name: demographicLabel }));
+
+  verifySankey(
+    categories.map(({ label }) => label),
+    ["6,193", "3,399", "2,056"]
+  );
+});
+
+test("locality filter", async () => {
+  renderWithStore(<VizSentenceTypeByLocation metric={metric} />);
+
+  await when(() => !metric.isLoading);
+
+  const menuButton = screen.getByRole("button", {
+    name: "Judicial District All Districts",
+  });
+  fireEvent.click(menuButton);
+  fireEvent.click(screen.getByRole("option", { name: "South Central" }));
+
+  verifySankey(["Total"], ["1,340", "735", "445"]);
+});

--- a/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.tsx
@@ -24,6 +24,7 @@ import DemographicFilterSelect from "../DemographicFilterSelect";
 import FiltersWrapper from "../FiltersWrapper";
 import LocalityFilterSelect from "../LocalityFilterSelect";
 import NoMetricData from "../NoMetricData";
+import { animation } from "../UiLibrary";
 import SentenceTypeChart, {
   CHART_BOTTOM_PADDING,
   CHART_HEIGHT,
@@ -52,13 +53,7 @@ const VizSentenceTypeByLocation: React.FC<VizSentenceTypeByLocationProps> = ({
   const chartTransitions = useTransition(
     { demographicView, dataGraph, localityId },
     (item) => `${item.demographicView} ${item.localityId}`,
-    {
-      initial: { opacity: 1 },
-      from: { opacity: 0 },
-      enter: { opacity: 1 },
-      leave: { opacity: 0, position: "absolute" },
-      config: { friction: 40, tension: 280 },
-    }
+    animation.crossFade
   );
 
   if (metric.dataGraph) {
@@ -74,7 +69,7 @@ const VizSentenceTypeByLocation: React.FC<VizSentenceTypeByLocationProps> = ({
           {chartTransitions.map(
             ({ item, key, props }) =>
               item.dataGraph && (
-                <animated.div key={key} style={{ ...props, top: 0 }}>
+                <animated.div key={key} style={props}>
                   <SentenceTypeChart {...item.dataGraph} />
                 </animated.div>
               )

--- a/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.tsx
@@ -1,0 +1,51 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { observer } from "mobx-react-lite";
+import React from "react";
+import SentenceTypeByLocationMetric from "../contentModels/SentenceTypeByLocationMetric";
+import DemographicFilterSelect from "../DemographicFilterSelect";
+import FiltersWrapper from "../FiltersWrapper";
+import LocalityFilterSelect from "../LocalityFilterSelect";
+import NoMetricData from "../NoMetricData";
+import SentenceTypeChart from "./SentenceTypeChart";
+
+type VizSentenceTypeByLocationProps = {
+  metric: SentenceTypeByLocationMetric;
+};
+
+const VizSentenceTypeByLocation: React.FC<VizSentenceTypeByLocationProps> = ({
+  metric,
+}) => {
+  if (metric.dataGraph) {
+    return (
+      <>
+        <FiltersWrapper
+          filters={[
+            <LocalityFilterSelect metric={metric} />,
+            <DemographicFilterSelect metric={metric} />,
+          ]}
+        />
+        <SentenceTypeChart {...metric.dataGraph} />
+      </>
+    );
+  }
+
+  return <NoMetricData metric={metric} />;
+};
+
+export default observer(VizSentenceTypeByLocation);

--- a/spotlight-client/src/VizSentenceTypeByLocation/index.ts
+++ b/spotlight-client/src/VizSentenceTypeByLocation/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export { default } from "./VizSentenceTypeByLocation";

--- a/spotlight-client/src/contentModels/SentenceTypeByLocationMetric.test.ts
+++ b/spotlight-client/src/contentModels/SentenceTypeByLocationMetric.test.ts
@@ -1,0 +1,98 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { runInAction, when } from "mobx";
+import { DemographicView } from "../demographics";
+import { reactImmediately } from "../testUtils";
+import createMetricMapping from "./createMetricMapping";
+import SentenceTypeByLocationMetric from "./SentenceTypeByLocationMetric";
+import contentFixture from "./__fixtures__/tenant_content_exhaustive";
+
+const testTenantId = "US_ND";
+const testMetricId = "SentenceTypesCurrent";
+const testMetadataMapping = {
+  [testMetricId]: contentFixture.metrics[testMetricId],
+};
+
+function getTestMetric() {
+  return createMetricMapping({
+    localityLabelMapping: contentFixture.localities,
+    metadataMapping: testMetadataMapping,
+    tenantId: testTenantId,
+  }).get(testMetricId) as SentenceTypeByLocationMetric;
+}
+
+async function getPopulatedMetric() {
+  const metric = getTestMetric();
+
+  metric.populateAllRecords();
+
+  await when(() => Boolean(metric.records));
+
+  return metric;
+}
+
+test("total data", async () => {
+  const metric = await getPopulatedMetric();
+
+  reactImmediately(() => {
+    expect(metric.dataGraph).toMatchSnapshot();
+  });
+
+  expect.hasAssertions();
+});
+
+test.each([["raceOrEthnicity"], ["gender"], ["ageBucket"]] as [
+  Exclude<DemographicView, "nofilter">
+][])("%s data", async (demographicView) => {
+  const metric = await getPopulatedMetric();
+
+  runInAction(() => {
+    metric.demographicView = demographicView;
+  });
+
+  reactImmediately(() => {
+    expect(metric.dataGraph).toMatchSnapshot();
+  });
+
+  expect.hasAssertions();
+});
+
+test("locality filter", async () => {
+  const metric = await getPopulatedMetric();
+
+  reactImmediately(() =>
+    expect(metric.records?.every((record) => record.locality === "ALL")).toBe(
+      true
+    )
+  );
+
+  const facilityId = contentFixture.localities.Sentencing.entries[1].id;
+
+  runInAction(() => {
+    metric.localityId = facilityId;
+  });
+
+  reactImmediately(() => {
+    expect(metric.records?.length).toBeGreaterThan(0);
+    expect(
+      metric.records?.every((record) => record.locality === facilityId)
+    ).toBe(true);
+  });
+
+  expect.hasAssertions();
+});

--- a/spotlight-client/src/contentModels/SentenceTypeByLocationMetric.ts
+++ b/spotlight-client/src/contentModels/SentenceTypeByLocationMetric.ts
@@ -59,7 +59,6 @@ export default class SentenceTypeByLocationMetric extends Metric<
       recordIsTotalByDimension(this.demographicView)
     );
 
-    // TODO: sort?
     return recordsToReturn;
   }
 
@@ -67,7 +66,7 @@ export default class SentenceTypeByLocationMetric extends Metric<
     | { sources: GraphNode[]; targets: GraphNode[]; edges: GraphEdge[] }
     | undefined {
     const { demographicView, records } = this;
-    if (!records || demographicView === "nofilter") return;
+    if (!records || demographicView === "nofilter") return undefined;
 
     const sources = ["Incarceration", "Probation", "Both"];
 

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -203,12 +203,12 @@ const content: DeepRequired<TenantContent> = {
       label: "sentencing locality",
       entries: [
         {
-          id: "sentencing a",
-          label: "sentencing A",
+          id: "NORTHEAST",
+          label: "Northeast",
         },
         {
-          id: "sentencing b",
-          label: "sentencing B",
+          id: "SOUTHWEST",
+          label: "Southwest",
         },
       ],
     },

--- a/spotlight-client/src/contentModels/__snapshots__/SentenceTypeByLocationMetric.test.ts.snap
+++ b/spotlight-client/src/contentModels/__snapshots__/SentenceTypeByLocationMetric.test.ts.snap
@@ -1,0 +1,315 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ageBucket data 1`] = `
+Object {
+  "edges": Array [
+    Object {
+      "source": "Incarceration",
+      "target": "<25",
+      "value": 1147,
+    },
+    Object {
+      "source": "Probation",
+      "target": "<25",
+      "value": 96,
+    },
+    Object {
+      "source": "Both",
+      "target": "<25",
+      "value": 267,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "25-29",
+      "value": 1262,
+    },
+    Object {
+      "source": "Probation",
+      "target": "25-29",
+      "value": 1248,
+    },
+    Object {
+      "source": "Both",
+      "target": "25-29",
+      "value": 538,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "30-34",
+      "value": 1420,
+    },
+    Object {
+      "source": "Probation",
+      "target": "30-34",
+      "value": 604,
+    },
+    Object {
+      "source": "Both",
+      "target": "30-34",
+      "value": 434,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "35-39",
+      "value": 1875,
+    },
+    Object {
+      "source": "Probation",
+      "target": "35-39",
+      "value": 0,
+    },
+    Object {
+      "source": "Both",
+      "target": "35-39",
+      "value": 402,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "40<",
+      "value": 337,
+    },
+    Object {
+      "source": "Probation",
+      "target": "40<",
+      "value": 1601,
+    },
+    Object {
+      "source": "Both",
+      "target": "40<",
+      "value": 416,
+    },
+  ],
+  "sources": Array [
+    Object {
+      "id": "Incarceration",
+    },
+    Object {
+      "id": "Probation",
+    },
+    Object {
+      "id": "Both",
+    },
+  ],
+  "targets": Array [
+    Object {
+      "id": "<25",
+    },
+    Object {
+      "id": "25-29",
+    },
+    Object {
+      "id": "30-34",
+    },
+    Object {
+      "id": "35-39",
+    },
+    Object {
+      "id": "40<",
+    },
+  ],
+}
+`;
+
+exports[`gender data 1`] = `
+Object {
+  "edges": Array [
+    Object {
+      "source": "Incarceration",
+      "target": "Male",
+      "value": 6034,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Male",
+      "value": 3112,
+    },
+    Object {
+      "source": "Both",
+      "target": "Male",
+      "value": 1961,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "Female",
+      "value": 159,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Female",
+      "value": 285,
+    },
+    Object {
+      "source": "Both",
+      "target": "Female",
+      "value": 96,
+    },
+  ],
+  "sources": Array [
+    Object {
+      "id": "Incarceration",
+    },
+    Object {
+      "id": "Probation",
+    },
+    Object {
+      "id": "Both",
+    },
+  ],
+  "targets": Array [
+    Object {
+      "id": "Male",
+    },
+    Object {
+      "id": "Female",
+    },
+  ],
+}
+`;
+
+exports[`raceOrEthnicity data 1`] = `
+Object {
+  "edges": Array [
+    Object {
+      "source": "Incarceration",
+      "target": "Native American",
+      "value": 1050,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Native American",
+      "value": 0,
+    },
+    Object {
+      "source": "Both",
+      "target": "Native American",
+      "value": 225,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "Black",
+      "value": 1613,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Black",
+      "value": 115,
+    },
+    Object {
+      "source": "Both",
+      "target": "Black",
+      "value": 371,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "Hispanic",
+      "value": 422,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Hispanic",
+      "value": 1581,
+    },
+    Object {
+      "source": "Both",
+      "target": "Hispanic",
+      "value": 430,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "White",
+      "value": 1946,
+    },
+    Object {
+      "source": "Probation",
+      "target": "White",
+      "value": 377,
+    },
+    Object {
+      "source": "Both",
+      "target": "White",
+      "value": 498,
+    },
+    Object {
+      "source": "Incarceration",
+      "target": "Other",
+      "value": 1061,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Other",
+      "value": 1425,
+    },
+    Object {
+      "source": "Both",
+      "target": "Other",
+      "value": 533,
+    },
+  ],
+  "sources": Array [
+    Object {
+      "id": "Incarceration",
+    },
+    Object {
+      "id": "Probation",
+    },
+    Object {
+      "id": "Both",
+    },
+  ],
+  "targets": Array [
+    Object {
+      "id": "Native American",
+    },
+    Object {
+      "id": "Black",
+    },
+    Object {
+      "id": "Hispanic",
+    },
+    Object {
+      "id": "White",
+    },
+    Object {
+      "id": "Other",
+    },
+  ],
+}
+`;
+
+exports[`total data 1`] = `
+Object {
+  "edges": Array [
+    Object {
+      "source": "Incarceration",
+      "target": "Total",
+      "value": 6193,
+    },
+    Object {
+      "source": "Probation",
+      "target": "Total",
+      "value": 3399,
+    },
+    Object {
+      "source": "Both",
+      "target": "Total",
+      "value": 2056,
+    },
+  ],
+  "sources": Array [
+    Object {
+      "id": "Incarceration",
+    },
+    Object {
+      "id": "Probation",
+    },
+    Object {
+      "id": "Both",
+    },
+  ],
+  "targets": Array [
+    Object {
+      "id": "Total",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Description of the change

Brings the Sankey diagram for sentence types into v2. With this addition, the Sentencing narrative page is now complete.

<img width="704" alt="Screen Shot 2021-02-05 at 11 50 54 AM" src="https://user-images.githubusercontent.com/5385319/107094144-61a9df00-67bb-11eb-9e8d-dc8245693743.png">

Unlike most of the other charts in this application, this one is very specifically tailored to the data source — so much so that I didn't even want to put it in the "charts" directory as it is in no way reusable for anything other than visualizing this exact data. It's also a lot more sensitive to size than most of the others, and not all of that transitioned well to the v2 layout. Changes of note: 
- the chart no longer has a minimum width; that approach did not play nicely with the two-column layout or the animated transitions I have been adding. That means it becomes illegible on smaller screens, but since the layout in general is not responsive I propose to defer the solution to #309 (probably it will involve a layout change triggered by some breakpoint, but the page in general is too broken right now to come up with a working solution)
- the right margin is now flexible based on an estimate of how long the labels will be, reducing wasted negative space (which was exacerbated by the v2 layout)
- the native Semiotic animations for this chart type were particularly weird and jarring; they have been eliminated in favor of a cross-fade when the filters are changed, similar to how we have treated other charts in V2.

Tooltip placement is a little weird still, but not any weirder than it was before; that is a known issue documented in #311 .

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #300 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
