### PR TITLE
prevent dropdowns from flowing off the screen

### DIFF
--- a/spotlight-client/src/UiLibrary/Dropdown/InPlaceMenu.tsx
+++ b/spotlight-client/src/UiLibrary/Dropdown/InPlaceMenu.tsx
@@ -36,6 +36,7 @@ const InPlaceOptionList = styled.ul`
   border: 1px solid ${colors.rule};
   border-radius: ${rem(BUTTON_HEIGHT / 4)};
   font-size: ${rem(13)};
+  max-height: 70vh;
   white-space: nowrap;
 
   &:focus {
@@ -54,14 +55,22 @@ const InPlaceMenu = ({
   waitForCloseAnimation,
 }: MenuProps): React.ReactElement => {
   const [menuHeight, setMenuHeight] = useState(0);
+  const [listOverflow, setListOverflow] = useState("visible");
 
   const showMenuItems = isOpen || waitForCloseAnimation;
-  const menuStyles = useSpring({
+  const wrapperStyles = useSpring({
     from: { height: 0 },
     height: isOpen ? menuHeight : 0,
     config: { clamp: true, friction: 20, tension: 210 },
     onRest: (props) => {
-      if (props.height === 0) setWaitForCloseAnimation(false);
+      if (props.height === 0) {
+        setWaitForCloseAnimation(false);
+        setListOverflow("visible");
+      } else {
+        // updated at the end of the animation because it will
+        // interfere with menu expansion if it's already set
+        setListOverflow("auto");
+      }
     },
   });
 
@@ -75,8 +84,11 @@ const InPlaceMenu = ({
       }}
     >
       {({ measureRef }) => (
-        <InPlaceMenuWrapper style={menuStyles}>
-          <InPlaceOptionList {...getMenuProps({ ref: measureRef })}>
+        <InPlaceMenuWrapper style={wrapperStyles}>
+          <InPlaceOptionList
+            {...getMenuProps({ ref: measureRef })}
+            style={{ overflow: listOverflow }}
+          >
             {showMenuItems &&
               options.map((option, index) =>
                 renderOption({


### PR DESCRIPTION
## Description of the change

Long dropdowns may compete with scroll-snapping behavior and make certain options difficult to access. This makes sure menus stay within the viewport and scroll their overflowing items if necessary. 

![dropdown scroll](https://user-images.githubusercontent.com/5385319/127378821-f9c91cd4-3af5-4370-bf2c-3fd3fa1feeae.gif)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Closes #463 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
