### PR TITLE
Add FAST as a supervision office

### DIFF
--- a/spotlight-client/src/contentApi/sources/us_pa.ts
+++ b/spotlight-client/src/contentApi/sources/us_pa.ts
@@ -678,6 +678,7 @@ const content: TenantContent = {
         { id: "CO", label: "Central Office" },
         { id: "10", label: "Chester" },
         { id: "06", label: "Erie" },
+        { id: "FAST", label: "Fugitive Apprehension Search Teams" },
         { id: "03", label: "Harrisburg" },
         { id: "08", label: "Mercer" },
         { id: "01", label: "Philadelphia" },


### PR DESCRIPTION
## Description of the change

https://github.com/Recidiviz/recidiviz-data/issues/9663 added FAST as a supervision office to the underlying data. This goes ahead and adds it as the "Fugitive Apprehension Search Teams" label on Spotlight as well.

![Screen Shot 2021-10-20 at 3 14 27 PM](https://user-images.githubusercontent.com/3762913/138181133-d2d634ba-c995-4978-a928-eeb1708a60c1.png)
![Screen Shot 2021-10-20 at 3 14 32 PM](https://user-images.githubusercontent.com/3762913/138181136-3b4bcf2d-61ea-4ce0-940b-66f439457987.png)

## Type of change

- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Recidiviz/recidiviz-data#9663

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
