### PR TITLE
Hide "What Happens After Probation" and "What Happens After Parole" sections

### DIFF
--- a/spotlight-client/src/contentApi/sources/us_id.ts
+++ b/spotlight-client/src/contentApi/sources/us_id.ts
@@ -376,12 +376,6 @@ const content: TenantContent = {
           metricTypeId: "ProbationPopulationHistorical",
         },
         {
-          title: "What happens after probation?",
-          body:
-            "After probation, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful probation completion has changed over time, and how the overall rate of successful probation completion varies by demographic.",
-          metricTypeId: "ProbationSuccessHistorical",
-        },
-        {
           title: "Why do revocations happen?",
           body:
             "Revocations happen when a person on probation violates a condition of their supervision or commits a new crime. In Idaho, probation revocations fall into one of three categories: technical violation, new offense, and absconsion.",
@@ -407,12 +401,6 @@ const content: TenantContent = {
           body:
             "Broadly speaking, increased activity in earlier parts of the criminal justice system (such as arrests and sentencing) will result in increases in the parole population. Changes in parole sentence lengths, earlier releases from prison, etc. may also contribute to the rise and fall of this number.",
           metricTypeId: "ParolePopulationHistorical",
-        },
-        {
-          title: "What happens after parole?",
-          body:
-            "After parole, a person may be successfully discharged or revoked to prison. Take a look at how the rate of successful parole completion has changed over time, and how the overall rate of successful parole completion varies by demographic.",
-          metricTypeId: "ParoleSuccessHistorical",
         },
         {
           title: "Why do revocations happen?",


### PR DESCRIPTION
## Description of the change

Hide broken "What Happens After Probation" and "What Happens After Parole" sections in Idaho in preparation for Idaho launch.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #584 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
