### PR TITLE
configure feedback URL per tenant

### DIFF
--- a/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
+++ b/spotlight-client/src/SiteNavigation/SiteNavigation.tsx
@@ -32,7 +32,6 @@ import {
   NavGroupItem,
   NavLink,
   ExternalNavLink,
-  FEEDBACK_URL,
   NavButton,
   ShareButtonProps,
 } from "./shared";
@@ -121,9 +120,13 @@ const SiteNavigation: React.FC<ShareButtonProps> = ({ openShareModal }) => {
               />
             </NavGroupItem>
           )}
-          <NavGroupItem>
-            <ExternalNavLink href={FEEDBACK_URL}>Feedback</ExternalNavLink>
-          </NavGroupItem>
+          {tenant && (
+            <NavGroupItem>
+              <ExternalNavLink href={tenant.feedbackUrl}>
+                Feedback
+              </ExternalNavLink>
+            </NavGroupItem>
+          )}
           <NavGroupItem>
             <NavButton onClick={openShareModal}>Share</NavButton>
           </NavGroupItem>

--- a/spotlight-client/src/SiteNavigation/SiteNavigationMobile.tsx
+++ b/spotlight-client/src/SiteNavigation/SiteNavigationMobile.tsx
@@ -34,7 +34,6 @@ import {
   NavGroup,
   NavGroupItem as NavGroupItemBase,
   NavLink as NavLinkBase,
-  FEEDBACK_URL,
   ExternalNavLink as ExternalNavLinkBase,
   NavButton as ExternalNavButton,
   ShareButtonProps,
@@ -203,9 +202,13 @@ const SiteNavigation: React.FC<ShareButtonProps> = ({ openShareModal }) => {
                   </NavLink>
                 </NavMenuItem>
               )}
