### PR TITLE
Add racial disparities to homepage chart previews

### DIFF
--- a/spotlight-client/src/App.test.tsx
+++ b/spotlight-client/src/App.test.tsx
@@ -128,7 +128,7 @@ describe("navigation", () => {
     const homeLink = inNav.getByRole("link", { name: "Spotlight" });
     const tenantLink = inNav.getByRole("link", { name: "North Dakota" });
     const sentencingLink = await screen.findByRole("link", {
-      name: "Sentencing Data",
+      name: "Racial Disparities Data",
     });
 
     fireEvent.click(sentencingLink);
@@ -136,7 +136,7 @@ describe("navigation", () => {
     // so we are using *ByTestId queries here instead
     await waitFor(async () =>
       expect(await screen.findByTestId("PageTitle")).toHaveTextContent(
-        "Sentencing"
+        "Racial Disparities"
       )
     );
 
@@ -145,9 +145,7 @@ describe("navigation", () => {
       expect(await screen.findByTestId("PageTitle")).toHaveTextContent("DOCR")
     );
 
-    expect(
-      screen.queryByText("Racial Disparities Data")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Sentencing Data")).not.toBeInTheDocument();
 
     fireEvent.click(homeLink);
     await waitFor(async () =>

--- a/spotlight-client/src/OtherNarrativeLinksPreview/OtherNarrativeLinksPreview.tsx
+++ b/spotlight-client/src/OtherNarrativeLinksPreview/OtherNarrativeLinksPreview.tsx
@@ -211,8 +211,6 @@ const OtherNarrativeLinksPreview = (): React.ReactElement | null => {
     <Wrapper>
       <LinkList>
         {narrativesToDisplay.map((narrative) => {
-          if (!narrative) return null;
-
           return (
             <NarrativeLink
               key={narrative.id}

--- a/spotlight-client/src/RacialDisparitiesNarrativePage/BarChartPair.tsx
+++ b/spotlight-client/src/RacialDisparitiesNarrativePage/BarChartPair.tsx
@@ -28,6 +28,8 @@ const CHART_HEIGHT = 165;
 
 const CHART_HEIGHT_MOBILE = 100;
 
+const CHART_HEIGHT_PREVIEW = 135;
+
 const Wrapper = styled.div`
   padding: ${rem(48)} 0;
 `;
@@ -38,9 +40,10 @@ const Spacer = styled.div`
 
 type BarChartPairProps = {
   data: DemographicCategoryRecords[];
-  download: () => void;
-  filters: VizControlsProps["filters"];
-  methodology: string;
+  download?: () => void;
+  filters?: VizControlsProps["filters"];
+  methodology?: string;
+  preview?: boolean;
 };
 
 export default function BarChartPair({
@@ -48,23 +51,30 @@ export default function BarChartPair({
   download,
   filters,
   methodology,
+  preview,
 }: BarChartPairProps): React.ReactElement {
   const [highlightedCategory, setHighlightedCategory] = useState<
     ItemToHighlight | undefined
   >();
 
-  const chartHeight = useBreakpoint(CHART_HEIGHT, [
+  let chartHeight = useBreakpoint(CHART_HEIGHT, [
     "mobile-",
     CHART_HEIGHT_MOBILE,
   ]);
 
+  if (preview) {
+    chartHeight = CHART_HEIGHT_PREVIEW;
+  }
+
   return (
     <Wrapper>
-      <VizControls
-        filters={filters}
-        methodology={methodology}
-        download={download}
-      />
+      {filters && methodology && download && (
+        <VizControls
+          filters={filters}
+          methodology={methodology}
+          download={download}
+        />
+      )}
       <ProportionalBar
         data={data[0].records}
         title={data[0].label}
@@ -80,7 +90,7 @@ export default function BarChartPair({
         highlighted={highlightedCategory}
         setHighlighted={setHighlightedCategory}
       />
-      <VizNotes smallData />
+      {!preview && <VizNotes smallData />}
     </Wrapper>
   );
 }

--- a/spotlight-client/src/VizDemographicsByCategory/VizDemographicsByCategory.tsx
+++ b/spotlight-client/src/VizDemographicsByCategory/VizDemographicsByCategory.tsx
@@ -82,7 +82,6 @@ const VizDemographicsByCategory: React.FC<VizDemographicsByCategoryProps> = ({
                     <BubbleChart
                       height={bubbleChartHeight}
                       data={item.dataSeries[0].records}
-                      preview={preview}
                     />
                   ) : (
                     item.dataSeries.map(

--- a/spotlight-client/src/charts/BubbleChart.tsx
+++ b/spotlight-client/src/charts/BubbleChart.tsx
@@ -72,13 +72,11 @@ const LegendWrapper = styled.div`
 type BubbleChartProps = {
   data: CategoricalChartRecord[];
   height: number;
-  preview?: boolean;
 };
 
 export default function BubbleChart({
   data,
   height,
-  preview,
 }: BubbleChartProps): React.ReactElement {
   const { highlighted, setHighlighted } = useHighlightedItem();
 

--- a/spotlight-client/src/contentModels/SystemNarrative.ts
+++ b/spotlight-client/src/contentModels/SystemNarrative.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import {
+  MetricTypeId,
   SystemNarrativeContent,
   SystemNarrativeTypeId,
 } from "../contentApi/types";
@@ -32,7 +33,7 @@ type ConstructorArgs = {
   id: SystemNarrativeTypeId;
   title: string;
   previewTitle?: string;
-  preview: string;
+  preview: MetricTypeId;
   introduction: string;
   sections: SystemNarrativeSection[];
 };
@@ -44,7 +45,7 @@ export default class SystemNarrative {
 
   readonly previewTitle?: string;
 
-  readonly preview: string;
+  readonly preview: MetricTypeId;
 
   readonly introduction: string;
 


### PR DESCRIPTION
## Description of the change

Adds a chart preview component for Racial Disparities, applies a new sort order, and limits the number of preview links to four. 

Should unblock the release of this new homepage design to prod!

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

> Closes #490 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
