### PR TITLE
Add PA recidivism sections

### DIFF
--- a/spotlight-client/src/DataStore/TenantStore.test.ts
+++ b/spotlight-client/src/DataStore/TenantStore.test.ts
@@ -193,6 +193,6 @@ test("section number is validated against current narrative", () => {
   });
 
   reactImmediately(() => {
-    expect(tenantStore.currentSectionNumber).toBe(4);
+    expect(tenantStore.currentSectionNumber).toBe(6);
   });
 });

--- a/spotlight-client/src/MetricVizControls/MetricVizControls.tsx
+++ b/spotlight-client/src/MetricVizControls/MetricVizControls.tsx
@@ -18,10 +18,10 @@
 import React from "react";
 import Metric from "../contentModels/Metric";
 import { MetricRecord } from "../contentModels/types";
-import VizControls from "../VizControls";
+import VizControls, { VizControlsProps } from "../VizControls";
 
 type MetricVizControlsProps = {
-  filters: React.ReactElement[];
+  filters: VizControlsProps["filters"];
   metric: Metric<MetricRecord>;
 };
 

--- a/spotlight-client/src/VizControls/VizControls.tsx
+++ b/spotlight-client/src/VizControls/VizControls.tsx
@@ -69,7 +69,7 @@ const MethodologyCopy = styled(CopyBlock)`
 `;
 
 export interface VizControlsProps {
-  filters: (React.ReactElement | null)[];
+  filters: React.ReactNode[];
   download: () => void;
   methodology: string;
 }

--- a/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.tsx
+++ b/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.tsx
@@ -64,10 +64,12 @@ const VizRecidivismRateCumulative: React.FC<VizRecidivismRateCumulativeProps> = 
         <MetricVizControls
           filters={[
             <CohortFilterSelect metric={metric} />,
-            <DemographicFilterSelect
-              disabled={selectedCohorts.length !== 1}
-              metric={metric}
-            />,
+            metric.includesDemographics && (
+              <DemographicFilterSelect
+                disabled={selectedCohorts.length !== 1}
+                metric={metric}
+              />
+            ),
           ]}
           metric={metric}
         />

--- a/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.tsx
+++ b/spotlight-client/src/VizRecidivismRateCumulative/VizRecidivismRateCumulative.tsx
@@ -80,8 +80,13 @@ const VizRecidivismRateCumulative: React.FC<VizRecidivismRateCumulativeProps> = 
                   title="Cumulative Recidivism Rate"
                   xAccessor="followupYears"
                   // we don't want the X axis to get shorter when cohorts are filtered
-                  xExtent={[0, 10]}
+                  xExtent={[0, metric.maxFollowupPeriod]}
                   xLabel="Years since release"
