### PR TITLE
Add parole terminations metric for PA

### DIFF
--- a/spotlight-api/core/metricsApi.js
+++ b/spotlight-api/core/metricsApi.js
@@ -62,6 +62,8 @@ const ALL_METRIC_FILES = [
   "supervision_revocations_by_period_by_type_by_demographics.json",
   "supervision_success_by_month.json",
   "supervision_success_by_period_by_demographics.json",
+  "supervision_terminations_by_month.json",
+  "supervision_terminations_by_period_by_demographics.json",
 ];
 
 /**

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -138,7 +138,7 @@ const content: TenantContent = {
             addressing critical needs of justice-involved individuals, including employment,
             housing, and need-based care.
           </p>`,
-          metricTypeId: "ParoleSuccessHistorical",
+          metricTypeId: "ParoleTerminationsHistorical",
         },
         {
           title: "Why do revocations happen?",
@@ -281,8 +281,8 @@ const content: TenantContent = {
         prison may occasionally serve their parole in a different state.
       </p>`,
     },
-    ParoleSuccessHistorical: {
-      name: "Historical Parole Completion Rates",
+    ParoleTerminationsHistorical: {
+      name: "Historical Parole Successful Termination Rates",
       methodology: `<p>
         This data reports the percentage of people projected to complete parole in a
         given month who have successfully completed parole by the end of that month.

--- a/spotlight-client/src/contentApi/types.ts
+++ b/spotlight-client/src/contentApi/types.ts
@@ -104,6 +104,7 @@ export const MetricTypeIdList = [
   "ParolePopulationCurrent",
   "ParolePopulationHistorical",
   "ParoleSuccessHistorical",
+  "ParoleTerminationsHistorical",
   "ParoleRevocationsAggregate",
   "ParoleProgrammingCurrent",
 ] as const;

--- a/spotlight-client/src/contentModels/Metric.test.ts
+++ b/spotlight-client/src/contentModels/Metric.test.ts
@@ -88,7 +88,11 @@ describe("data fetching", () => {
     MetricTypeIdList.filter(
       (id) =>
         // the `records` property is not supported for these metric types
-        !["ProbationSuccessHistorical", "ParoleSuccessHistorical"].includes(id)
+        ![
+          "ProbationSuccessHistorical",
+          "ParoleSuccessHistorical",
+          "ParoleTerminationsHistorical",
+        ].includes(id)
     )
   )("for metric %s", (metricId, done) => {
     expect.hasAssertions();
@@ -198,7 +202,11 @@ describe("data download", () => {
       (id) =>
         // these metric types have multiple data sources, so the files they download will be different;
         // see SupervisionSuccessRateMetric tests for coverage
-        !["ProbationSuccessHistorical", "ParoleSuccessHistorical"].includes(id)
+        ![
+          "ProbationSuccessHistorical",
+          "ParoleSuccessHistorical",
+          "ParoleTerminationsHistorical",
+        ].includes(id)
     )
   )("for metric %s", async (metricId, done) => {
     const metric = getTestMetric(metricId);

--- a/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
+++ b/spotlight-client/src/contentModels/__fixtures__/tenant_content_exhaustive.ts
@@ -137,6 +137,10 @@ const content: ExhaustiveTenantContent = {
       name: "test ParoleSuccessHistorical name",
       methodology: "test ParoleSuccessHistorical methodology",
     },
+    ParoleTerminationsHistorical: {
+      name: "test ParoleTerminationsHistorical name",
+      methodology: "test ParoleTerminationsHistorical methodology",
+    },
     ParoleRevocationsAggregate: {
       name: "test ParoleRevocationsAggregate name",
       methodology: "test ParoleRevocationsAggregate methodology",

--- a/spotlight-client/src/contentModels/createMetricMapping.ts
+++ b/spotlight-client/src/contentModels/createMetricMapping.ts
@@ -24,6 +24,8 @@ import {
   paroleRevocationReasons,
   paroleSuccessRateDemographics,
   paroleSuccessRateMonthly,
+  paroleTerminationRateDemographics,
+  paroleTerminationRateMonthly,
   prisonAdmissionReasons,
   prisonPopulationCurrent,
   prisonPopulationHistorical,
@@ -356,6 +358,28 @@ export default function createMetricMapping({
             demographicDataTransformer: paroleSuccessRateDemographics,
             demographicSourceFileName:
               "supervision_success_by_period_by_demographics",
+          })
+        );
+        break;
+      case "ParoleTerminationsHistorical":
+        if (!localityLabelMapping?.Parole)
+          throw new Error(localityContentError);
+
+        metricMapping.set(
+          metricType,
+          new SupervisionSuccessRateMetric({
+            ...metadata,
+            demographicFilter,
+            id: metricType,
+            tenantId,
+            defaultDemographicView: "total",
+            defaultLocalityId: TOTAL_KEY,
+            localityLabels: localityLabelMapping.Parole,
+            dataTransformer: paroleTerminationRateMonthly,
+            sourceFileName: "supervision_terminations_by_month",
+            demographicDataTransformer: paroleTerminationRateDemographics,
+            demographicSourceFileName:
+              "supervision_terminations_by_period_by_demographics",
           })
         );
         break;

--- a/spotlight-client/src/metricsApi/SupervisionSuccessRateDemographicsRecord.ts
+++ b/spotlight-client/src/metricsApi/SupervisionSuccessRateDemographicsRecord.ts
@@ -40,6 +40,18 @@ function createSupervisionSuccessRateDemographicRecord(
   };
 }
 
+function createSupervisionTerminationRateDemographicRecord(
+  record: ValuesType<RawMetricData>
+) {
+  return {
+    rate: Number(record.success_rate),
+    rateDenominator: Number(record.termination_count),
+    rateNumerator: Number(record.successful_termination_count),
+    locality: record.district,
+    ...extractDemographicFields(record),
+  };
+}
+
 export function probationSuccessRateDemographics(
   rawRecords: RawMetricData
 ): SupervisionSuccessRateDemographicsRecord[] {
@@ -54,4 +66,12 @@ export function paroleSuccessRateDemographics(
   return rawRecords
     .filter(recordIsParole)
     .map(createSupervisionSuccessRateDemographicRecord);
+}
+
+export function paroleTerminationRateDemographics(
+  rawRecords: RawMetricData
+): SupervisionSuccessRateDemographicsRecord[] {
+  return rawRecords
+    .filter(recordIsParole)
+    .map(createSupervisionTerminationRateDemographicRecord);
 }

--- a/spotlight-client/src/metricsApi/SupervisionSuccessRateMonthlyRecord.ts
+++ b/spotlight-client/src/metricsApi/SupervisionSuccessRateMonthlyRecord.ts
@@ -53,6 +53,23 @@ function createSupervisionSuccessRateMonthlyRecord(
   };
 }
 
+function createSupervisionTerminationRateMonthlyRecord(
+  record: ValuesType<RawMetricData>
+) {
+  const year = Number(record.year);
+  const month = Number(record.month);
+
+  return {
+    locality: record.district,
+    year,
+    month,
+    label: getCohortLabel({ year, month }),
+    rateNumerator: Number(record.successful_termination_count),
+    rateDenominator: Number(record.termination_count),
+    rate: Number(record.success_rate),
+  };
+}
+
 export function probationSuccessRateMonthly(
   rawRecords: RawMetricData
 ): SupervisionSuccessRateMonthlyRecord[] {
@@ -67,4 +84,12 @@ export function paroleSuccessRateMonthly(
   return rawRecords
     .filter(recordIsParole)
     .map(createSupervisionSuccessRateMonthlyRecord);
+}
+
+export function paroleTerminationRateMonthly(
+  rawRecords: RawMetricData
+): SupervisionSuccessRateMonthlyRecord[] {
+  return rawRecords
+    .filter(recordIsParole)
+    .map(createSupervisionTerminationRateMonthlyRecord);
 }


### PR DESCRIPTION
## Description of the change

This replaces the original parole success metric with the new "successful parole terminations" variation for Pennsylvania (necessary for data availability reasons, as seen in https://github.com/Recidiviz/recidiviz-data/pull/8155). Mostly this change is boilerplate and the new metric is a drop-in replacement, though it does require its own data transformation functions to handle the slightly different API response. 

(Files are in staging, you can run the backend from this branch to test locally)

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

> Closes #452 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
