### PR TITLE
Align historical window with current month

### DIFF
--- a/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
+++ b/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
@@ -149,6 +149,8 @@ test("imputed data does not include the current month", async () => {
     );
 
     expect(currentMonthRecords?.length).toBe(0);
+
+    expect(metric.dataIncludesCurrentMonth).toBe(false);
   });
   expect.hasAssertions();
 });
@@ -166,6 +168,8 @@ test("imputed data includes current month", async () => {
     );
 
     expect(currentMonthRecords?.length).toBe(1);
+
+    expect(metric.dataIncludesCurrentMonth).toBe(true);
   });
   expect.hasAssertions();
 });

--- a/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.ts
+++ b/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { ascending } from "d3-array";
-import { startOfMonth } from "date-fns";
+import { isSameDay, startOfMonth } from "date-fns";
 import { computed, makeObservable, observable, runInAction } from "mobx";
 import { DataSeries } from "../charts";
 import {
@@ -41,7 +41,7 @@ function dataIncludesCurrentMonth(
   records: HistoricalPopulationBreakdownRecord[]
 ) {
   const thisMonth = startOfMonth(new Date());
-  return records.some((record) => record.date === thisMonth);
+  return records.some((record) => isSameDay(record.date, thisMonth));
 }
 
 /**


### PR DESCRIPTION
## Description of the change

A flag on the `HistoricalPopulationBreakdown` data model was not getting set correctly, causing the default 20-year time window on the chart to be off by one month; the data was correct but the tests missed this bug because they weren't checking the flag. Now fixed!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #350

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
