### PR TITLE
Critical IE bugfixes

### DIFF
--- a/spotlight-client/src/NarrativeLayout/NarrativeLayout.tsx
+++ b/spotlight-client/src/NarrativeLayout/NarrativeLayout.tsx
@@ -47,7 +47,8 @@ const NavStickyContainer = styled.div`
 `;
 
 export const SectionsContainer = styled.div`
-  flex: 1 1 auto;
+  /* flex-basis needs to be set or contents may overflow in IE 11 */
+  flex: 1 1 100%;
   /* min-width cannot be auto or children will not shrink when viewport does */
   min-width: 0;
 `;

--- a/spotlight-client/src/NarrativeLayout/StickySection.tsx
+++ b/spotlight-client/src/NarrativeLayout/StickySection.tsx
@@ -120,8 +120,10 @@ const StickySection: React.FC<{
     <Container>
       <Sticker>
         <LeftContainer ref={copyContainerRef} $isSticky={isLeftSticky}>
-          {leftContents}
-          <StickyOverflowIndicator ref={overflowRef} />
+          <div>
+            {leftContents}
+            <StickyOverflowIndicator ref={overflowRef} />
+          </div>
         </LeftContainer>
       </Sticker>
       <RightContainer>{rightContents}</RightContainer>

--- a/spotlight-client/src/charts/WindowedTimeSeries.tsx
+++ b/spotlight-client/src/charts/WindowedTimeSeries.tsx
@@ -47,6 +47,14 @@ const ChartWrapper = styled(BaseChartWrapper)`
   .frame {
     .visualization-layer {
       shape-rendering: geometricPrecision;
+
+      /*
+        there are two of these but only the inner one has dimensions applied;
+        overflow isn't hidden by default in IE 11 which breaks windowing
+      */
+      .visualization-layer {
+        overflow: hidden;
+      }
     }
 
     .axis.x {


### PR DESCRIPTION
## Description of the change

QA revealed two thoroughly broken features in IE 11: the windowed time series chart (it was not cropping at its window boundaries) and ... the entire racial disparities page (due to a bug in flexbox implementation, text was not wrapping, causing massive horizontal overflow; once that was fixed, it was also cropping off the longer text sections if they didn't fit on one screen). This fixes all that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Part of #366 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