-              <NavMenuItem>
-                <ExternalNavLink href={FEEDBACK_URL}>Feedback</ExternalNavLink>
-              </NavMenuItem>
+              {tenant && (
+                <NavMenuItem>
+                  <ExternalNavLink href={tenant.feedbackUrl}>
+                    Feedback
+                  </ExternalNavLink>
+                </NavMenuItem>
+              )}
               <NavMenuItem>
                 <NavButton
                   onClick={() => {

--- a/spotlight-client/src/SiteNavigation/shared.tsx
+++ b/spotlight-client/src/SiteNavigation/shared.tsx
@@ -81,9 +81,6 @@ export const NavButton = styled(UnStyledButton)`
   ${linkStyles}
 `;
 
-export const FEEDBACK_URL =
-  "https://docs.google.com/forms/d/e/1FAIpQLSc3_wV2ltGumMdGTcLehUM41tQri0ZW5RjIKh0JJlhpJGE9Hg/viewform";
-
 export type ShareButtonProps = {
   openShareModal: () => void;
 };

--- a/spotlight-client/src/SystemNarrativePage/__fixtures__/contentSource.ts
+++ b/spotlight-client/src/SystemNarrativePage/__fixtures__/contentSource.ts
@@ -21,6 +21,7 @@ const content: TenantContent = {
   name: "Test Tenant",
   description: "test tenant description",
   coBrandingCopy: "test tenant co-branding",
+  feedbackUrl: "https://example.com/feedback",
   metrics: {
     SentencePopulationCurrent: {
       name: "test SentencePopulationCurrent name",

--- a/spotlight-client/src/contentApi/sources/us_nd.ts
+++ b/spotlight-client/src/contentApi/sources/us_nd.ts
@@ -86,6 +86,8 @@ const content: TenantContent = {
     '<a href="https://www.docr.nd.gov">The North Dakota Department of Corrections and Rehabilitation (DOCR)</a> provides correctional services for the state of North Dakota. Our mission is to transform lives, influence change, and strengthen community. Transparency is a critical element of our mission; sharing information builds greater accountability between the DOCR and the communities we serve.',
   coBrandingCopy:
     'Produced in collaboration with <a href="https://www.docr.nd.gov">the North Dakota Department of Corrections and Rehabilitation</a>.',
+  feedbackUrl:
+    "https://docs.google.com/forms/d/e/1FAIpQLSc3_wV2ltGumMdGTcLehUM41tQri0ZW5RjIKh0JJlhpJGE9Hg/viewform",
   demographicCategories: {
     raceOrEthnicity: [
       "AMERICAN_INDIAN_ALASKAN_NATIVE",

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -22,6 +22,7 @@ const content: TenantContent = {
   description: "",
   coBrandingCopy:
     'Produced in collaboration with <a href="https://www.cor.pa.gov">the Pennsylvania Department of Corrections</a>.',
+  feedbackUrl: "https://forms.gle/7bZMpgGR69uaW1eNA",
   demographicCategories: {
     raceOrEthnicity: [
       "BLACK",

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -43,6 +43,7 @@ export type TenantContent = {
   name: string;
   description: string;
   coBrandingCopy: string;
+  feedbackUrl: string;
   metrics: {
     [key in Extract<
       MetricTypeId,

--- a/spotlight-client/src/contentModels/Tenant.test.ts
+++ b/spotlight-client/src/contentModels/Tenant.test.ts
@@ -38,6 +38,8 @@ test.each([
   const tenant = createTenant({ tenantId: "US_ND" });
   expect(tenant.name).toBe(fixture.name);
   expect(tenant.description).toBe(fixture.description);
+  expect(tenant.coBrandingCopy).toBe(fixture.coBrandingCopy);
+  expect(tenant.feedbackUrl).toBe(fixture.feedbackUrl);
 });
 
 test.each([

--- a/spotlight-client/src/contentModels/Tenant.ts
+++ b/spotlight-client/src/contentModels/Tenant.ts
@@ -27,6 +27,7 @@ type InitOptions = {
   name: string;
   description: string;
   coBrandingCopy: string;
+  feedbackUrl: string;
   metrics: MetricMapping;
   systemNarratives: SystemNarrativeMapping;
   racialDisparitiesNarrative?: RacialDisparitiesNarrative;
@@ -48,6 +49,8 @@ export default class Tenant {
 
   readonly coBrandingCopy: string;
 
+  readonly feedbackUrl: string;
+
   readonly metrics: InitOptions["metrics"];
 
   readonly systemNarratives: SystemNarrativeMapping;
@@ -59,6 +62,7 @@ export default class Tenant {
     name,
     description,
     coBrandingCopy,
+    feedbackUrl,
     metrics,
     systemNarratives,
     racialDisparitiesNarrative,
@@ -67,6 +71,7 @@ export default class Tenant {
     this.name = name;
     this.description = description;
     this.coBrandingCopy = coBrandingCopy;
+    this.feedbackUrl = feedbackUrl;
     this.metrics = metrics;
     this.systemNarratives = systemNarratives;
     this.racialDisparitiesNarrative = racialDisparitiesNarrative;
@@ -131,6 +136,7 @@ export function createTenant({ tenantId }: TenantFactoryOptions): Tenant {
     name: allTenantContent.name,
     description: allTenantContent.description,
     coBrandingCopy: allTenantContent.coBrandingCopy,
+    feedbackUrl: allTenantContent.feedbackUrl,
     metrics,
     systemNarratives: getSystemNarrativesForTenant({
       allTenantContent,

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -33,6 +33,7 @@ const content: ExhaustiveTenantContent = {
   name: "Test Tenant",
   description: "test tenant description",
   coBrandingCopy: "test tenant co-branding",
+  feedbackUrl: "https://example.com/feedback",
   // tests are based on ND data which has this demo profile
   demographicCategories: {
     raceOrEthnicity: [

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_partial.ts
@@ -21,6 +21,7 @@ const content: TenantContent = {
   name: "Test Tenant",
   description: "test tenant description",
   coBrandingCopy: "test tenant co-branding",
+  feedbackUrl: "https://example.com/feedback",
   // this is an intentionally non-exhaustive set of metrics
   metrics: {
     SentencePopulationCurrent: {


### PR DESCRIPTION
## Description of the change

Changes the URL for the feedback link (which appears in top navigation) from a constant to a unique URL configured per tenant. Also means we hide the link when there is no active tenant (has no practical effect in prod but you'll see it in dev or staging)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #397 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
