### PR TITLE
ensure mobx is configured before stores are instantiated

### DIFF
--- a/spotlight-client/src/DataStore/RootStore.ts
+++ b/spotlight-client/src/DataStore/RootStore.ts
@@ -16,10 +16,19 @@
 // =============================================================================
 
 import { Auth0ClientOptions } from "@auth0/auth0-spa-js";
-import { computed, makeObservable } from "mobx";
+import { computed, configure, makeObservable } from "mobx";
 import TenantStore from "./TenantStore";
 import UiStore from "./UiStore";
 import UserStore from "./UserStore";
+
+configure({
+  // make proxies optional for IE 11 support
+  useProxies: "ifavailable",
+  // activate runtime linting
+  computedRequiresReaction: true,
+  reactionRequiresObservable: true,
+  observableRequiresReaction: true,
+});
 
 /**
  * Returns the auth settings configured for the current environment, if any.

--- a/spotlight-client/src/index.tsx
+++ b/spotlight-client/src/index.tsx
@@ -19,7 +19,6 @@ import "react-app-polyfill/ie11";
 import "react-app-polyfill/stable";
 import "intersection-observer";
 
-import { configure } from "mobx";
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactModal from "react-modal";
@@ -27,15 +26,6 @@ import smoothScroll from "smoothscroll-polyfill";
 import App from "./App";
 
 smoothScroll.polyfill();
-
-configure({
-  // make proxies optional for IE 11 support
-  useProxies: "ifavailable",
-  // activate runtime linting
-  computedRequiresReaction: true,
-  reactionRequiresObservable: true,
-  observableRequiresReaction: true,
-});
 
 ReactDOM.render(<App />, document.getElementById("root"), () => {
   ReactModal.setAppElement("#root");


### PR DESCRIPTION
## Description of the change

Moves the MobX configuration call into the RootStore module to ensure it is run before we instantiate stores. Because Proxies are enabled by default (and IE 11 does not support Proxies), this [makes sure we disable proxies before any observables are created by Mobx](https://github.com/mobxjs/mobx/discussions/2607). 

This was causing the ND site to fail in production in IE 11 because some observable data is created by the store constructors — but only when a custom tenant domain is detected. This would cause an error because the `RootStore` is instantiated in the body of a module that would run when imported by `/src/index.tsx`, before calling `configure` in the body of the index module. (Tricky — I was ultimately able to repro this locally by hacking the `getTenantFromDomain` function to always return a tenant ID, and to verify the fix by the same means.) 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Closes #454

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
