### PR TITLE
Fix staging deploy workflow that I broke

### DIFF
--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -2,8 +2,7 @@ name: Spotlight Staging Deploy
 on:
   push:
     branches:
-      # TODO: change this back to master after testing
-      - ian/336-deploy-broken
+      - master
     paths:
       - "spotlight-client/**"
 defaults:

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -2,7 +2,8 @@ name: Spotlight Staging Deploy
 on:
   push:
     branches:
-      - master
+      # TODO: change this back to master after testing
+      - ian/336-deploy-broken
     paths:
       - "spotlight-client/**"
 defaults:
@@ -64,7 +65,7 @@ jobs:
           check-name: Test Spotlight Client
           wait-interval: 10 # seconds
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v2
+        uses: w9jds/firebase-action@v2.0.0
         env:
           GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
           PROJECT_PATH: ./spotlight-client

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -24,7 +24,7 @@ import withRouteSync from "../withRouteSync";
 const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
-      <h1>Spotlight Home</h1>
+      <h1>Spotlight</h1>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -24,7 +24,7 @@ import withRouteSync from "../withRouteSync";
 const PageHome: React.FC<RouteComponentProps> = () => {
   return (
     <div>
-      <h1>Spotlight</h1>
+      <h1>Spotlight Home</h1>
       <ul>
         {TenantIdList.map((tenantId) => (
           <li key={tenantId}>


### PR DESCRIPTION
## Description of the change

In the last PR I rather sloppily failed to test what I thought was inconsequential change that actually wound up breaking the deploy workflow; turns out the Github Actions syntax does not extrapolate from `v2` to `v2.0.0` like I assumed it would. 🤦🏻 

Runs in the commit history here verify that it now works against this branch (and also that it correctly fails if the tests didn't pass, which also wasn't explicitly tested in my last PR).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #336 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
