### PR TITLE
Hide locality filter dropdown if there are no dropdown options

### DIFF
--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
@@ -38,6 +38,11 @@ const LocalityFilterSelect: React.FC<LocalityFilterSelectProps> = ({
     metric.localityId = newFilter;
   });
 
+  // if there are no locality entries, don't display the dropdown. We are skipping this for Idaho launch. See https://github.com/Recidiviz/public-dashboard/issues/582
+  if (metric.localityLabels.entries.length === 0) {
+    return null;
+  }
+
   return (
     <Dropdown
       label={metric.localityLabels.label}

--- a/spotlight-client/src/VizControls/VizControls.tsx
+++ b/spotlight-client/src/VizControls/VizControls.tsx
@@ -51,6 +51,10 @@ const FilterWrapper = styled.div`
   &:last-child {
     margin-right: 0;
   }
+
+  &:empty {
+    margin-right: 0;
+  }
 `;
 
 const Button = styled.button`


### PR DESCRIPTION
## Description of the change

We are launching Idaho without breaking down locality by judicial districts, so hide the locality dropdown option in Idaho.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #582

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
