### PR TITLE
Fix unresponsive navigation menu

### DIFF
--- a/spotlight-client/src/UiLibrary/Dropdown/DropdownBase.tsx
+++ b/spotlight-client/src/UiLibrary/Dropdown/DropdownBase.tsx
@@ -86,6 +86,8 @@ const DropdownBase: React.FC<
   // helper for animation of menu opening and closing
   const [waitForCloseAnimation, setWaitForCloseAnimation] = useState(false);
 
+  const { selectedItem, ...passThruSelectProps } = selectProps;
+
   const {
     closeMenu,
     isOpen,
@@ -97,7 +99,11 @@ const DropdownBase: React.FC<
   } = useSelect({
     items: options,
     onIsOpenChange: () => setWaitForCloseAnimation(true),
-    ...selectProps,
+    // passing null explicitly clears the selection; without it,
+    // Downshift maintains an internal selection state that we don't want.
+    // The dropdown is either fully controlled by an input prop or it is stateless
+    selectedItem: selectedItem || null,
+    ...passThruSelectProps,
   });
 
   // animate button hover state


### PR DESCRIPTION
## Description of the change

Makes sure the dropdown selection is explicitly cleared when it is not provided (as in the case of the navigation menu); otherwise it remembers the last thing you clicked and leads to bugs such as the one linked here.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #381 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