+                  xTicks={
+                    metric.maxFollowupPeriod < 10
+                      ? metric.maxFollowupPeriod
+                      : undefined
+                  }
                   highlighted={
                     highlightedCohort
                       ? { label: `${highlightedCohort}` }

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/FollowupPeriodFilterSelect.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/FollowupPeriodFilterSelect.tsx
@@ -17,11 +17,11 @@
 
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
-import React from "react";
+import React, { useMemo } from "react";
 import RecidivismRateMetric from "../contentModels/RecidivismRateMetric";
 import { Dropdown } from "../UiLibrary";
 
-const options = [
+const OPTIONS = [
   {
     id: "1",
     label: "1 Year",
@@ -50,6 +50,13 @@ const FollowupPeriodFilterSelect: React.FC<FollowupPeriodFilterSelectProps> = ({
       metric.followUpYears = Number(newFilter);
     }
   );
+
+  // 5 year followup is not guaranteed to be supported;
+  // technically none of them are "guaranteed", but 3 years is industry standard,
+  // so in practice maxFollowupPeriod should never be less than that
+  const options = useMemo(() => {
+    return OPTIONS.filter((opt) => Number(opt.id) <= metric.maxFollowupPeriod);
+  }, [metric.maxFollowupPeriod]);
 
   return (
     <Dropdown

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
@@ -30,6 +30,7 @@ import RecidivismRateMetric from "../contentModels/RecidivismRateMetric";
 import DemographicFilterSelect from "../DemographicFilterSelect";
 import MetricVizControls from "../MetricVizControls";
 import { animation } from "../UiLibrary";
+import { formatAsNumber, formatAsPct } from "../utils";
 import VizNotes from "../VizNotes";
 import withMetricHydrator from "../withMetricHydrator";
 import FollowupPeriodFilterSelect from "./FollowupPeriodFilterSelect";
@@ -52,14 +53,22 @@ const getTooltipProps: TooltipContentFunction = (columnData) => {
     summary: { data: CommonDataPoint & { denominator: number } }[];
   };
 
+  const records = [];
+
+  if (Number.isNaN(value)) {
+    records.push({
+      value: `${formatAsPct(pct as number)} of ${formatAsNumber(denominator)}`,
+    });
+  } else {
+    records.push({
+      pct,
+      value: `${value} of ${formatAsNumber(denominator)}`,
+    });
+  }
+
   return {
     title: `${label}`,
-    records: [
-      {
-        pct,
-        value: `${value} of ${denominator}`,
-      },
-    ],
+    records,
   };
 };
 

--- a/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
+++ b/spotlight-client/src/VizRecidivismRateSingleFollowup/VizRecidivismRateSingleFollowup.tsx
@@ -118,7 +118,9 @@ const VizRecidivismRateSingleFollowup: React.FC<VizRecidivismRateSingleFollowupP
             <MetricVizControls
               filters={[
                 <FollowupPeriodFilterSelect metric={metric} />,
-                <DemographicFilterSelect metric={metric} />,
+                metric.includesDemographics && (
+                  <DemographicFilterSelect metric={metric} />
+                ),
               ]}
               metric={metric}
             />

--- a/spotlight-client/src/charts/RateTrend.tsx
+++ b/spotlight-client/src/charts/RateTrend.tsx
@@ -21,7 +21,7 @@ import XYFrame from "semiotic/lib/XYFrame";
 import styled from "styled-components/macro";
 import ChartWrapperBase from "./ChartWrapper";
 import ColorLegend from "./ColorLegend";
-import { formatAsPct } from "../utils";
+import { formatAsNumber, formatAsPct } from "../utils";
 import XHoverController from "./XHoverController";
 import { animation } from "../UiLibrary";
 import { highlightFade } from "./utils";
@@ -143,11 +143,24 @@ export default function RateTrend({
       );
       if (!matchingRecord) return;
 
+      let pct: number | undefined = matchingRecord.rate;
+      let value = `${formatAsNumber(
+        matchingRecord.rateNumerator
+      )} of ${formatAsNumber(matchingRecord.rateDenominator)}`;
+
+      if (Number.isNaN(matchingRecord.rateNumerator)) {
+        value = `${formatAsPct(pct)} of ${formatAsNumber(
+          matchingRecord.rateDenominator
+        )}`;
+
+        pct = undefined;
+      }
+
       records.push({
         color: dataSeries.color,
         label: dataSeries.label,
-        pct: matchingRecord.rate,
-        value: `${matchingRecord.rateNumerator} of ${matchingRecord.rateDenominator}`,
+        pct,
+        value,
       });
     });
 

--- a/spotlight-client/src/charts/RateTrend.tsx
+++ b/spotlight-client/src/charts/RateTrend.tsx
@@ -109,6 +109,7 @@ type RateTrendProps = {
   xAccessor: string;
   xExtent?: XYFrameProps["xExtent"];
   xLabel?: string;
+  xTicks?: number;
 };
 
 /**
@@ -122,6 +123,7 @@ export default function RateTrend({
   xAccessor,
   xExtent,
   xLabel,
+  xTicks = 10,
 }: RateTrendProps): React.ReactElement {
   const [highlighted, setHighlighted] = useState<ItemToHighlight | undefined>();
 
@@ -187,7 +189,7 @@ export default function RateTrend({
                         // @ts-expect-error seems to be a typing error in Semiotic,
                         // this needs to be a string
                         label: xLabel,
-                        ticks: 10,
+                        ticks: xTicks,
                       },
                     ]}
                     baseMarkProps={BASE_MARK_PROPS}

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -183,21 +183,19 @@ const content: TenantContent = {
     PrisonRecidivismRateHistorical: {
       name: "Cumulative Recidivism Rates",
       methodology: `<p>
-        In distributions by age, individuals are counted towards the age group they
-        fall into as of the reporting date. Gender distributions only include male and
-        female due to low numbers of other reported genders. Distributions by race count
-        individuals with more than one reported race or ethnicity towards the racial or
-        ethnic identity that is least represented in the general population.
+        The DOC uses three different measures of recidivism: rearrest, reincarceration,
+        and overall recidivism. This data depicts overall recidivism, which is
+        defined by the DOC as the first instance of any type of rearrest or reincarceration
+        after the individual is released from the DOC.
       </p>`,
     },
     PrisonRecidivismRateSingleFollowupHistorical: {
       name: "Recidivism Rates Over Time",
       methodology: `<p>
-        In distributions by age, individuals are counted towards the age group they
-        fall into as of the reporting date. Gender distributions only include male and
-        female due to low numbers of other reported genders. Distributions by race count
-        individuals with more than one reported race or ethnicity towards the racial or
-        ethnic identity that is least represented in the general population.
+        The DOC uses three different measures of recidivism: rearrest, reincarceration,
+        and overall recidivism. This data depicts overall recidivism, which is
+        defined by the DOC as the first instance of any type of rearrest or reincarceration
+        after the individual is released from the DOC.
       </p>`,
     },
 

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -73,7 +73,8 @@ const content: TenantContent = {
           title: "How many people end up back in prison?",
           body: `<p>
             After release from prison, a significant proportion of formerly incarcerated
-            individuals are charged with additional crimes. This is typically termed “recidivism.”
+            individuals end up back in prison or charged with additional crimes. This is
+            typically termed “recidivism.”
           </p>`,
           metricTypeId: "PrisonRecidivismRateHistorical",
         },

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -69,6 +69,22 @@ const content: TenantContent = {
           </p>`,
           metricTypeId: "PrisonAdmissionReasonsCurrent",
         },
+        {
+          title: "How many people end up back in prison?",
+          body: `<p>
+            After release from prison, a significant proportion of formerly incarcerated
+            individuals are charged with additional crimes. This is typically termed “recidivism.”
+          </p>`,
+          metricTypeId: "PrisonRecidivismRateHistorical",
+        },
+        {
+          title: "How has the recidivism rate changed over time?",
+          body: `<p>
+            We can also observe the recidivism rate over time for a given number of years
+            after original release.
+          </p>`,
+          metricTypeId: "PrisonRecidivismRateSingleFollowupHistorical",
+        },
       ],
     },
     Parole: {
@@ -162,6 +178,26 @@ const content: TenantContent = {
         currently incarcerated in a DOC facility. When an individual is admitted to a
         state prison, the reason for the admission is documented by prison officials.
         These categories are pulled from that documentation.
+      </p>`,
+    },
+    PrisonRecidivismRateHistorical: {
+      name: "Cumulative Recidivism Rates",
+      methodology: `<p>
+        In distributions by age, individuals are counted towards the age group they
+        fall into as of the reporting date. Gender distributions only include male and
+        female due to low numbers of other reported genders. Distributions by race count
+        individuals with more than one reported race or ethnicity towards the racial or
+        ethnic identity that is least represented in the general population.
+      </p>`,
+    },
+    PrisonRecidivismRateSingleFollowupHistorical: {
+      name: "Recidivism Rates Over Time",
+      methodology: `<p>
+        In distributions by age, individuals are counted towards the age group they
+        fall into as of the reporting date. Gender distributions only include male and
+        female due to low numbers of other reported genders. Distributions by race count
+        individuals with more than one reported race or ethnicity towards the racial or
+        ethnic identity that is least represented in the general population.
       </p>`,
     },
 

--- a/spotlight-client/src/contentModels/RecidivismRateMetric.test.ts
+++ b/spotlight-client/src/contentModels/RecidivismRateMetric.test.ts
@@ -265,3 +265,42 @@ test("report unknowns", async (done) => {
     }
   );
 });
+
+test("maxFollowupPeriod", async () => {
+  fetchMock.mockOnce(
+    JSON.stringify({
+      recidivism_rates_by_cohort_by_year: [
+        {
+          state_code: "US_DEMO",
+          gender: "ALL",
+          age_bucket: "ALL",
+          race_or_ethnicity: "ALL",
+          releases: "10",
+          release_cohort: "2018",
+          followup_years: "1",
+          recidivism_rate: "0.2",
+          recidivated_releases: "2",
+        },
+        {
+          state_code: "US_DEMO",
+          gender: "ALL",
+          age_bucket: "ALL",
+          race_or_ethnicity: "ALL",
+          releases: "10",
+          release_cohort: "2018",
+          followup_years: "3",
+          recidivism_rate: "0.3",
+          recidivated_releases: "3",
+        },
+      ],
+    })
+  );
+
+  const metric = await getPopulatedMetric("PrisonRecidivismRateHistorical");
+
+  reactImmediately(() => {
+    expect(metric.maxFollowupPeriod).toBe(3);
+  });
+
+  expect.hasAssertions();
+});

--- a/spotlight-client/src/contentModels/RecidivismRateMetric.test.ts
+++ b/spotlight-client/src/contentModels/RecidivismRateMetric.test.ts
@@ -304,3 +304,54 @@ test("maxFollowupPeriod", async () => {
 
   expect.hasAssertions();
 });
+
+describe("demographic breakdowns", () => {
+  test("enabled", async () => {
+    const metric = await getPopulatedMetric("PrisonRecidivismRateHistorical");
+
+    reactImmediately(() => {
+      expect(metric.includesDemographics).toBe(true);
+    });
+
+    expect.hasAssertions();
+  });
+
+  test("disabled", async () => {
+    fetchMock.mockOnce(
+      JSON.stringify({
+        recidivism_rates_by_cohort_by_year: [
+          {
+            state_code: "US_DEMO",
+            gender: "ALL",
+            age_bucket: "ALL",
+            race_or_ethnicity: "ALL",
+            releases: "10",
+            release_cohort: "2018",
+            followup_years: "1",
+            recidivism_rate: "0.2",
+            recidivated_releases: "2",
+          },
+          {
+            state_code: "US_DEMO",
+            gender: "ALL",
+            age_bucket: "ALL",
+            race_or_ethnicity: "ALL",
+            releases: "10",
+            release_cohort: "2018",
+            followup_years: "3",
+            recidivism_rate: "0.3",
+            recidivated_releases: "3",
+          },
+        ],
+      })
+    );
+
+    const metric = await getPopulatedMetric("PrisonRecidivismRateHistorical");
+
+    reactImmediately(() => {
+      expect(metric.includesDemographics).toBe(false);
+    });
+
+    expect.hasAssertions();
+  });
+});

--- a/spotlight-client/src/contentModels/RecidivismRateMetric.ts
+++ b/spotlight-client/src/contentModels/RecidivismRateMetric.ts
@@ -18,7 +18,10 @@
 import { ascending, groups } from "d3-array";
 import { action, computed, makeObservable, observable } from "mobx";
 import { DataSeries, ItemToHighlight } from "../charts";
-import { recordIsTotalByDimension } from "../demographics";
+import {
+  dataIncludesBreakdowns,
+  recordIsTotalByDimension,
+} from "../demographics";
 import { RateFields, RecidivismRateRecord } from "../metricsApi";
 import { colors } from "../UiLibrary";
 import { countUnknowns } from "./unknowns";
@@ -66,6 +69,7 @@ export default class RecidivismRateMetric extends Metric<RecidivismRateRecord> {
       cohortDataSeries: computed,
       followUpYears: observable,
       highlightedCohort: observable,
+      includesDemographics: computed,
       maxFollowupPeriod: computed,
       selectedCohorts: computed,
       setHighlightedCohort: action,
@@ -252,5 +256,12 @@ export default class RecidivismRateMetric extends Metric<RecidivismRateRecord> {
     if (!allRecords) return 10;
 
     return Math.max(...allRecords.map((record) => record.followupYears));
+  }
+
+  get includesDemographics(): boolean | undefined {
+    const { allRecords } = this;
+    if (!allRecords) return undefined;
+
+    return dataIncludesBreakdowns(allRecords);
   }
 }

--- a/spotlight-client/src/contentModels/RecidivismRateMetric.ts
+++ b/spotlight-client/src/contentModels/RecidivismRateMetric.ts
@@ -66,6 +66,7 @@ export default class RecidivismRateMetric extends Metric<RecidivismRateRecord> {
       cohortDataSeries: computed,
       followUpYears: observable,
       highlightedCohort: observable,
+      maxFollowupPeriod: computed,
       selectedCohorts: computed,
       setHighlightedCohort: action,
       setSelectedCohorts: action,
@@ -241,5 +242,15 @@ export default class RecidivismRateMetric extends Metric<RecidivismRateRecord> {
       .filter((item) => Object.values(item.unknowns).some((val) => val));
 
     return countsByCohort.length ? countsByCohort : undefined;
+  }
+
+  /**
+   * Maximum follow-up period present in data. Defaults to 10 when not hydrated.
+   */
+  get maxFollowupPeriod(): number {
+    const { allRecords } = this;
+    if (!allRecords) return 10;
+
+    return Math.max(...allRecords.map((record) => record.followupYears));
   }
 }

--- a/spotlight-client/src/contentModels/downloadData.ts
+++ b/spotlight-client/src/contentModels/downloadData.ts
@@ -18,11 +18,23 @@
 import { csvFormat } from "d3-dsv";
 import downloadjs from "downloadjs";
 import JsZip from "jszip";
+import mapValues from "lodash/mapValues";
 import { stripHtml } from "string-strip-html";
+
+type Records = Record<string, unknown>[];
+
+function recordsToCsv(data: Records): string {
+  // filter out NaNs before writing to file
+  return csvFormat(
+    data.map((record) =>
+      mapValues(record, (v) => (Number.isNaN(v) ? undefined : v))
+    )
+  );
+}
 
 type DownloadProps = {
   archiveName: string;
-  dataFiles: { name: string; data: Record<string, unknown>[] }[];
+  dataFiles: { name: string; data: Records }[];
   readmeContents: string;
 };
 
@@ -39,7 +51,7 @@ export default function downloadData({
     );
 
     dataFiles.forEach(({ name, data }) => {
-      zip.file(`${archiveName}/${name}.csv`, csvFormat(data));
+      zip.file(`${archiveName}/${name}.csv`, recordsToCsv(data));
     });
 
     zip

--- a/spotlight-client/src/demographics/utils.test.ts
+++ b/spotlight-client/src/demographics/utils.test.ts
@@ -17,7 +17,11 @@
 
 import { DemographicFields } from "../metricsApi";
 import { DemographicView } from "./types";
-import { createDemographicCategories, recordIsTotalByDimension } from "./utils";
+import {
+  createDemographicCategories,
+  dataIncludesBreakdowns,
+  recordIsTotalByDimension,
+} from "./utils";
 
 describe("recordIsTotalByDimension", () => {
   const testData: Array<DemographicFields & { count: number }> = [
@@ -116,4 +120,40 @@ describe("createDemographicCategories", () => {
       { identifier: "OTHER", label: "Other" },
     ]);
   });
+});
+
+test("dataIncludesBreakdowns", () => {
+  expect(
+    dataIncludesBreakdowns([
+      {
+        gender: "ALL",
+        ageBucket: "ALL",
+        raceOrEthnicity: "ALL",
+        count: 10,
+      },
+      {
+        gender: "ALL",
+        ageBucket: "ALL",
+        raceOrEthnicity: "ALL",
+        count: 20,
+      },
+    ])
+  ).toBe(false);
+
+  expect(
+    dataIncludesBreakdowns([
+      {
+        gender: "MALE",
+        ageBucket: "ALL",
+        raceOrEthnicity: "ALL",
+        count: 10,
+      },
+      {
+        gender: "ALL",
+        ageBucket: "ALL",
+        raceOrEthnicity: "ALL",
+        count: 20,
+      },
+    ])
+  ).toBe(true);
 });

--- a/spotlight-client/src/demographics/utils.ts
+++ b/spotlight-client/src/demographics/utils.ts
@@ -152,3 +152,18 @@ export function getDemographicViewLabel(
 ): string {
   return demographicViewLabels[view];
 }
+
+/**
+ * Inspects an array of records to report whether it contains breakdown records
+ * or is made exclusively of total records.
+ */
+export function dataIncludesBreakdowns<RecordFormat extends DemographicFields>(
+  data: RecordFormat[]
+): boolean {
+  return data.some(
+    (record) =>
+      record.ageBucket !== TOTAL_KEY ||
+      record.gender !== TOTAL_KEY ||
+      record.raceOrEthnicity !== TOTAL_KEY
+  );
+}


### PR DESCRIPTION
## Description of the change

Plugs in some generic copy and baseline methodology text for Pennsylvania recidivism data to include those metrics on the prison page. 

(data in this chart is randomly generated in a profile realistic for PA)

<img width="985" alt="Screen Shot 2021-05-17 at 4 49 23 PM" src="https://user-images.githubusercontent.com/5385319/118570699-8524e400-b731-11eb-901c-9b15e8636854.png">

Also accommodates a few differences in the PA data profile, which arose because we will be using a different data source than our normal ingested data, which includes rearrest counts in the overall recidivism rate but is less robust in other ways:

- limits the cumulative followup periods to three years (by determining the max followup period available in data)
- excludes 5 year followup from the bar chart
- excludes all demographic breakdown features (by detecting presence of breakdown records in data), because we don't have that data for PA
- prevents the display of `NaN`s when recidivism counts are missing. This may ultimately get resolved in the calc pipeline (either we get those values from the source or we impute them), but as the current source I was working from did not have them, I thought this was a safe fallback.

This data doesn't exist yet in staging; if you want to run this locally I can share a test file that you can serve locally in demo mode, just contact me directly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #426 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
