### PR TITLE
[Security] Skip Nightfall if Dependabot PR

### DIFF
--- a/.github/workflows/nightfall.yml
+++ b/.github/workflows/nightfall.yml
@@ -8,6 +8,7 @@ jobs:
   nightfalldlp:
     name: nightfalldlp
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo Action
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description of the change

> Skip Nightfall if Dependabot PR. Nightfall does not work for Dependabot. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
