### PR TITLE
Map host domain to tenant ID

### DIFF
--- a/spotlight-client/@types/global.d.ts
+++ b/spotlight-client/@types/global.d.ts
@@ -1,0 +1,7 @@
+import type { JSDOM } from "jsdom";
+
+// this comes from the jest-environment-jsdom-global package;
+// only present in the test environment
+declare global {
+  const jsdom: JSDOM;
+}

--- a/spotlight-client/package.json
+++ b/spotlight-client/package.json
@@ -12,7 +12,7 @@
     "dev": "react-scripts start",
     "eject": "react-scripts eject",
     "lint": "tsc && eslint '**/*.{js,ts,tsx}'",
-    "test": "react-scripts test --env=jest-environment-jsdom-sixteen"
+    "test": "react-scripts test --env=jest-environment-jsdom-global"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.13.1",
@@ -101,27 +101,29 @@
     "@testing-library/react": "^11.1.1",
     "@testing-library/user-event": "^12.7.0",
     "@types/jest": "^24.0.0",
+    "@types/jsdom": "^16.2.10",
     "@types/node": "^12.0.0",
-    "env-cmd": "^10.1.0",
-    "@typescript-eslint/parser": "^4.4.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
+    "@typescript-eslint/parser": "^4.4.0",
+    "babel-eslint": "^10.0.0",
+    "env-cmd": "^10.1.0",
     "eslint": "^6.6.0",
+    "eslint-config-react-app": "^6.0.0",
     "eslint-import-resolver-typescript": "^2.3.0",
+    "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.23.1",
-    "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "babel-eslint": "^10.0.0",
-    "prettier": "^2.2.1",
-    "eslint-plugin-flowtype": "^5.2.0",
     "jest-date-mock": "^1.0.8",
+    "jest-environment-jsdom-global": "^2.0.4",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-fetch-mock": "^3.0.3",
     "jest-mock-extended": "^1.0.13",
