### PR TITLE
Page not found .... page

### DIFF
--- a/spotlight-client/src/App.tsx
+++ b/spotlight-client/src/App.tsx
@@ -24,8 +24,8 @@ import styled from "styled-components/macro";
 import AuthWall from "./AuthWall";
 import { FOOTER_HEIGHT, NAV_BAR_HEIGHT } from "./constants";
 import GlobalStyles from "./GlobalStyles";
+import NotFound from "./NotFound";
 import PageNarrative from "./PageNarrative";
-import PageNotFound from "./PageNotFound";
 import PageTenant from "./PageTenant";
 import PageviewTracker from "./PageviewTracker";
 import { NarrativesSlug } from "./routerUtils/types";
@@ -35,6 +35,7 @@ import SiteNavigation from "./SiteNavigation";
 import StoreProvider from "./StoreProvider";
 import TooltipMobile from "./TooltipMobile";
 import { breakpoints } from "./UiLibrary";
+import withRouteSync from "./withRouteSync";
 
 // set custom breakpoints for media queries
 setupBreakpoints({
@@ -47,6 +48,8 @@ setupBreakpoints({
 const PassThroughPage: React.FC<RouteComponentProps> = ({ children }) => (
   <>{children}</>
 );
+
+const PageNotFound = withRouteSync(NotFound);
 
 const Main = styled.div.attrs({ role: "main" })`
   padding-top: ${rem(NAV_BAR_HEIGHT)};

--- a/spotlight-client/src/App.tsx
+++ b/spotlight-client/src/App.tsx
@@ -73,9 +73,8 @@ const App: React.FC = () => {
                 <PageNarrative
                   path={`/${NarrativesSlug}/:narrativeTypeId/*sectionNumber`}
                 />
-                <PageNotFound default />
+                <PageNotFound path="/*" />
               </PassThroughPage>
-              <PageNotFound default />
             </Router>
             <ScrollManager />
             <PageviewTracker />

--- a/spotlight-client/src/DataStore/UiStore.ts
+++ b/spotlight-client/src/DataStore/UiStore.ts
@@ -25,6 +25,8 @@ export default class UiStore {
 
   renderTooltipMobile?: (props: Record<string, unknown>) => React.ReactNode;
 
+  isRouteInvalid = false;
+
   constructor({ rootStore }: { rootStore: RootStore }) {
     makeAutoObservable(this, {
       rootStore: false,
@@ -67,6 +69,7 @@ export default class UiStore {
   get currentPageTitle(): string | undefined {
     const titleParts: string[] = [];
 
+    const { isRouteInvalid } = this;
     const { tenant, narrative } = this.rootStore;
 
     if (tenant) {
@@ -77,7 +80,7 @@ export default class UiStore {
       }
     }
 
-    if (!titleParts.length) {
+    if (!titleParts.length && !isRouteInvalid) {
       // this is valid if we are on the site homepage;
       // otherwise it is an intermediate state that should not leak into reactions
       if (window.location.pathname !== "/") {
@@ -86,6 +89,10 @@ export default class UiStore {
     }
 
     titleParts.push("Spotlight by Recidiviz");
+
+    if (isRouteInvalid) {
+      titleParts.unshift("Page not found");
+    }
 
     return titleParts.join(" — ");
   }

--- a/spotlight-client/src/NarrativeLayout/NarrativeNavigation/NarrativeNavigation.tsx
+++ b/spotlight-client/src/NarrativeLayout/NarrativeNavigation/NarrativeNavigation.tsx
@@ -20,6 +20,7 @@ import { format } from "d3-format";
 import { rem } from "polished";
 import React from "react";
 import styled from "styled-components/macro";
+import { DeepNonNullable } from "utility-types";
 import getUrlForResource from "../../routerUtils/getUrlForResource";
 import normalizeRouteParams from "../../routerUtils/normalizeRouteParams";
 import { LayoutSection } from "../types";
@@ -60,7 +61,7 @@ const SectionNavigation: React.FC<NavigationProps> = ({
   const { tenantId, narrativeTypeId } = normalizeRouteParams(
     useParams()
     // these keys should always be present on this page
-  ) as Required<
+  ) as DeepNonNullable<
     Pick<
       ReturnType<typeof normalizeRouteParams>,
       "tenantId" | "narrativeTypeId"

--- a/spotlight-client/src/NotFound/NotFound.tsx
+++ b/spotlight-client/src/NotFound/NotFound.tsx
@@ -20,7 +20,6 @@ import { rem } from "polished";
 import React from "react";
 import styled from "styled-components/macro";
 import { breakpoints, CopyBlock, PageSection, PageTitle } from "../UiLibrary";
-import withRouteSync from "../withRouteSync";
 
 const Wrapper = styled(PageSection)`
   margin: ${rem(48)} 0;
@@ -30,7 +29,7 @@ const Wrapper = styled(PageSection)`
   }
 `;
 
-const PageNotFound = (): React.ReactElement => {
+const NotFound = (): React.ReactElement => {
   return (
     <Wrapper>
       <PageTitle>Page not found.</PageTitle>
@@ -42,4 +41,4 @@ const PageNotFound = (): React.ReactElement => {
   );
 };
 
-export default withRouteSync(PageNotFound);
+export default NotFound;

--- a/spotlight-client/src/NotFound/index.ts
+++ b/spotlight-client/src/NotFound/index.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,4 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export { default } from "./PageNotFound";
+export { default } from "./NotFound";

--- a/spotlight-client/src/PageNotFound/PageNotFound.tsx
+++ b/spotlight-client/src/PageNotFound/PageNotFound.tsx
@@ -15,13 +15,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { Link, RouteComponentProps } from "@reach/router";
+import { Link } from "@reach/router";
 import { rem } from "polished";
 import React from "react";
 import styled from "styled-components/macro";
 import { breakpoints, CopyBlock, PageSection, PageTitle } from "../UiLibrary";
+import withRouteSync from "../withRouteSync";
 
-const Introduction = styled(PageSection)`
+const Wrapper = styled(PageSection)`
   margin: ${rem(48)} 0;
 
   @media screen and (min-width: ${breakpoints.tablet[0]}px) {
@@ -29,14 +30,16 @@ const Introduction = styled(PageSection)`
   }
 `;
 
-const PageNotFound: React.FC<RouteComponentProps> = () => (
-  <Introduction>
-    <PageTitle>Page not found.</PageTitle>
-    <CopyBlock>
-      <Link to="/">Return home,</Link> or use the navigation menu above to find
-      your destination.
-    </CopyBlock>
-  </Introduction>
-);
+const PageNotFound = (): React.ReactElement => {
+  return (
+    <Wrapper>
+      <PageTitle>Page not found.</PageTitle>
+      <CopyBlock>
+        <Link to="/">Return home,</Link> or use the navigation menu above to
+        find your destination.
+      </CopyBlock>
+    </Wrapper>
+  );
+};
 
-export default PageNotFound;
+export default withRouteSync(PageNotFound);

--- a/spotlight-client/src/PageTenant/PageTenant.tsx
+++ b/spotlight-client/src/PageTenant/PageTenant.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import styled from "styled-components/macro";
 import OtherNarrativeLinks from "../OtherNarrativeLinks";
 import { useDataStore } from "../StoreProvider";
-import { breakpoints, CopyBlock, PageSection, typefaces } from "../UiLibrary";
+import { breakpoints, CopyBlock, PageSection, PageTitle } from "../UiLibrary";
 import withRouteSync from "../withRouteSync";
 
 const Introduction = styled(PageSection)`
@@ -36,17 +36,8 @@ const Introduction = styled(PageSection)`
 
 const Links = styled(PageSection)``;
 
-const Title = styled.h1`
-  font-family: ${typefaces.display};
-  font-size: ${rem(32)};
-  letter-spacing: -0.04em;
-  line-height: 1.4;
-  margin-bottom: ${rem(32)};
+const Title = styled(PageTitle)`
   max-width: ${rem(760)};
-
-  @media screen and (min-width: ${breakpoints.tablet[0]}px) {
-    font-size: ${rem(52)};
-  }
 `;
 
 const Description = styled(CopyBlock)`

--- a/spotlight-client/src/UiLibrary/PageTitle.ts
+++ b/spotlight-client/src/UiLibrary/PageTitle.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,28 +15,19 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { Link, RouteComponentProps } from "@reach/router";
 import { rem } from "polished";
-import React from "react";
 import styled from "styled-components/macro";
-import { breakpoints, CopyBlock, PageSection, PageTitle } from "../UiLibrary";
+import breakpoints from "./breakpoints";
+import { typefaces } from "./typography";
 
-const Introduction = styled(PageSection)`
-  margin: ${rem(48)} 0;
+export default styled.h1`
+  font-family: ${typefaces.display};
+  font-size: ${rem(32)};
+  letter-spacing: -0.04em;
+  line-height: 1.4;
+  margin-bottom: ${rem(32)};
 
   @media screen and (min-width: ${breakpoints.tablet[0]}px) {
-    margin: ${rem(160)} 0;
+    font-size: ${rem(52)};
   }
 `;
-
-const PageNotFound: React.FC<RouteComponentProps> = () => (
-  <Introduction>
-    <PageTitle>Page not found.</PageTitle>
-    <CopyBlock>
-      <Link to="/">Return home,</Link> or use the navigation menu above to find
-      your destination.
-    </CopyBlock>
-  </Introduction>
-);
-
-export default PageNotFound;

--- a/spotlight-client/src/UiLibrary/index.ts
+++ b/spotlight-client/src/UiLibrary/index.ts
@@ -27,5 +27,6 @@ export { default as FixedBottomPanel } from "./FixedBottomPanel";
 export * from "./Modal";
 export * from "./narrative";
 export * from "./PageSection";
+export { default as PageTitle } from "./PageTitle";
 export * from "./typography";
 export { default as zIndex } from "./zIndex";

--- a/spotlight-client/src/UiLibrary/narrative.ts
+++ b/spotlight-client/src/UiLibrary/narrative.ts
@@ -21,6 +21,7 @@ import breakpoints from "./breakpoints";
 import colors from "./colors";
 import CopyBlock from "./CopyBlock";
 import { FullScreenSection } from "./PageSection";
+import PageTitle from "./PageTitle";
 import { typefaces } from "./typography";
 
 export const NarrativeIntroContainer = styled(FullScreenSection)`
@@ -34,13 +35,7 @@ export const NarrativeIntroContainer = styled(FullScreenSection)`
   }
 `;
 
-export const NarrativeTitle = styled.h1`
-  font-family: ${typefaces.display};
-  font-size: ${rem(32)};
-  letter-spacing: -0.05em;
-  line-height: 1;
-  margin-bottom: ${rem(24)};
-
+export const NarrativeTitle = styled(PageTitle)`
   @media screen and (min-width: ${breakpoints.tablet[0]}px) {
     font-size: ${rem(88)};
     margin-bottom: ${rem(64)};

--- a/spotlight-client/src/routerUtils/getUrlForResource.ts
+++ b/spotlight-client/src/routerUtils/getUrlForResource.ts
@@ -17,13 +17,14 @@
 
 import assertNever from "assert-never";
 import { paramCase } from "change-case";
+import { DeepNonNullable } from "utility-types";
 import { NarrativesSlug, NormalizedRouteParams } from "./types";
 
 function makeRouteParam(param: string) {
   return paramCase(param);
 }
 
-type RequiredParams = Required<NormalizedRouteParams>;
+type RequiredParams = DeepNonNullable<NormalizedRouteParams>;
 
 type GetUrlOptions =
   | { page: "home" }

--- a/spotlight-client/src/routerUtils/normalizeRouteParams.ts
+++ b/spotlight-client/src/routerUtils/normalizeRouteParams.ts
@@ -38,7 +38,8 @@ function normalizeTenantId(rawParam: ValuesType<RouteParams>) {
   if (typeof rawParam === "string") {
     const normalizedString = constantCase(rawParam);
     if (isTenantId(normalizedString)) return normalizedString;
-    throw new Error(`unknown TenantId: ${normalizedString}`);
+
+    return null;
   }
   return undefined;
 }
@@ -49,7 +50,7 @@ function normalizeNarrativeTypeId(rawParam: ValuesType<RouteParams>) {
 
     if (isNarrativeTypeId(normalizedString)) return normalizedString;
 
-    throw new Error(`unknown narrative type id: ${normalizedString}`);
+    return null;
   }
   return undefined;
 }

--- a/spotlight-client/src/routerUtils/types.ts
+++ b/spotlight-client/src/routerUtils/types.ts
@@ -24,8 +24,8 @@ export type RouteParams = {
 };
 
 export type NormalizedRouteParams = {
-  tenantId?: TenantId;
-  narrativeTypeId?: NarrativeTypeId;
+  tenantId?: TenantId | null;
+  narrativeTypeId?: NarrativeTypeId | null;
 };
 
 export const NarrativesSlug = "collections";


### PR DESCRIPTION
## Description of the change

Any URL that can't be resolved should now land you on a proper "not found" page.

![Screen Shot 2021-03-17 at 4 13 07 PM](https://user-images.githubusercontent.com/5385319/111559635-230a2b80-874e-11eb-8c57-2946c5318f30.png)

In cases where we can partially resolve the URL (i.e., the tenant is valid but something after it is not), the tenant-specific navigation should be present to give you more recovery paths. This involved changing how we handle invalid route parameters so they don't throw errors ... there is some wonky stuff associated with that but I tried to keep it all encapsulated in the `withRouteSync` function. It is also complicated somewhat by [a bug](https://github.com/reach/router/issues/250) in Reach Router that obliterates all the route parameters on default routes, so I had to use a wildcard path instead.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #361 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
