### PR TITLE
let prison admission categories be customized

### DIFF
--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -180,6 +180,17 @@ const content: TenantContent = {
         state prison, the reason for the admission is documented by prison officials.
         These categories are pulled from that documentation.
       </p>`,
+      fieldMapping: [
+        {
+          categoryLabel: "New admissions and probation revocations",
+          fieldName: "new_admission_count",
+        },
+        {
+          categoryLabel: "Parole revocations",
+          fieldName: "parole_revocation_count",
+        },
+        { categoryLabel: "Other", fieldName: "other_count" },
+      ],
     },
     PrisonRecidivismRateHistorical: {
       name: "Cumulative Recidivism Rates",

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -18,6 +18,7 @@
 import type { Topology } from "topojson-specification";
 import { SupervisionType } from "../contentModels/RacialDisparitiesNarrative";
 import { AgeValue, GenderValue, RaceOrEthnicityValue } from "../demographics";
+import { CategoryFieldMapping } from "../metricsApi";
 
 export type LocalityLabels = {
   label: string;
@@ -52,6 +53,12 @@ export type TenantContent = {
       | "ParolePopulationCurrent"
     >]?: MetricContent & { totalLabel: string };
   } &
+    {
+      [key in Extract<
+        MetricTypeId,
+        "PrisonAdmissionReasonsCurrent"
+      >]?: MetricContent & { fieldMapping?: CategoryFieldMapping[] };
+    } &
     { [key in MetricTypeId]?: MetricContent };
   systemNarratives: {
     [key in SystemNarrativeTypeId]?: SystemNarrativeContent;

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -67,6 +67,18 @@ const content: ExhaustiveTenantContent = {
     PrisonAdmissionReasonsCurrent: {
       name: "test PrisonAdmissionReasonsCurrent name",
       methodology: "test PrisonAdmissionReasonsCurrent methodology",
+      fieldMapping: [
+        { categoryLabel: "New admissions", fieldName: "new_admission_count" },
+        {
+          categoryLabel: "Parole revocations",
+          fieldName: "parole_revocation_count",
+        },
+        {
+          categoryLabel: "Probation revocations",
+          fieldName: "probation_revocation_count",
+        },
+        { categoryLabel: "Other", fieldName: "other_count" },
+      ],
     },
     PrisonStayLengthAggregate: {
       name: "test PrisonStayLengthAggregate name",

--- a/spotlight-client/src/contentModels/createMetricMapping.ts
+++ b/spotlight-client/src/contentModels/createMetricMapping.ts
@@ -35,6 +35,7 @@ import {
   probationRevocationReasons,
   probationSuccessRateDemographics,
   probationSuccessRateMonthly,
+  RawMetricData,
   recidivismRateAllFollowup,
   recidivismRateConventionalFollowup,
   sentencePopulationCurrent,
@@ -381,7 +382,14 @@ export default function createMetricMapping({
             defaultDemographicView: "total",
             defaultLocalityId: undefined,
             localityLabels: undefined,
-            dataTransformer: prisonAdmissionReasons,
+            dataTransformer: (rawRecords: RawMetricData) => {
+              let fieldMapping;
+
+              if ("fieldMapping" in metadata) {
+                fieldMapping = metadata.fieldMapping;
+              }
+              return prisonAdmissionReasons(rawRecords, fieldMapping);
+            },
             sourceFileName: "incarceration_population_by_admission_reason",
           })
         );

--- a/spotlight-client/src/metricsApi/DemographicsByCategoryRecord.ts
+++ b/spotlight-client/src/metricsApi/DemographicsByCategoryRecord.ts
@@ -29,9 +29,12 @@ export type DemographicsByCategoryRecord = DemographicFields & {
   count: number;
 };
 
-function getCategoryTransposeFunction(
-  fields: { fieldName: string; categoryLabel: string }[]
-) {
+export type CategoryFieldMapping = {
+  fieldName: string;
+  categoryLabel: string;
+};
+
+function getCategoryTransposeFunction(fields: CategoryFieldMapping[]) {
   return (records: RawMetricData) => {
     // these come in as wide records that we need to transpose to long
     const recordsByCategory = records.map((record) => {
@@ -48,7 +51,7 @@ function getCategoryTransposeFunction(
   };
 }
 
-const revocationReasonFields = [
+const revocationReasonFields: CategoryFieldMapping[] = [
   {
     categoryLabel: REVOCATION_TYPE_LABELS.ABSCOND,
     fieldName: "absconsion_count",
@@ -80,7 +83,7 @@ export function paroleRevocationReasons(
   );
 }
 
-const prisonAdmissionFields = [
+const defaultPrisonAdmissionFields: CategoryFieldMapping[] = [
   { categoryLabel: "New admissions", fieldName: "new_admission_count" },
   { categoryLabel: "Parole revocations", fieldName: "parole_revocation_count" },
   {
@@ -91,12 +94,13 @@ const prisonAdmissionFields = [
 ];
 
 export function prisonAdmissionReasons(
-  rawRecords: RawMetricData
+  rawRecords: RawMetricData,
+  fieldMapping = defaultPrisonAdmissionFields
 ): DemographicsByCategoryRecord[] {
-  return getCategoryTransposeFunction(prisonAdmissionFields)(rawRecords);
+  return getCategoryTransposeFunction(fieldMapping)(rawRecords);
 }
 
-const prisonReleaseFields = [
+const prisonReleaseFields: CategoryFieldMapping[] = [
   {
     categoryLabel: "Transfer out of system",
     fieldName: "external_transfer_count",
@@ -116,7 +120,7 @@ export function prisonReleaseTypes(
   return getCategoryTransposeFunction(prisonReleaseFields)(rawRecords);
 }
 
-export const prisonStayLengthFields = [
+export const prisonStayLengthFields: CategoryFieldMapping[] = [
   { categoryLabel: "<1 year", fieldName: "years_0_1" },
   { categoryLabel: "1–2", fieldName: "years_1_2" },
   { categoryLabel: "2–3", fieldName: "years_2_3" },


### PR DESCRIPTION
## Description of the change

Allows for per-tenant overrides of the fields and labels used to represent prison admission categories. The immediate use is to exclude one field and rename another for PA (they don't reliably break out probation revocations in their admission data). North Dakota remains on the default list and its behavior should be unchanged. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #427 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
