### PR TITLE
Multi-tenant navigation with PA placeholder content

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         working-directory: spotlight-client
     env:
       REACT_APP_API_URL: http://localhost:3002
+      REACT_APP_ENABLED_TENANTS: US_ND,US_PA
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -30,6 +30,8 @@ jobs:
           REACT_APP_AUTH_ENABLED: true
           REACT_APP_AUTH_ENV: development
           REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
+          REACT_APP_ENABLED_TENANTS: US_ND,US_PA
+
         run: yarn build
       - name: Store build artifact
         uses: actions/upload-artifact@v2

--- a/spotlight-client/README.md
+++ b/spotlight-client/README.md
@@ -31,6 +31,7 @@ Expected environment variables include:
 - `REACT_APP_AUTH_ENABLED` - set to `true` or `false` to toggle Auth0 protection per environment. Currently only used in staging to make the entire site private. No need to enable this locally unless you are developing or testing something auth-related. If set to `true` then `REACT_APP_AUTH_ENV` **must** be set to a supported value.
 - `REACT_APP_AUTH_ENV` - a string indicating the "auth environment" used to point to the correct Auth0 tenant. `development` (which also covers staging) is the only supported value, which **must** be set if `REACT_APP_AUTH_ENABLED` is `true`.
 - `REACT_APP_API_URL` - the base URL of the backend API server. This should be set to http://localhost:3001 when running the server locally, and to http://localhost:3002 in the test environment (because some tests will make requests to this URL).
+- `REACT_APP_ENABLED_TENANTS` - a feature flag for activating individual tenants, in the form of a comma-separated list of tenant IDs (e.g., "US_ND,US_PA") that should be available. Tenants that are configured but not enumerated here will not be accessible to users.
 
 (Note that variables must be prefixed with `REACT_APP_` to be available inside the client application.)
 

