### PR TITLE
update main branch references in CI and docs

### DIFF
--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -2,7 +2,7 @@ name: Spotlight Staging Deploy
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "spotlight-client/**"
 defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,13 @@ Please provide as much information as you can to help us reproduce and fix the
 bug. We have issue templates from which to choose when filing new issues.
 Generally, they require:
 
-* A concise title and clear description of the bug and how it manifests
-* Precise, ordered steps to reproduce it
-* A description of what you expected to occur and how it differed from reality
-* A description of any relevant data that was present and//or used (_sans PII of
-any kind_)
-* Environment information, such as your OS and browser, or versions of
-Python, Google Cloud SDK, or any relevant libraries
+- A concise title and clear description of the bug and how it manifests
+- Precise, ordered steps to reproduce it
+- A description of what you expected to occur and how it differed from reality
+- A description of any relevant data that was present and//or used (_sans PII of
+  any kind_)
+- Environment information, such as your OS and browser, or versions of
+  Python, Google Cloud SDK, or any relevant libraries
 
 ### Submitting Feature Requests
 
@@ -56,11 +56,11 @@ to what you believe to be the right repository.
 Provide as much information as you can to help us consider and prioritize the
 feature. Again, we have issue templates to help. They include:
 
-* A concise title and clear description of the suggested feature
-* Why you believe it would be valuable, and the impact you believe it would
-provide
-* If a change in existing functionality, why you believe this is advantageous to
-the current functionality
+- A concise title and clear description of the suggested feature
+- Why you believe it would be valuable, and the impact you believe it would
+  provide
+- If a change in existing functionality, why you believe this is advantageous to
+  the current functionality
 
 ### Questions, Comments, Concerns
 
@@ -88,6 +88,7 @@ into an area where you feel less comfortable or need to learn something new.
 ### Doing the Work
 
 **tl;dr:**
+
 1. Work on a feature branch
 1. Test your change manually by running the app locally
 1. [Run linting and tests often](README.md)
@@ -112,7 +113,7 @@ Related, include unit and//or integration tests to cover any new code. Update or
 remove existing test cases where appropriate.
 
 When you are passing linting and testing locally and are satisfied with the
-current state of your work, submit a pull request against `master`. However,
+current state of your work, submit a pull request against `main`. However,
 you can also submit Work In Progress ("WIP") pull requests to gather early
 feedback if you believe it would be helpful. If you do so, please format the
 title as "WIP: My title here" and place the PR in a "Draft" state via Github's UI.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains npm packages related to our Spotlight data publishing product, as well as some shared configuration and tooling that involves multiple packages.
 
-![Build Status](https://github.com/Recidiviz/public-dashboard/workflows/Build%20Status/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/public-dashboard/badge.svg?branch=master)](https://coveralls.io/github/Recidiviz/public-dashboard?branch=master)
+![Build Status](https://github.com/Recidiviz/public-dashboard/workflows/Build%20Status/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/Recidiviz/public-dashboard/badge.svg?branch=main)](https://coveralls.io/github/Recidiviz/public-dashboard?branch=main)
 
 ## Packages in this repository
 

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -64,7 +64,7 @@ Once you have the required permissions, you can set up your environment for depl
 
 ### Deploying to Staging
 
-All commits to `master` are automatically deployed to the staging environment by the `spotlight-staging` Github CI workflow, keeping staging up to date as pull requests are merged. (It thus bears mentioning that you should not merge anything to `master` that isn't immediately deployable!)
+All commits to `main` are automatically deployed to the staging environment by the `spotlight-staging` Github CI workflow, keeping staging up to date as pull requests are merged. (It thus bears mentioning that you should not merge anything to `main` that isn't immediately deployable!)
 
 You can also generate and deploy staging builds locally as needed. To generate a staging build, invoke the following yarn script: `yarn build-staging`. This will include the appropriate environment variables from `.env.development`. Each time this is run, the `/build` directory will be wiped clean.
 


### PR DESCRIPTION
## Description of the change

What was once `master` is now `main`. Our staging deploy workflow is the only tooling affected by this. (Prettier also seems to have objected to some of the formatting in our Contributing doc ... there is one changed branch reference in there as well.)

As of now still waiting for Coveralls to register the new default branch; the workflow change can't really be verified until after the merge, for obvious reasons, but there isn't any real concern there.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

part of https://github.com/Recidiviz/recidiviz-data/issues/6688

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
