### PR TITLE
Automated staging deploy from master

### DIFF
--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -50,6 +50,20 @@ jobs:
         with:
           name: build
           path: spotlight-client/build
+      - name: Wait on lint
+        uses: lewagon/wait-on-check-action@v0.2
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: Lint Spotlight Client
+          wait-interval: 10 # seconds
+      - name: Wait on tests
+        uses: lewagon/wait-on-check-action@v0.2
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: Test Spotlight Client
+          wait-interval: 10 # seconds
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         env:

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -1,0 +1,57 @@
+name: Spotlight Staging Deploy
+on:
+  push:
+    branches:
+      # TODO: should be master, not this test branch
+      - ian/336-deploy
+    paths:
+      - "spotlight-client/**"
+defaults:
+  run:
+    working-directory: spotlight-client
+
+jobs:
+  build:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - uses: c-hive/gha-yarn-cache@v1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build
+        # in lieu of build-staging, which consumes a .env that is not available in CI,
+        # we configure the build for staging here
+        env:
+          REACT_APP_AUTH_ENABLED: true
+          REACT_APP_AUTH_ENV: development
+          REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
+        run: yarn build
+      - name: Store build artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: build
+          path: build
+  deploy:
+    name: Deploy frontend
+    needs: build
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@master
+        with:
+          name: public
+          path: public
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        env:
+          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
+        with:
+          args: deploy -P staging

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -64,7 +64,7 @@ jobs:
           check-name: Test Spotlight Client
           wait-interval: 10 # seconds
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v2
         env:
           GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
           PROJECT_PATH: ./spotlight-client

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: build
-          path: build
+          path: spotlight-client/build
           if-no-files-found: error
   deploy:
     name: Deploy frontend
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: build
-          path: build/
+          path: spotlight-client/build
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         env:

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -54,5 +54,6 @@ jobs:
         uses: w9jds/firebase-action@master
         env:
           GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
+          PROJECT_PATH: ./spotlight-client
         with:
           args: deploy -P staging

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -2,8 +2,7 @@ name: Spotlight Staging Deploy
 on:
   push:
     branches:
-      # TODO: should be master, not this test branch
-      - ian/336-deploy
+      - master
     paths:
       - "spotlight-client/**"
 defaults:

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -33,10 +33,11 @@ jobs:
           REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
         run: yarn build
       - name: Store build artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: build
           path: build
+          if-no-files-found: error
   deploy:
     name: Deploy frontend
     needs: build
@@ -45,10 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download build artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v2
         with:
-          name: public
-          path: public
+          name: build
+          path: build/
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         env:

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -2,6 +2,8 @@
 
 This package is a React client application for the next-generation Spotlight public data publishing website (not yet launched). It was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) and is written in [TypeScript](https://www.typescriptlang.org/docs).
 
+TEST
+
 ## Development
 
 ### Getting set up

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -36,6 +36,8 @@ Expected environment variables include:
 
 The build process, as described below, ensures that the proper values are compiled and included in the static bundle at build time, for the right environment.
 
+The necessary environment variables **must** also be added to the `spotlight-staging` Github CI workflow in `/.github/workflows`; this workflow carries out automated staging deployments. It does not have access to the `.env` files used by your local environment. (Adding or updating secrets requires admin privileges on this repository; if you don't have those, reach out to a Recidiviz staff member for help.)
+
 ### Running the application locally
 
 `yarn dev` will start a Webpack development server on port `3000` and open the homepage in your browser.
@@ -62,7 +64,9 @@ Once you have the required permissions, you can set up your environment for depl
 
 ### Deploying to Staging
 
-To generate a staging build, invoke the following yarn script: `yarn build-staging`. This will include the appropriate environment variables from `.env.development`. Each time this is run, the `/build` directory will be wiped clean.
+All commits to `master` are automatically deployed to the staging environment by the `spotlight-staging` Github CI workflow, keeping staging up to date as pull requests are merged. (It thus bears mentioning that you should not merge anything to `master` that isn't immediately deployable!)
+
+You can also generate and deploy staging builds locally as needed. To generate a staging build, invoke the following yarn script: `yarn build-staging`. This will include the appropriate environment variables from `.env.development`. Each time this is run, the `/build` directory will be wiped clean.
 
 You should then test this locally by running `firebase serve`: it will run the staging build locally, pointed to the staging API backend. (Note that this means you will have to deploy the backend to staging first if your build requires unreleased backend features.)
 

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -2,8 +2,6 @@
 
 This package is a React client application for the next-generation Spotlight public data publishing website (not yet launched). It was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) and is written in [TypeScript](https://www.typescriptlang.org/docs).
 
-TEST
-
 ## Development
 
 ### Getting set up

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -24,7 +24,7 @@ import withRouteSync from "../withRouteSync";
 const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
-      <h1>Spotlight Home</h1>
+      <h1>Spotlight</h1>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -25,7 +25,6 @@ const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
       <h1>Spotlight</h1>
-      <h2>home</h2>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -25,6 +25,7 @@ const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
       <h1>Spotlight</h1>
+      <h2>home</h2>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -24,7 +24,7 @@ import withRouteSync from "../withRouteSync";
 const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
-      <h1>Spotlight</h1>
+      <h1>Spotlight Home</h1>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>


### PR DESCRIPTION
## Description of the change

I had an odd lot of time this afternoon so I decided to see if I could get this working. Not an earth-shattering productivity improvement, but it is nice (and useful, now that substantive UI changes are coming in at a decent clip), and I wanted to understand the Github CI environment a little better. 

There is a new workflow here that does the following: 
- only runs on pushes to `master` (in practical terms, after a PR merge)
- only runs if the push actually changed anything in the `spotlight-client` package
- waits for the lint & test jobs for the `spotlight-client` package to succeed
- if all conditions pass, creates a staging build of the `spotlight-client` frontend application and deploys it to the Firebase staging environment

The relevant secrets are stored in an "environment" on this repository called "staging"; the workflow authenticates to Firebase using a new service account I created that has only "Firebase Hosting Admin" privileges (the least access required for the Firebase features we currently use).

I tested this against this branch before redirecting it to only run on `master`; you can see a properly working run in the checks for 54ae1f4.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #336 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
