### PR TITLE
Exclude probation from PA racial disparities narrative

### DIFF
--- a/spotlight-client/src/RacialDisparitiesNarrativePage/SupervisionTypeFilterSelect.tsx
+++ b/spotlight-client/src/RacialDisparitiesNarrativePage/SupervisionTypeFilterSelect.tsx
@@ -21,14 +21,8 @@ import { observer } from "mobx-react-lite";
 import React from "react";
 import RacialDisparitiesNarrative, {
   SupervisionType,
-  SupervisionTypeList,
 } from "../contentModels/RacialDisparitiesNarrative";
 import { Dropdown } from "../UiLibrary";
-
-const DROPDOWN_OPTIONS = SupervisionTypeList.map((id) => ({
-  id,
-  label: `${id === "supervision" ? "All " : ""}${capitalCase(id)}`,
-}));
 
 type SupervisionTypeFilterSelectProps = {
   narrative: RacialDisparitiesNarrative;
@@ -46,11 +40,16 @@ const SupervisionTypeFilterSelect: React.FC<SupervisionTypeFilterSelectProps> = 
     }
   );
 
+  const options = narrative.supervisionTypeList.map((id) => ({
+    id,
+    label: `${id === "supervision" ? "All " : ""}${capitalCase(id)}`,
+  }));
+
   return (
     <Dropdown
       label="Supervision Type"
       onChange={onChange}
-      options={DROPDOWN_OPTIONS}
+      options={options}
       selectedId={narrative.supervisionType}
     />
   );

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -336,6 +336,7 @@ const content: TenantContent = {
       supervisionPopulation: "All people under supervision",
       totalPopulationSentences: "All people sentenced and under DOC control",
     },
