### PR TITLE
Fix formatting of racial disparities text

### DIFF
--- a/spotlight-client/package.json
+++ b/spotlight-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spotlight-client",
   "description": "A public-facing dashboard to help educate citizens and build accountability",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "repository": "git@github.com:Recidiviz/public-dashboard.git",
   "author": "Recidiviz <team@recidiviz.org>",

--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -551,16 +551,21 @@ const content: TenantContent = {
       conclusion: {
         title:
           "What are we doing to further improve disparities in criminal justice in Pennsylvania?",
-        body: `<p>
+        body: `<div>
           The Pennsylvania Department of Corrections has supported a
           series of legislative initiatives that help create a more equitable
           justice system in the commonwealth. Under Governor Wolf’s leadership,
           Pennsylvania has enacted a new Clean Slate law, fought against the
           reinstatement of mandatory minimum sentences, and implemented two
-          Justice Reinvestment initiatives (2012, 2016). The Black proportion of the
+          Justice Reinvestment initiatives (<a
+          href="https://www.pccd.pa.gov/Pages/JRI%20Subpages/JRI-in-Pennsylvania-(2011-2012).aspx">2012</a>,
+          <a
+          href="https://www.pccd.pa.gov/Pages/JRI%20Subpages/Current-JRI-in-Pennsylvania-(2016).aspx">2016</a>).
+          The Black proportion of the
           incarcerated population in Pennsylvania is at its lowest point since
           2010 partially due to these efforts.
-        </p>`,
+        </div>
+        <div></div>`,
         // empty because there is no chart or data in this section
         methodology: "",
       },


### PR DESCRIPTION
## Description of the change

I somehow missed the first time that this automatically splits across two columns, so it currently looks like this:

<img width="1792" alt="Screen Shot 2021-07-21 at 5 27 25 PM" src="https://user-images.githubusercontent.com/3762913/126562601-26a05f66-25dc-45b0-8f55-61381d076b5f.png">

this now forces it to the first column:

<img width="1792" alt="Screen Shot 2021-07-21 at 5 28 12 PM" src="https://user-images.githubusercontent.com/3762913/126562511-c53ddffd-549c-4239-8f14-38c20ed1abdc.png">

for the small screens:

<img width="378" alt="Screen Shot 2021-07-21 at 5 28 54 PM" src="https://user-images.githubusercontent.com/3762913/126562575-04190c8d-cb9e-45e4-b134-7bf31fc887bd.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues


## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