--- a/spotlight-client/src/App-auth.test.tsx
+++ b/spotlight-client/src/App-auth.test.tsx
@@ -54,8 +54,7 @@ async function getApp() {
 // mocking the node env is esoteric, see https://stackoverflow.com/a/48042799
 const ORIGINAL_ENV = process.env;
 
-// home page redirects to the ND home page
-const authenticatedTextMatch = /North Dakota/;
+const authenticatedTextMatch = /Spotlight/;
 
 beforeEach(async () => {
   // make a copy that we can modify

--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -54,10 +54,10 @@ describe("navigation", () => {
     expect(screen.getByRole(...lookupArgs)).toBeInTheDocument();
   }
 
-  test("site home redirects to ND", async () => {
+  test("site home", async () => {
     renderNavigableApp();
     expect(
-      await screen.findByRole("heading", { name: /North Dakota/, level: 1 })
+      await screen.findByRole("heading", { name: /Spotlight/, level: 1 })
     ).toBeVisible();
   });
 
@@ -108,7 +108,7 @@ describe("navigation", () => {
   });
 
   test("links", async () => {
-    renderNavigableApp();
+    renderNavigableApp({ route: "/us-nd" });
 
     const inNav = within(screen.getByRole("navigation"));
 
@@ -145,10 +145,9 @@ describe("navigation", () => {
     );
 
     fireEvent.click(homeLink);
-    // home redirect to ND
     await waitFor(async () =>
       expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
-        "North Dakota"
+        "Spotlight"
       )
     );
   });

--- a/spotlight-client/src/App.tsx
+++ b/spotlight-client/src/App.tsx
@@ -25,6 +25,7 @@ import AuthWall from "./AuthWall";
 import { FOOTER_HEIGHT, NAV_BAR_HEIGHT } from "./constants";
 import GlobalStyles from "./GlobalStyles";
 import NotFound from "./NotFound";
+import PageHome from "./PageHome";
 import PageNarrative from "./PageNarrative";
 import PageTenant from "./PageTenant";
 import PageviewTracker from "./PageviewTracker";
@@ -69,13 +70,12 @@ const App: React.FC = () => {
                 NOTE: every leaf route component in this router should be wrapped
                 by the withRouteSync higher-order component to keep data and UI in sync!
               */}
-              {/* while there is only one state, home simply redirects to ND home */}
-              <Redirect from="/" to="/us-nd" noThrow />
               {/*
                 this was the ND homepage for v1;
                 let's make sure people who bookmarked it are not lost
               */}
               <Redirect from="/us_nd/overview" to="/us-nd" noThrow />
+              <PageHome path="/" />
               <PassThroughPage path="/:tenantId">
                 <PageTenant path="/" />
                 <PageNarrative path={`/${NarrativesSlug}/:narrativeTypeId`} />

--- a/spotlight-client/src/DataStore/TenantStore.test.ts
+++ b/spotlight-client/src/DataStore/TenantStore.test.ts
@@ -99,7 +99,16 @@ test("lock tenant if set from current domain", () => {
   reactImmediately(() => {
     expect(tenantStore.currentTenant?.id).toBe("US_ND");
     expect(tenantStore.currentTenantId).toBe("US_ND");
+    expect(tenantStore.locked).toBe(true);
   });
 
-  // TODO (#391): we shouldn't be able to change to another tenant either
+  // we shouldn't be able to switch to another tenant either
+  runInAction(() => {
+    tenantStore.currentTenantId = "US_PA";
+  });
+  reactImmediately(() => {
+    expect(tenantStore.currentTenant?.id).toBe("US_ND");
+    expect(tenantStore.currentTenantId).toBe("US_ND");
+    expect(tenantStore.locked).toBe(true);
+  });
 });

--- a/spotlight-client/src/DataStore/TenantStore.ts
+++ b/spotlight-client/src/DataStore/TenantStore.ts
@@ -32,6 +32,8 @@ export default class TenantStore {
 
   currentTenantId?: TenantId;
 
+  readonly locked: boolean = false;
+
   rootStore: RootStore;
 
   tenants: Map<TenantId, Tenant>;
@@ -46,6 +48,7 @@ export default class TenantStore {
     // tenant mapped from domain should be locked
     const tenantFromDomain = getTenantFromDomain();
     if (tenantFromDomain) {
+      this.locked = true;
       this.currentTenantId = tenantFromDomain;
       // returning null renders an observable property immutable
       intercept(this, "currentTenantId", () => null);

--- a/spotlight-client/src/DataStore/TenantStore.ts
+++ b/spotlight-client/src/DataStore/TenantStore.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { intercept, makeAutoObservable } from "mobx";
+import { ERROR_MESSAGES } from "../constants";
 import {
   isSystemNarrativeTypeId,
   NarrativeTypeId,
@@ -63,10 +64,18 @@ export default class TenantStore {
   get currentTenant(): Tenant | undefined {
     if (!this.currentTenantId) return undefined;
     if (!this.tenants.has(this.currentTenantId)) {
-      this.tenants.set(
-        this.currentTenantId,
-        createTenant({ tenantId: this.currentTenantId })
-      );
+      // if the tenant is not enabled, the caller will get undefined,
+      // so they need to be prepared to handle that
+      try {
+        this.tenants.set(
+          this.currentTenantId,
+          createTenant({ tenantId: this.currentTenantId })
+        );
+      } catch (error) {
+        if (!error.message.includes(ERROR_MESSAGES.disabledTenant)) {
+          throw error;
+        }
+      }
     }
     return this.tenants.get(this.currentTenantId);
   }

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -1,0 +1,71 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { Link, Redirect } from "@reach/router";
+import { observer } from "mobx-react-lite";
+import { rem } from "polished";
+import React from "react";
+import styled from "styled-components/macro";
+import getTenantList from "../contentApi/getTenantList";
+import getUrlForResource from "../routerUtils/getUrlForResource";
+import { useDataStore } from "../StoreProvider";
+import { CopyBlock, PageSection, PageTitle } from "../UiLibrary";
+import withRouteSync from "../withRouteSync";
+
+const PageContainer = styled(PageSection)`
+  padding-bottom: ${rem(48)};
+  padding-top: ${rem(48)};
+`;
+
+const PageHome = (): React.ReactElement => {
+  const {
+    tenantStore: { locked, currentTenantId },
+  } = useDataStore();
+
+  if (locked && currentTenantId) {
+    return (
+      <Redirect
+        to={getUrlForResource({
+          page: "tenant",
+          params: { tenantId: currentTenantId },
+        })}
+      />
+    );
+  }
+
+  return (
+    <PageContainer>
+      <PageTitle>Spotlight</PageTitle>
+      <CopyBlock>
+        {getTenantList().map(({ id, name }) => (
+          <p>
+            <Link
+              to={getUrlForResource({
+                page: "tenant",
+                params: { tenantId: id },
+              })}
+            >
+              {name}
+            </Link>
+          </p>
+        ))}
+      </CopyBlock>
+    </PageContainer>
+  );
+};
+
+export default withRouteSync(observer(PageHome));

--- a/spotlight-client/src/PageHome/PageHome.tsx
+++ b/spotlight-client/src/PageHome/PageHome.tsx
@@ -39,6 +39,7 @@ const PageHome = (): React.ReactElement => {
   if (locked && currentTenantId) {
     return (
       <Redirect
+        noThrow
         to={getUrlForResource({
           page: "tenant",
           params: { tenantId: currentTenantId },

--- a/spotlight-client/src/PageHome/index.ts
+++ b/spotlight-client/src/PageHome/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export { default } from "./PageHome";

--- a/spotlight-client/src/ScrollManager/ScrollManager.test.tsx
+++ b/spotlight-client/src/ScrollManager/ScrollManager.test.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { act, waitFor } from "@testing-library/react";
+import { act } from "@testing-library/react";
 import { NarrativesSlug } from "../routerUtils/types";
 import { renderNavigableApp } from "../testUtils";
 

--- a/spotlight-client/src/constants.ts
+++ b/spotlight-client/src/constants.ts
@@ -21,6 +21,7 @@ export const ERROR_MESSAGES = {
   noMetricData: "Unable to retrieve valid data for this metric.",
   missingRequiredContent:
     "Unable to create Metric because required content is missing.",
+  disabledTenant: "This tenant has not been enabled.",
 };
 
 export const NAV_BAR_HEIGHT = 80;

--- a/spotlight-client/src/contentApi/getTenantList.test.ts
+++ b/spotlight-client/src/contentApi/getTenantList.test.ts
@@ -15,30 +15,19 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { act, waitFor } from "@testing-library/react";
-import { NarrativesSlug } from "../routerUtils/types";
-import { renderNavigableApp } from "../testUtils";
+import getTenantList from "./getTenantList";
 
-const scrollSpy = jest.spyOn(window, "scrollTo");
-
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
-test("scrolls on page change", async () => {
-  const {
-    history: { navigate },
-  } = renderNavigableApp();
-
-  expect(scrollSpy).toHaveBeenCalledWith(0, 0);
-  scrollSpy.mockClear();
-
-  await act(() => navigate(`/us-nd/${NarrativesSlug}/prison`));
-  expect(scrollSpy).toHaveBeenCalledWith(0, 0);
-  scrollSpy.mockClear();
-
-  // we cannot really test non-scrolling behavior reliably,
-  // because intra-page route changes also trigger scrolling, and JSDOM
-  // does not implement any real scrolling functionality
-  // so the positions cannot be meaningfully inspected
+test("getTenantList", () => {
+  expect(getTenantList()).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "id": "US_ND",
+        "name": "North Dakota",
+      },
+      Object {
+        "id": "US_PA",
+        "name": "Pennsylvania",
+      },
+    ]
+  `);
 });

--- a/spotlight-client/src/contentApi/getTenantList.ts
+++ b/spotlight-client/src/contentApi/getTenantList.ts
@@ -18,9 +18,17 @@
 import retrieveContent from "./retrieveContent";
 import { TenantId, TenantIdList } from "./types";
 
-export default function getTenantList(): { id: TenantId; name: string }[] {
-  return TenantIdList.map((id) => ({
-    id,
-    name: retrieveContent({ tenantId: id }).name,
-  }));
+type TenantListItem = { id: TenantId; name: string };
+
+export default function getTenantList(): TenantListItem[] {
+  return TenantIdList.map((id) => {
+    try {
+      return {
+        id,
+        name: retrieveContent({ tenantId: id }).name,
+      };
+    } catch {
+      return null;
+    }
+  }).filter((t): t is TenantListItem => t !== null);
 }

--- a/spotlight-client/src/contentApi/getTenantList.ts
+++ b/spotlight-client/src/contentApi/getTenantList.ts
@@ -1,0 +1,26 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import retrieveContent from "./retrieveContent";
+import { TenantId, TenantIdList } from "./types";
+
+export default function getTenantList(): { id: TenantId; name: string }[] {
+  return TenantIdList.map((id) => ({
+    id,
+    name: retrieveContent({ tenantId: id }).name,
+  }));
+}

--- a/spotlight-client/src/contentApi/isTenantEnabled.test.ts
+++ b/spotlight-client/src/contentApi/isTenantEnabled.test.ts
@@ -1,0 +1,74 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+// we have to import everything dynamically to manipulate process.env,
+// which is weird and Typescript doesn't like it, so silence these warnings
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let cleanup: any;
+let TenantIdList: any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// this doesn't do anything but convince TypeScript this file is a module,
+// since we don't have any top-level imports
+export {};
+
+// mocking the node env is esoteric, see https://stackoverflow.com/a/48042799
+const ORIGINAL_ENV = process.env;
+
+/**
+ * Convenience method for importing test module after updating environment
+ */
+async function getTestFn() {
+  return (await import("./isTenantEnabled")).isTenantEnabled;
+}
+
+beforeEach(async () => {
+  // make a copy that we can modify
+  process.env = { ...ORIGINAL_ENV };
+
+  jest.resetModules();
+  // reimport all modules except the test module
+  const reactTestingLibrary = await import("@testing-library/react");
+  cleanup = reactTestingLibrary.cleanup;
+  TenantIdList = (await import("./types")).TenantIdList;
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  // dynamic imports break auto cleanup so we have to do it manually
+  cleanup();
+});
+
+test("all tenants enabled", async () => {
+  process.env.REACT_APP_ENABLED_TENANTS = TenantIdList.join(",");
+
+  const isTenantEnabled = await getTestFn();
+
+  expect(TenantIdList.map(isTenantEnabled)).toEqual(
+    TenantIdList.map(() => true)
+  );
+});
+
+test("disabled tenant", async () => {
+  process.env.REACT_APP_ENABLED_TENANTS = "US_ND";
+
+  const isTenantEnabled = await getTestFn();
+
+  expect(TenantIdList.map(isTenantEnabled)).toEqual(
+    TenantIdList.map((id: string) => id === "US_ND")
+  );
+});

--- a/spotlight-client/src/contentApi/isTenantEnabled.ts
+++ b/spotlight-client/src/contentApi/isTenantEnabled.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2020 Recidiviz, Inc.
+// Copyright (C) 2021 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,26 +15,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { ERROR_MESSAGES } from "../constants";
-import { isTenantEnabled } from "./isTenantEnabled";
-import US_ND from "./sources/us_nd";
-import US_PA from "./sources/us_pa";
-import { TenantContent, TenantId } from "./types";
+import { TenantId } from "./types";
 
-const CONTENT_SOURCES: Record<TenantId, TenantContent> = { US_ND, US_PA };
-
-type RetrieveContentParams = {
-  tenantId: TenantId;
-};
+const enabledTenants = process.env.REACT_APP_ENABLED_TENANTS?.split(
+  ","
+).map((id) => id.trim());
 
 /**
- * Provides the entire content object for the tenant specified by `tenantId`.
+ * Tenants have to be explicitly enabled per environment; this function
+ * checks against that configuration for a given tenant.
  */
-export default function retrieveContent({
-  tenantId,
-}: RetrieveContentParams): TenantContent {
-  if (isTenantEnabled(tenantId)) {
-    return CONTENT_SOURCES[tenantId];
-  }
-  throw new Error(`${ERROR_MESSAGES.disabledTenant} (${tenantId})`);
+export function isTenantEnabled(id: TenantId): boolean {
+  return Array.isArray(enabledTenants) && enabledTenants.includes(id);
 }

--- a/spotlight-client/src/contentApi/retrieveContent.test.ts
+++ b/spotlight-client/src/contentApi/retrieveContent.test.ts
@@ -17,8 +17,10 @@
 
 import retrieveContent from "./retrieveContent";
 import US_ND from "./sources/us_nd";
+import US_PA from "./sources/us_pa";
 
 test("returns content for the specified tenant", () => {
-  const tenantContent = retrieveContent({ tenantId: "US_ND" });
-  expect(tenantContent).toEqual(US_ND);
+  expect(retrieveContent({ tenantId: "US_ND" })).toEqual(US_ND);
+
+  expect(retrieveContent({ tenantId: "US_PA" })).toEqual(US_PA);
 });

--- a/spotlight-client/src/contentApi/retrieveContent.ts
+++ b/spotlight-client/src/contentApi/retrieveContent.ts
@@ -16,9 +16,10 @@
 // =============================================================================
 
 import US_ND from "./sources/us_nd";
+import US_PA from "./sources/us_pa";
 import { TenantContent, TenantId } from "./types";
 
-const CONTENT_SOURCES: Record<TenantId, TenantContent> = { US_ND };
+const CONTENT_SOURCES: Record<TenantId, TenantContent> = { US_ND, US_PA };
 
 type RetrieveContentParams = {
   tenantId: TenantId;

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -1,0 +1,60 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { TenantContent } from "../types";
+
+const content: TenantContent = {
+  name: "Pennsylvania",
+  description: "",
+  coBrandingCopy: "",
+  systemNarratives: {
+    Prison: {
+      title: "Prison",
+      introduction: "",
+      sections: [],
+    },
+    Parole: {
+      title: "Parole",
+      introduction: "",
+      sections: [],
+    },
+  },
+  metrics: {},
+  racialDisparitiesNarrative: {
+    introduction: "",
+    introductionMethodology: "",
+    chartLabels: {
+      totalPopulation: "",
+      totalSentenced: "",
+      paroleGrant: "",
+      incarceratedPopulation: "",
+      otherGroups: "",
+      programmingParticipants: "",
+      supervisionPopulation: "",
+      totalPopulationSentences: "",
+    },
+    sections: {},
+  },
+  localities: {
+    Prison: {
+      label: "",
+      entries: [],
+    },
+  },
+};
+
+export default content;

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -25,7 +25,7 @@ export type LocalityLabels = {
 // ============================
 // Tenant types
 
-export const TenantIdList = ["US_ND"] as const;
+export const TenantIdList = ["US_ND", "US_PA"] as const;
 export type TenantId = typeof TenantIdList[number];
 export function isTenantId(x: string): x is TenantId {
   return TenantIdList.includes(x as TenantId);

--- a/spotlight-client/src/testUtils/testUtils.tsx
+++ b/spotlight-client/src/testUtils/testUtils.tsx
@@ -48,6 +48,9 @@ export function renderNavigableApp({ route = "/" } = {}): {
   history: ReturnType<typeof createHistory>;
   rendered: ReturnType<typeof render>;
 } {
+  // make sure the current window.history state matches the route we are rendering
+  // (Reach Router will keep it in sync for subsequent navigation)
+  window.history.replaceState(null, "", route);
   const history = createHistory(createMemorySource(route));
 
   return {

--- a/spotlight-client/src/withRouteSync/withRouteSync.tsx
+++ b/spotlight-client/src/withRouteSync/withRouteSync.tsx
@@ -19,6 +19,7 @@ import { RouteComponentProps } from "@reach/router";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { ComponentType, useEffect } from "react";
+import { isTenantEnabled } from "../contentApi/isTenantEnabled";
 import NotFound from "../NotFound";
 import normalizeRouteParams from "../routerUtils/normalizeRouteParams";
 import { RouteParams } from "../routerUtils/types";
@@ -47,8 +48,14 @@ const withRouteSync = <Props extends RouteComponentProps & RouteParams>(
       normalizedProps.tenantId &&
       tenantStore.currentTenantId !== normalizedProps.tenantId;
 
+    const isTenantDisabled = Boolean(
+      tenantStore.currentTenantId &&
+        !isTenantEnabled(tenantStore.currentTenantId)
+    );
+
     const isRouteInvalid =
       isTenantForbidden ||
+      isTenantDisabled ||
       Object.values(normalizedProps).includes(null) ||
       // catchall path for partially valid URLs; e.g. :tenantId/something-invalid
       path === "/*";

--- a/spotlight-client/src/withRouteSync/withRouteSync.tsx
+++ b/spotlight-client/src/withRouteSync/withRouteSync.tsx
@@ -17,6 +17,7 @@
 
 import { RouteComponentProps } from "@reach/router";
 import { action } from "mobx";
+import { observer } from "mobx-react-lite";
 import React, { ComponentType, useEffect } from "react";
 import NotFound from "../NotFound";
 import normalizeRouteParams from "../routerUtils/normalizeRouteParams";
@@ -40,9 +41,17 @@ const withRouteSync = <Props extends RouteComponentProps & RouteParams>(
 
     const { path } = props;
 
+    const isTenantForbidden =
+      tenantStore.locked &&
+      // we're checking for wrong Tenants, not no Tenant
+      normalizedProps.tenantId &&
+      tenantStore.currentTenantId !== normalizedProps.tenantId;
+
     const isRouteInvalid =
+      isTenantForbidden ||
+      Object.values(normalizedProps).includes(null) ||
       // catchall path for partially valid URLs; e.g. :tenantId/something-invalid
-      Object.values(normalizedProps).includes(null) || path === "/*";
+      path === "/*";
 
     // this is fine, we actually want this to run on every render
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -69,7 +78,7 @@ const withRouteSync = <Props extends RouteComponentProps & RouteParams>(
     );
   };
 
-  return WrappedRouteComponent;
+  return observer(WrappedRouteComponent);
 };
 
 export default withRouteSync;


### PR DESCRIPTION
## Description of the change

Completes the initial preparations to support multiple tenants. In the final analysis this wound up including:

- adds placeholder content for PA. This is the bare minimum required to let you navigate around to the expected pages, but there is neither copy nor data yet for the metrics so I just left them out for now.
- replaces the automatic redirect to ND with a check for a "locked" Tenant in the data store. If the lock is engaged, the homepage will redirect to that tenant's home page, and direct visits to any other tenants' paths will result in a Not Found page.
- Adds a basic homepage with links to the available tenants. This is only intended for use in local and staging environments, though it will technically also be in prod if you manage to visit the base Firebase URL.
- Adds a feature flag for granular tenant releases per environment. This will make intermediate prod releases safer because we can suppress the PA pages entirely even while they are available in staging. (Direct visits to the url of a disabled tenant also result in Page Not Found, so it should look the same to an end user as if the tenant didn't exist.)

I tested as much of this functionality as I could in Jest but supplemented it with some pretty thorough manual testing, by editing my hosts file to point the domains of interest at my local dev server. There should be no change in behavior for the existing ND prod domain, and the new staging domains also worked as expected. (I also tested this in staging a bit but that environment isn't necessarily up to date with this branch now.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #389, closes #391 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