+    supervisionTypes: ["parole"],
     sections: {
       beforeCorrections: {
         title: "Disparities are already present before incarceration",
@@ -375,13 +376,12 @@ const content: TenantContent = {
       supervision: {
         title: "How can community supervision impact disparities?",
         body: `<p>
-          For individuals on probation (community supervision in lieu of a prison
-          sentence) or on parole, failure can mean revocation: a process that removes
+          For individuals on parole, failure can mean revocation: a process that removes
           people from community supervision and places them in prison.
         </p>
         <p>
           {ethnonymCapitalized} represent {supervision.populationProportion36Mo} of the
-          {supervisionType} population, but were {supervision.revocationProportion36Mo}
+          parole population, but were {supervision.revocationProportion36Mo}
           of revocation admissions to prison in the last 3 years.
         </p>
         <p>
@@ -389,7 +389,7 @@ const content: TenantContent = {
           {supervision.technicalProportion36Mo} of the time for technical violations (a
           rule of supervision, rather than a crime),
           {supervision.absconsionProportion36Mo} of the time for absconsion from
-          {supervisionType}, and {supervision.newCrimeProportion36Mo} of the time for
+          parole, and {supervision.newCrimeProportion36Mo} of the time for
           new crimes. In contrast, overall revocations for technical violations are
           {supervision.overall.technicalProportion36Mo}, revocations for absconsion
           {supervision.overall.absconsionProportion36Mo} and revocations for new crime

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import type { Topology } from "topojson-specification";
+import { SupervisionType } from "../contentModels/RacialDisparitiesNarrative";
 import { AgeValue, GenderValue, RaceOrEthnicityValue } from "../demographics";
 
 export type LocalityLabels = {
@@ -174,4 +175,5 @@ export type RacialDisparitiesNarrativeContent = {
   introduction: string;
   introductionMethodology: string;
   sections: RacialDisparitiesSections;
+  supervisionTypes?: SupervisionType[];
 };

--- a/spotlight-client/src/contentModels/RacialDisparitiesNarrative.test.tsx
+++ b/spotlight-client/src/contentModels/RacialDisparitiesNarrative.test.tsx
@@ -288,3 +288,32 @@ describe("available categories", () => {
     expect(narrative.allCategories).toMatchSnapshot();
   });
 });
+
+describe("supervision types", () => {
+  test("default", async () => {
+    reactImmediately(() => {
+      expect(narrative.supervisionTypeList).toEqual([
+        "supervision",
+        "parole",
+        "probation",
+      ]);
+      expect(narrative.supervisionType).toBe("supervision");
+    });
+  });
+
+  test("limited", () => {
+    narrative = RacialDisparitiesNarrative.build({
+      tenantId: testTenantId,
+      content: {
+        ...contentFixture.racialDisparitiesNarrative,
+        supervisionTypes: ["parole"],
+      },
+      categoryFilter: contentFixture.demographicCategories.raceOrEthnicity,
+    });
+
+    reactImmediately(() => {
+      expect(narrative.supervisionTypeList).toEqual(["parole"]);
+      expect(narrative.supervisionType).toBe("parole");
+    });
+  });
+});

--- a/spotlight-client/src/contentModels/RacialDisparitiesNarrative.ts
+++ b/spotlight-client/src/contentModels/RacialDisparitiesNarrative.ts
@@ -146,7 +146,6 @@ export type TemplateVariables = {
 type ConstructorOpts = {
   tenantId: TenantId;
   defaultCategory?: RaceIdentifier;
-  defaultSupervisionType?: SupervisionType;
   content: RacialDisparitiesNarrativeContent;
   categoryFilter?: DemographicCategoryFilter["raceOrEthnicity"];
 };
@@ -193,6 +192,8 @@ export default class RacialDisparitiesNarrative implements Hydratable {
 
   selectedCategory: RaceIdentifier;
 
+  readonly supervisionTypeList: SupervisionType[];
+
   supervisionType: SupervisionType;
 
   static build(props: ConstructorOpts): RacialDisparitiesNarrative {
@@ -202,13 +203,15 @@ export default class RacialDisparitiesNarrative implements Hydratable {
   constructor({
     tenantId,
     defaultCategory,
-    defaultSupervisionType,
     content,
     categoryFilter,
   }: ConstructorOpts) {
     this.tenantId = tenantId;
     this.selectedCategory = defaultCategory || "BLACK";
-    this.supervisionType = defaultSupervisionType || "supervision";
+    this.supervisionTypeList = [
+      ...(content.supervisionTypes || SupervisionTypeList),
+    ];
+    [this.supervisionType] = this.supervisionTypeList;
     this.chartLabels = content.chartLabels;
     this.introduction = content.introduction;
     this.introductionMethodology = content.introductionMethodology;
@@ -763,9 +766,11 @@ export default class RacialDisparitiesNarrative implements Hydratable {
       sections.push({
         ...supervision,
         chartData: this.revocationsDataSeries,
+        // TODO: only true if there are multiple types available
         supervisionFilter: true,
         download: this.getDownloadFn({
           name: "supervision",
+          // TODO: limit to what's known to be available? or will that happen automatically
           fieldsToInclude: ["parole", "probation", "supervision"],
         }),
       });

--- a/spotlight-client/src/contentModels/RacialDisparitiesNarrative.ts
+++ b/spotlight-client/src/contentModels/RacialDisparitiesNarrative.ts
@@ -85,11 +85,7 @@ type SentencingMetrics = {
   probationPctCurrent: number;
 };
 
-export const SupervisionTypeList = [
-  "supervision",
-  "parole",
-  "probation",
-] as const;
+const SupervisionTypeList = ["supervision", "parole", "probation"] as const;
 export type SupervisionType = typeof SupervisionTypeList[number];
 
 function getSentencingMetrics(
@@ -766,12 +762,10 @@ export default class RacialDisparitiesNarrative implements Hydratable {
       sections.push({
         ...supervision,
         chartData: this.revocationsDataSeries,
-        // TODO: only true if there are multiple types available
-        supervisionFilter: true,
+        supervisionFilter: this.supervisionTypeList.length > 1,
         download: this.getDownloadFn({
           name: "supervision",
-          // TODO: limit to what's known to be available? or will that happen automatically
-          fieldsToInclude: ["parole", "probation", "supervision"],
+          fieldsToInclude: this.supervisionTypeList,
         }),
       });
     }

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -286,6 +286,7 @@ const content: ExhaustiveTenantContent = {
     introduction: `introduction {likelihoodVsWhite.BLACK} {likelihoodVsWhite.HISPANIC}
         {likelihoodVsWhite.AMERICAN_INDIAN_ALASKAN_NATIVE}`,
     introductionMethodology: "introduction methodology",
+    supervisionTypes: ["supervision", "parole", "probation"],
     sections: {
       beforeCorrections: {
         title: "beforeCorrections title",


### PR DESCRIPTION
## Description of the change

Because Pennsylvania will be launching with parole data only, the supervision section of the Racial Disparities narrative needed to support configuration of which supervision types were available. I considered having this be based on inspecting the API data to see which fields were available, but it seemed like it would be less error-prone to explicitly configure it at the tenant level instead. 

In the UI for this section, the configuration is applied to the filter selector as well as the downloadable CSV blob. 

This isn't actually dependent on any changes being made to the calc export for these metrics (at the moment, they are still present and simply ignored) ... it's possible that the backend solution for https://github.com/Recidiviz/recidiviz-data/issues/7203 will require some further frontend accommodations, but we should be able to build that on top of this if necessary. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #414 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
