### PR TITLE
Change missing data algorithm to disregard current date

### DIFF
--- a/spotlight-client/src/VizHistoricalPopulationBreakdown/VizHistoricalPopulationBreakdown.tsx
+++ b/spotlight-client/src/VizHistoricalPopulationBreakdown/VizHistoricalPopulationBreakdown.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { startOfMonth, sub } from "date-fns";
+import { sub } from "date-fns";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 import { isWindowSizeId, WindowedTimeSeries, WindowSizeId } from "../charts";
@@ -31,10 +31,9 @@ const VizHistoricalPopulationBreakdown: React.FC<{
 }> = ({ metric }) => {
   const [windowSizeId, setWindowSizeId] = useState<WindowSizeId>("20");
 
-  let defaultRangeEnd = startOfMonth(new Date());
-  if (!metric.dataIncludesCurrentMonth) {
-    defaultRangeEnd = sub(defaultRangeEnd, { months: 1 });
-  }
+  if (!metric.latestMonthInData) return null;
+
+  const defaultRangeEnd = metric.latestMonthInData;
 
   let defaultRangeStart: Date | undefined;
   if (windowSizeId !== "custom") {

--- a/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
+++ b/spotlight-client/src/contentModels/HistoricalPopulationBreakdownMetric.test.ts
@@ -16,7 +16,6 @@
 // =============================================================================
 
 import { isEqual } from "date-fns";
-import { advanceTo, clear } from "jest-date-mock";
 import { runInAction, when } from "mobx";
 import {
   createDemographicCategories,
@@ -72,10 +71,6 @@ const mockTransformer = jest.fn();
 
 beforeEach(() => {
   mockedFetchAndTransformMetric.mockResolvedValue([...mockData]);
-});
-
-afterEach(() => {
-  clear();
 });
 
 const getMetric = async () => {
@@ -135,49 +130,15 @@ test("fills in missing data", async () => {
               );
             }
           });
+
+          // records are sorted and span 240 months
+          expect(series[0].date).toEqual(new Date(2000, 10, 1));
+          expect(series[series.length - 1].date).toEqual(new Date(2020, 9, 1));
         });
       }
     });
   });
 
-  expect.hasAssertions();
-});
-
-test("imputed data does not include the current month", async () => {
-  // later than most recent month present in the fixture
-  advanceTo(new Date(2020, 11, 10));
-  const currentMonth = new Date(2020, 11, 1);
-
-  const metric = await getMetric();
-
-  reactImmediately(() => {
-    const currentMonthRecords = metric.records?.filter((record) =>
-      isEqual(record.date, currentMonth)
-    );
-
-    expect(currentMonthRecords?.length).toBe(0);
-
-    expect(metric.dataIncludesCurrentMonth).toBe(false);
-  });
-  expect.hasAssertions();
-});
-
-test("imputed data includes current month", async () => {
-  // most recent month present in the fixture
-  advanceTo(new Date(2020, 9, 10));
-  const currentMonth = new Date(2020, 9, 1);
-
-  const metric = await getMetric();
-
-  reactImmediately(() => {
-    const currentMonthRecords = metric.records?.filter((record) =>
-      isEqual(record.date, currentMonth)
-    );
-
-    expect(currentMonthRecords?.length).toBe(1);
-
-    expect(metric.dataIncludesCurrentMonth).toBe(true);
-  });
   expect.hasAssertions();
 });
 

--- a/spotlight-client/src/contentModels/getMissingMonths.ts
+++ b/spotlight-client/src/contentModels/getMissingMonths.ts
@@ -32,13 +32,13 @@ const monthFromRecord = (record: MonthRecord) =>
  * demographic category for it to work as expected. The demographicFields prop
  * should reflect that category to ensure generated records have the correct shape.
  */
-export default function getMissingMonths({
+function getMissingMonths({
+  end,
   expectedMonths,
-  includeCurrentMonth,
   records,
 }: {
+  end: Date;
   expectedMonths: number;
-  includeCurrentMonth: boolean;
   records: MonthRecord[];
 }): MonthRecord[] {
   // scan the data to see what months we have
@@ -53,14 +53,6 @@ export default function getMissingMonths({
 
   const missingMonths: MonthRecord[] = [];
 
-  let end = new Date();
-  if (!includeCurrentMonth) {
-    // there may be a reporting lag for the current month; if it's missing,
-    // instead of patching it we should just shift the entire window back one month
-    if (isMonthMissing(end)) {
-      end = subMonths(end, 1);
-    }
-  }
   const start = subMonths(end, expectedMonths - 1);
   eachMonthOfInterval({ start, end }).forEach((monthStart) => {
     if (isMonthMissing(monthStart)) {
@@ -73,3 +65,5 @@ export default function getMissingMonths({
 
   return missingMonths;
 }
+
+export default getMissingMonths;


### PR DESCRIPTION
## Description of the change

In order to impute missing records in historical data to zeroes, the frontend needs to make some assumptions about what the intended time window is. This changes that baseline assumption: instead of always assuming historical data will be relative to the current date, it now assumes that the latest date present in the data it receives is the end of the reporting window, and it will only impute values backwards from that point.

This shouldn't change anything on the existing happy path (which accounts for reporting lag of less than one month, in practice expected to only be a few days), but it optimizes for a different edge case. The old approach allowed for an edge case of trailing zeroes at the expense of being able to handle long reporting lags, whereas the new approach flips that tradeoff. Pennsylvania is going to launch with a several-month reporting lag, which would be erroneously reported as several months of zero population or zero parole completions statewide without this change; the opposite edge case, which would entail there actually being a zero statewide prison or supervision population or zero planned completions in an entire state for an entire month, is very unlikely and as far as I know has yet to happen in ND. 

(If it does happen, though, this approach will technically be wrong and may impute spurious zeroes at the beginning of the reporting window ... tagging backend folks on this review to make sure they're aware and that they don't see any potential issues with that.)

This all means that, on its own, this change won't have any effect, but once https://github.com/Recidiviz/recidiviz-data/issues/7709 is released this will accommodate that new reporting window. The advantage of doing it this way (rather than defining more explicit special case handling for PA) is that, once the reporting lag is resolved and PA data comes up to date again, there shouldn't be any additional frontend work required to support that.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #442

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
