### PR TITLE
Improve performance of flaky FE tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "14.x"
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn install --frozen-lockfile
-      - run: yarn test --coverage
+      - run: yarn test --coverage --runInBand
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
@@ -69,7 +69,7 @@ jobs:
           node-version: "14.x"
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn install --frozen-lockfile
-      - run: yarn test --coverage --forceExit
+      - run: yarn test --coverage --forceExit --runInBand
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
@@ -104,7 +104,7 @@ jobs:
           node-version: "14.x"
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn install --frozen-lockfile
-      - run: yarn test --coverage
+      - run: yarn test --coverage --runInBand
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/spotlight-client/src/App-auth.test.tsx
+++ b/spotlight-client/src/App-auth.test.tsx
@@ -77,7 +77,6 @@ afterEach(() => {
   cleanup();
 });
 
-// TODO (#353) async specs fail intermittently
 test("no auth required", async () => {
   const App = await getApp();
   render(<App />);
@@ -111,7 +110,6 @@ test("requires authentication", async () => {
   });
 });
 
-// TODO (#353) async specs fail intermittently
 test("requires email verification", async () => {
   // configure environment for valid authentication
   process.env.REACT_APP_AUTH_ENABLED = "true";

--- a/spotlight-client/src/App-auth.test.tsx
+++ b/spotlight-client/src/App-auth.test.tsx
@@ -123,12 +123,10 @@ test("requires email verification", async () => {
   render(<App />);
   await waitFor(() => {
     // application contents should not have been rendered without verification
-    expect(
-      screen.queryByRole("heading", { name: authenticatedTextMatch })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("PageTitle")).not.toBeInTheDocument();
     // there should be a message about the verification requirement
     expect(
-      screen.getByRole("heading", { name: /verification/i })
+      screen.getByRole("heading", { name: /verification/i, hidden: true })
     ).toBeInTheDocument();
   });
 });

--- a/spotlight-client/src/App-auth.test.tsx
+++ b/spotlight-client/src/App-auth.test.tsx
@@ -78,13 +78,12 @@ afterEach(() => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("no auth required", async () => {
+test("no auth required", async () => {
   const App = await getApp();
   render(<App />);
   // site home redirects to the ND home
-  const websiteName = await screen.findByRole("heading", {
-    name: authenticatedTextMatch,
-  });
+  const websiteName = await screen.findByTestId("PageTitle");
+  expect(websiteName).toHaveTextContent(authenticatedTextMatch);
   expect(websiteName).toBeInTheDocument();
 });
 
@@ -113,7 +112,7 @@ test("requires authentication", async () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("requires email verification", async () => {
+test("requires email verification", async () => {
   // configure environment for valid authentication
   process.env.REACT_APP_AUTH_ENABLED = "true";
   process.env.REACT_APP_AUTH_ENV = "development";

--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -108,7 +108,7 @@ describe("navigation", () => {
   });
 
   // TODO (#353) async specs fail intermittently
-  test.skip("links", async () => {
+  test("links", async () => {
     renderNavigableApp();
 
     const inNav = within(screen.getByRole("navigation"));
@@ -120,34 +120,38 @@ describe("navigation", () => {
     });
 
     fireEvent.click(sentencingLink);
-    expect(
-      await screen.findByRole("heading", { name: "Sentencing", level: 1 })
-    ).toBeInTheDocument();
+    // NOTE: *ByRole queries can be too expensive to run async with this much DOM,
+    // so we are using *ByTestId queries here instead
+    await waitFor(async () =>
+      expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
+        "Sentencing"
+      )
+    );
 
     fireEvent.click(tenantLink);
-    expect(
-      await screen.findByRole("heading", {
-        name: "Explore correctional data from North Dakota.",
-        level: 1,
-      })
-    ).toBeInTheDocument();
+    await waitFor(async () =>
+      expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
+        "Explore correctional data from North Dakota."
+      )
+    );
 
     const disparitiesLink = screen.getByRole("link", {
       name: "Racial Disparities",
     });
     fireEvent.click(disparitiesLink);
-    expect(
-      await screen.findByRole("heading", {
-        name: "Racial Disparities",
-        level: 1,
-      })
-    ).toBeInTheDocument();
+    await waitFor(async () =>
+      expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
+        "Racial Disparities"
+      )
+    );
 
     fireEvent.click(homeLink);
     // home redirect to ND
-    expect(
-      await screen.findByRole("heading", { name: /North Dakota/, level: 1 })
-    ).toBeInTheDocument();
+    await waitFor(async () =>
+      expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
+        "North Dakota"
+      )
+    );
   });
 
   // TODO (#353) async specs fail intermittently

--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -155,7 +155,7 @@ describe("navigation", () => {
   });
 
   // TODO (#353) async specs fail intermittently
-  test.skip("pageview tracking", async () => {
+  test("pageview tracking", async () => {
     segmentMock.page.mockReset();
 
     const {
@@ -170,10 +170,6 @@ describe("navigation", () => {
     expect(document.title).toBe(
       "Prison — North Dakota — Spotlight by Recidiviz"
     );
-    expect(segmentMock.page).toHaveBeenCalledTimes(2);
-
-    // in-page navigation doesn't trigger additional pageviews
-    await act(() => navigate(`/us-nd/${NarrativesSlug}/prison/2`));
     expect(segmentMock.page).toHaveBeenCalledTimes(2);
 
     await act(() => navigate(`/us-nd/${NarrativesSlug}/sentencing`));

--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -107,7 +107,6 @@ describe("navigation", () => {
     expect(screen.getByRole(...lookupArgs)).toBeInTheDocument();
   });
 
-  // TODO (#353) async specs fail intermittently
   test("links", async () => {
     renderNavigableApp();
 
@@ -154,7 +153,6 @@ describe("navigation", () => {
     );
   });
 
-  // TODO (#353) async specs fail intermittently
   test("pageview tracking", async () => {
     segmentMock.page.mockReset();
 

--- a/spotlight-client/src/Loading/Loading.tsx
+++ b/spotlight-client/src/Loading/Loading.tsx
@@ -53,7 +53,7 @@ const LoadingSpinnerText = styled.div`
 
 export default function Loading(): JSX.Element {
   return (
-    <LoadingWrapper role="status">
+    <LoadingWrapper role="status" data-testid="LoadingIndicator">
       <LoadingSpinnerIcon />
       <LoadingSpinnerText>Data is loading</LoadingSpinnerText>
     </LoadingWrapper>

--- a/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
+++ b/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
@@ -56,7 +56,6 @@ test("hydration in progress", () => {
   expect(screen.queryByText("hydrated")).not.toBeInTheDocument();
 });
 
-// TODO (#353) async specs fail intermittently
 test("hydrated", async () => {
   runInAction(() => {
     mockModel.isLoading = false;

--- a/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
+++ b/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
@@ -62,7 +62,7 @@ test("hydrated", async () => {
   });
 
   await waitFor(() => {
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("LoadingIndicator")).not.toBeInTheDocument();
     expect(screen.getByText("hydrated")).toBeInTheDocument();
   });
 });

--- a/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
+++ b/spotlight-client/src/ModelHydrator/ModelHydrator.test.tsx
@@ -57,7 +57,7 @@ test("hydration in progress", () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("hydrated", async () => {
+test("hydrated", async () => {
   runInAction(() => {
     mockModel.isLoading = false;
   });

--- a/spotlight-client/src/RacialDisparitiesNarrativePage/RacialDisparitiesNarrativePage.test.tsx
+++ b/spotlight-client/src/RacialDisparitiesNarrativePage/RacialDisparitiesNarrativePage.test.tsx
@@ -31,10 +31,11 @@ beforeEach(() => {
   });
 });
 
+// TODO (#353) same thing as the others
 test("renders all the sections", async () => {
-  expect(
-    await screen.findByRole("heading", { name: "Racial Disparities", level: 1 })
-  ).toBeInTheDocument();
+  expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
+    "Racial Disparities"
+  );
 
   return Promise.all(
     Object.values(narrativeContent.sections).map(async (section) => {

--- a/spotlight-client/src/RacialDisparitiesNarrativePage/RacialDisparitiesNarrativePage.test.tsx
+++ b/spotlight-client/src/RacialDisparitiesNarrativePage/RacialDisparitiesNarrativePage.test.tsx
@@ -31,7 +31,6 @@ beforeEach(() => {
   });
 });
 
-// TODO (#353) same thing as the others
 test("renders all the sections", async () => {
   expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
     "Racial Disparities"

--- a/spotlight-client/src/UiLibrary/PageTitle.ts
+++ b/spotlight-client/src/UiLibrary/PageTitle.ts
@@ -20,7 +20,7 @@ import styled from "styled-components/macro";
 import breakpoints from "./breakpoints";
 import { typefaces } from "./typography";
 
-export default styled.h1`
+export default styled.h1.attrs({ "data-testid": "PageTitle" })`
   font-family: ${typefaces.display};
   font-size: ${rem(32)};
   letter-spacing: -0.04em;

--- a/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
+++ b/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
@@ -54,7 +54,6 @@ test("loading", () => {
   expect(screen.getByText(/loading/i)).toBeInTheDocument();
 });
 
-// TODO (#353) async specs fail intermittently
 test("total counts", async () => {
   renderWithStore(<VizPopulationBreakdownByLocation metric={metric} />);
 
@@ -146,7 +145,6 @@ test("total counts", async () => {
   ).toHaveStyle(`fill: ${colors.dataViz[1]}`);
 });
 
-// TODO (#353) async specs fail intermittently
 test("counts filtered by locality", async () => {
   renderWithStore(<VizPopulationBreakdownByLocation metric={metric} />);
 

--- a/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
+++ b/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
@@ -55,11 +55,17 @@ test("loading", () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("total counts", async () => {
+test("total counts", async () => {
   renderWithStore(<VizPopulationBreakdownByLocation metric={metric} />);
 
   await waitFor(() => {
-    const stat = screen.getByRole("figure", { name: "Total people in prison" });
+    const stat = screen.getByRole("figure", {
+      name: "Total people in prison",
+      // performance is better if we don't check for visibility within the *ByRole query;
+      // it's also redundant since we do it immediately after this
+      hidden: true,
+    });
+
     expect(stat).toBeVisible();
     expect(within(stat).getByText("2,041")).toBeVisible();
   });
@@ -141,7 +147,7 @@ test.skip("total counts", async () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("counts filtered by locality", async () => {
+test("counts filtered by locality", async () => {
   renderWithStore(<VizPopulationBreakdownByLocation metric={metric} />);
 
   await when(() => !metric.isLoading);
@@ -158,7 +164,12 @@ test.skip("counts filtered by locality", async () => {
   fireEvent.click(option);
 
   await waitFor(() => {
-    const stat = screen.getByRole("figure", { name: "Total people in prison" });
+    const stat = screen.getByRole("figure", {
+      name: "Total people in prison",
+      // performance is better if we don't check for visibility within the *ByRole query;
+      // it's also redundant since we do it immediately after this
+      hidden: true,
+    });
     expect(within(stat).getByText("413")).toBeVisible();
   });
 

--- a/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
+++ b/spotlight-client/src/VizPopulationBreakdownByLocation/VizPopulationBreakdownByLocation.test.tsx
@@ -58,13 +58,7 @@ test("total counts", async () => {
   renderWithStore(<VizPopulationBreakdownByLocation metric={metric} />);
 
   await waitFor(() => {
-    const stat = screen.getByRole("figure", {
-      name: "Total people in prison",
-      // performance is better if we don't check for visibility within the *ByRole query;
-      // it's also redundant since we do it immediately after this
-      hidden: true,
-    });
-
+    const stat = screen.getByLabelText("Total people in prison");
     expect(stat).toBeVisible();
     expect(within(stat).getByText("2,041")).toBeVisible();
   });
@@ -162,12 +156,7 @@ test("counts filtered by locality", async () => {
   fireEvent.click(option);
 
   await waitFor(() => {
-    const stat = screen.getByRole("figure", {
-      name: "Total people in prison",
-      // performance is better if we don't check for visibility within the *ByRole query;
-      // it's also redundant since we do it immediately after this
-      hidden: true,
-    });
+    const stat = screen.getByLabelText("Total people in prison");
     expect(within(stat).getByText("413")).toBeVisible();
   });
 

--- a/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.test.tsx
+++ b/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.test.tsx
@@ -88,7 +88,6 @@ test("total chart", async () => {
   }
 });
 
-// TODO (#353) async specs fail intermittently
 test("demographic charts", async () => {
   renderWithStore(<VizRecidivismRateCumulative metric={metric} />);
 

--- a/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.test.tsx
+++ b/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.test.tsx
@@ -89,7 +89,7 @@ test("total chart", async () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("demographic charts", async () => {
+test("demographic charts", async () => {
   renderWithStore(<VizRecidivismRateCumulative metric={metric} />);
 
   await when(() => !metric.isLoading);
@@ -110,10 +110,6 @@ test.skip("demographic charts", async () => {
     name: "5 lines in a line chart",
   });
 
-  await waitFor(() => {
-    expect(lineChart).toBeVisible();
-  });
-
   expect(
     within(lineChart).getAllByRole("img", {
       name: /^3 point line starting value 0% at 0 ending value \d+% at 2/,
@@ -125,10 +121,6 @@ test.skip("demographic charts", async () => {
 
   [lineChart] = await screen.findAllByRole("group", {
     name: "2 lines in a line chart",
-  });
-
-  await waitFor(() => {
-    expect(lineChart).toBeVisible();
   });
 
   expect(
@@ -145,8 +137,6 @@ test.skip("demographic charts", async () => {
       name: "5 lines in a line chart",
     });
   });
-
-  expect(lineChart).toBeVisible();
 
   expect(
     within(lineChart).getAllByRole("img", {

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.test.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.test.tsx
@@ -103,7 +103,7 @@ test("total chart", async () => {
 });
 
 // TODO (#353) async specs fail intermittently
-test.skip("demographic charts", async () => {
+test("demographic charts", async () => {
   renderWithStore(<VizRecidivismRateSingleFollowup metric={metric} />);
 
   await when(() => !metric.isLoading);
@@ -148,6 +148,7 @@ test.skip("demographic charts", async () => {
   ).toBe(5);
 });
 
+// TODO: (#353): oneYearChart query finds nothing????
 test("followup period filter", async () => {
   renderWithStore(<VizRecidivismRateSingleFollowup metric={metric} />);
 
@@ -159,8 +160,9 @@ test("followup period filter", async () => {
   fireEvent.click(menuButton);
   fireEvent.click(screen.getByRole("option", { name: "1 Year" }));
 
-  const oneYearChart = screen.getByRole("group", {
+  const oneYearChart = await screen.findByRole("group", {
     name: "10 bars in a bar chart",
+    hidden: true,
   });
   expect(oneYearChart).toBeVisible();
 

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.test.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.test.tsx
@@ -102,7 +102,6 @@ test("total chart", async () => {
   ).toBeInTheDocument();
 });
 
-// TODO (#353) async specs fail intermittently
 test("demographic charts", async () => {
   renderWithStore(<VizRecidivismRateSingleFollowup metric={metric} />);
 
@@ -148,7 +147,6 @@ test("demographic charts", async () => {
   ).toBe(5);
 });
 
-// TODO: (#353): oneYearChart query finds nothing????
 test("followup period filter", async () => {
   renderWithStore(<VizRecidivismRateSingleFollowup metric={metric} />);
 


### PR DESCRIPTION
## Description of the change

Tweaks a few of the frontend integration tests to stop intermittent failures. No guarantees really but whereas before the failure rate was creeping up above 75% at times, with these changes I have yet to trigger a failure in a dozen-plus runs across my local and CI. 

I think the main culprit was the *ByRole queries in Testing Library, which apparently are [known to be resource hogs](https://github.com/testing-library/dom-testing-library/issues/820) to the point where they can overwhelm the async polling utilities and cause timeouts and/or failures. Improvements can be had by decoupling the role check from the visibility check, or by just using a different query type.

I only had to change a few of the tests that were known to fail in order to see an improvement; my suspicion is that the poor performance had some kind of cascade effect? Most of the ones I changed were ones that had large DOM trees for the queries to sift through, or that were maybe compounded by animated transitions or something. 

Hopefully this is not too brittle a fix? I am hoping we can avoid a more radical change along the lines of, like, scrapping integration tests in favor of smaller unit tests, etc.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #353

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