-    "lint-staged": ">=10"
+    "lint-staged": ">=10",
+    "prettier": "^2.2.1"
   },
   "browserslist": {
     "production": [

--- a/spotlight-client/src/DataStore/TenantStore.test.ts
+++ b/spotlight-client/src/DataStore/TenantStore.test.ts
@@ -22,52 +22,46 @@ import { reactImmediately } from "../testUtils";
 import RootStore from "./RootStore";
 
 let DataStore: RootStore;
+let tenantStore: typeof DataStore.tenantStore;
 
 beforeEach(() => {
   DataStore = new RootStore();
+  tenantStore = DataStore.tenantStore;
 });
 
-test("contains a tenant store", () => {
+test("belongs to root store", () => {
   expect(DataStore.tenantStore).toBeDefined();
 });
 
-describe("tenant store", () => {
-  let tenantStore: typeof DataStore.tenantStore;
-
-  beforeEach(() => {
-    tenantStore = DataStore.tenantStore;
-  });
-
-  test("has no default tenant", () => {
-    reactImmediately(() => {
-      expect(tenantStore.currentTenant).toBeUndefined();
-    });
-    expect.hasAssertions();
-  });
-
-  test("can set current tenant", () => {
-    runInAction(() => {
-      tenantStore.currentTenantId = "US_ND";
-    });
-
-    reactImmediately(() => {
-      expect(tenantStore.currentTenant).toBeInstanceOf(Tenant);
-    });
-    expect.hasAssertions();
-  });
-
-  test("can set current narrative", () => {
+test("has no default tenant", () => {
+  reactImmediately(() => {
     expect(tenantStore.currentTenant).toBeUndefined();
-
-    runInAction(() => {
-      tenantStore.currentTenantId = "US_ND";
-      tenantStore.currentNarrativeTypeId = "Prison";
-    });
-
-    reactImmediately(() => {
-      expect(tenantStore.currentNarrative).toBeInstanceOf(SystemNarrative);
-    });
-
-    expect.assertions(2);
   });
+  expect.hasAssertions();
+});
+
+test("can set current tenant", () => {
+  runInAction(() => {
+    tenantStore.currentTenantId = "US_ND";
+  });
+
+  reactImmediately(() => {
+    expect(tenantStore.currentTenant).toBeInstanceOf(Tenant);
+  });
+  expect.hasAssertions();
+});
+
+test("can set current narrative", () => {
+  expect(tenantStore.currentTenant).toBeUndefined();
+
+  runInAction(() => {
+    tenantStore.currentTenantId = "US_ND";
+    tenantStore.currentNarrativeTypeId = "Prison";
+  });
+
+  reactImmediately(() => {
+    expect(tenantStore.currentNarrative).toBeInstanceOf(SystemNarrative);
+  });
+
+  expect.assertions(2);
 });

--- a/spotlight-client/src/DataStore/TenantStore.ts
+++ b/spotlight-client/src/DataStore/TenantStore.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { makeAutoObservable } from "mobx";
+import { intercept, makeAutoObservable } from "mobx";
 import {
   isSystemNarrativeTypeId,
   NarrativeTypeId,
@@ -25,6 +25,7 @@ import RacialDisparitiesNarrative from "../contentModels/RacialDisparitiesNarrat
 import type SystemNarrative from "../contentModels/SystemNarrative";
 import Tenant, { createTenant } from "../contentModels/Tenant";
 import type RootStore from "./RootStore";
+import { getTenantFromDomain } from "./utils";
 
 export default class TenantStore {
   currentNarrativeTypeId?: NarrativeTypeId;
@@ -41,6 +42,14 @@ export default class TenantStore {
     this.rootStore = rootStore;
 
     this.tenants = new Map();
+
+    // tenant mapped from domain should be locked
+    const tenantFromDomain = getTenantFromDomain();
+    if (tenantFromDomain) {
+      this.currentTenantId = tenantFromDomain;
+      // returning null renders an observable property immutable
+      intercept(this, "currentTenantId", () => null);
+    }
   }
 
   /**

--- a/spotlight-client/src/DataStore/utils.test.ts
+++ b/spotlight-client/src/DataStore/utils.test.ts
@@ -1,0 +1,72 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { getTenantFromDomain } from "./utils";
+
+let originalUrl: string;
+
+beforeEach(() => {
+  originalUrl = window.location.href;
+});
+
+afterEach(() => {
+  jsdom.reconfigure({ url: originalUrl });
+});
+
+test("*.nd.gov matches ND", () => {
+  jsdom.reconfigure({ url: "https://dashboard.docr.nd.gov" });
+  expect(getTenantFromDomain()).toBe("US_ND");
+
+  // any subdomain should match
+  jsdom.reconfigure({ url: "https://new-dashboard-url.nd.gov" });
+  expect(getTenantFromDomain()).toBe("US_ND");
+
+  // make sure that last nd.gov doesn't trick us
+  jsdom.reconfigure({ url: "https://dashboard.maryland.gov" });
+  expect(getTenantFromDomain).toThrow();
+});
+
+test("other .gov domains error", () => {
+  jsdom.reconfigure({ url: "https://dashboard.pa.gov" });
+  expect(getTenantFromDomain).toThrow();
+
+  jsdom.reconfigure({ url: "https://dashboard.ca.gov" });
+  expect(getTenantFromDomain).toThrow();
+
+  jsdom.reconfigure({ url: "https://dashboard.co.gov" });
+  expect(getTenantFromDomain).toThrow();
+
+  jsdom.reconfigure({ url: "https://dashboard.whitehouse.gov" });
+  expect(getTenantFromDomain).toThrow();
+});
+
+test("staging domains matching tenants", () => {
+  jsdom.reconfigure({ url: "https://us-nd.spotlight-staging.recidiviz.org" });
+  expect(getTenantFromDomain()).toBe("US_ND");
+});
+
+test("no match", () => {
+  expect(getTenantFromDomain()).toBeUndefined();
+
+  // multi-tenant staging home
+  jsdom.reconfigure({ url: "https://spotlight-staging.recidiviz.org" });
+  expect(getTenantFromDomain()).toBeUndefined();
+
+  // unsupported tenant doesn't error, just doesn't trigger any special behavior
+  jsdom.reconfigure({ url: "https://us-ri.spotlight-staging.recidiviz.org" });
+  expect(getTenantFromDomain()).toBeUndefined();
+});

--- a/spotlight-client/src/DataStore/utils.ts
+++ b/spotlight-client/src/DataStore/utils.ts
@@ -36,7 +36,7 @@ export function getTenantFromDomain(): TenantId | undefined {
   }
 
   // staging domains
-  const stagingRegex = /^(.+).spotlight-staging.recidiviz.org$/;
+  const stagingRegex = /^(.+).spotlight-staging.recidiviz.org$/i;
   const stagingMatch = stagingRegex.exec(domain);
   if (stagingMatch) {
     return normalizeTenantId(stagingMatch[1]) ?? undefined;

--- a/spotlight-client/src/DataStore/utils.ts
+++ b/spotlight-client/src/DataStore/utils.ts
@@ -1,0 +1,44 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { TenantId } from "../contentApi/types";
+import { normalizeTenantId } from "../routerUtils/normalizeRouteParams";
+
+/**
+ * Reads the hostname from the current Location. If it maps to a TenantId
+ * (following known naming conventions), that TenantId will be returned;
+ * otherwise `undefined`. *.gov domains are a special case: if a .gov Location
+ * fails to match a known TenantID an error will be thrown.
+ */
+export function getTenantFromDomain(): TenantId | undefined {
+  const domain = window.location.hostname;
+
+  // production domains
+  if (domain.endsWith(".gov")) {
+    if (domain.endsWith(".nd.gov")) {
+      return "US_ND";
+    }
+    throw new Error("Unable to proceed; this .gov domain is not supported.");
+  }
+
+  // staging domains
+  const stagingRegex = /^(.+).spotlight-staging.recidiviz.org$/;
+  const stagingMatch = stagingRegex.exec(domain);
+  if (stagingMatch) {
+    return normalizeTenantId(stagingMatch[1]) ?? undefined;
+  }
+}

--- a/spotlight-client/src/routerUtils/normalizeRouteParams.ts
+++ b/spotlight-client/src/routerUtils/normalizeRouteParams.ts
@@ -17,7 +17,7 @@
 
 import { constantCase, pascalCase } from "change-case";
 import { ValuesType } from "utility-types";
-import { isNarrativeTypeId, isTenantId } from "../contentApi/types";
+import { isNarrativeTypeId, isTenantId, TenantId } from "../contentApi/types";
 import { NormalizedRouteParams, RouteParams } from "./types";
 
 /**
@@ -34,7 +34,9 @@ export default function normalizeRouteParams(
   };
 }
 
-function normalizeTenantId(rawParam: ValuesType<RouteParams>) {
+export function normalizeTenantId(
+  rawParam: ValuesType<RouteParams>
+): TenantId | null | undefined {
   if (typeof rawParam === "string") {
     const normalizedString = constantCase(rawParam);
     if (isTenantId(normalizedString)) return normalizedString;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,6 +2378,15 @@
   dependencies:
     jest-diff "^24.3.0"
 
+"@types/jsdom@^16.2.10":
+  version "16.2.10"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.10.tgz#c05ea94682d035943ae2453b79d56178496b6653"
+  integrity sha512-q3aIjp3ehhVSXSbvNyuireAfvU2umRiZ2aLumyeZewCnoNaokrRDdTu5IvaeE9pzNtWHXrUnM9lb22Vl3W08EA==
+  dependencies:
+    "@types/node" "*"
+    "@types/parse5" "*"
+    "@types/tough-cookie" "*"
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
@@ -2412,6 +2421,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/parse5@*":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.0.tgz#38590dc2c3cf5717154064e3ee9b6947ee21b299"
+  integrity sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA==
 
 "@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.3"
@@ -2589,6 +2603,11 @@
     "@types/topojson-server" "*"
     "@types/topojson-simplify" "*"
     "@types/topojson-specification" "*"
+
+"@types/tough-cookie@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/warning@^3.0.0":
   version "3.0.0"
@@ -9042,6 +9061,11 @@ jest-environment-jsdom-fourteen@1.0.1:
     jest-mock "^24.0.0"
     jest-util "^24.0.0"
     jsdom "^14.1.0"
+
+jest-environment-jsdom-global@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom-global/-/jest-environment-jsdom-global-2.0.4.tgz#b74704487a374a67ff301fc51cfeae30fae40e8e"
+  integrity sha512-1vB8q+PrszXW4Pf7Zgp3eQ4oNVbA7GY6+jmrg1qi6RtYRWDJ60/xdkhjqAbQpX8BRyvqQJYQi66LXER5YNeHXg==
 
 jest-environment-jsdom-sixteen@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Description of the change

For the first piece of multi-tenant support, we associate certain subdomains with tenant IDs and restrict the data models to only that matching tenant (when present). A slight adjustment to the Jest configuration allows us to test against different hosts in our test environment. (The `TenantStore` test module that looks new here is just renamed, and I added two new tests to it.)

This should have no effect on the site as currently configured, as there is only one tenant.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #388

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
