### PR TITLE
Fix link style on new homepages

### DIFF
--- a/spotlight-client/package.json
+++ b/spotlight-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spotlight-client",
   "description": "A public-facing dashboard to help educate citizens and build accountability",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "repository": "git@github.com:Recidiviz/public-dashboard.git",
   "author": "Recidiviz <team@recidiviz.org>",

--- a/spotlight-client/src/UiLibrary/PageTitle.ts
+++ b/spotlight-client/src/UiLibrary/PageTitle.ts
@@ -17,6 +17,7 @@
 
 import { rem } from "polished";
 import styled from "styled-components/macro";
+import colors from "./colors";
 import breakpoints from "./breakpoints";
 import { typefaces } from "./typography";
 
@@ -29,5 +30,9 @@ export default styled.h1.attrs({ "data-testid": "PageTitle" })`
 
   @media screen and (min-width: ${breakpoints.tablet[0]}px) {
     font-size: ${rem(52)};
+  }
+
+  a {
+    color: ${colors.accent};
   }
 `;


### PR DESCRIPTION
## Description of the change

We were not applying our brand styles to links in the new homepage copy. Now we are! (It makes them green)

![Screen Shot 2021-10-29 at 3 30 07 PM](https://user-images.githubusercontent.com/5385319/139508143-4ef9934d-5611-4c91-8196-20df5663de8f.png)

Included a version bump so I can release this patch ASAP

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Closes #496 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
