### PR TITLE
Bump version of download-artifact action

### DIFF
--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -1,5 +1,6 @@
 name: Spotlight Staging Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -1,10 +1,6 @@
 name: Spotlight Staging Deploy
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "spotlight-client/**"
 defaults:
   run:
     working-directory: spotlight-client

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -1,6 +1,10 @@
 name: Spotlight Staging Deploy
 on:
   push:
+    branches:
+      - main
+    paths:
+      - "spotlight-client/**"
 defaults:
   run:
     working-directory: spotlight-client

--- a/.github/workflows/spotlight-staging.yml
+++ b/.github/workflows/spotlight-staging.yml
@@ -34,7 +34,7 @@ jobs:
 
         run: yarn build
       - name: Store build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: spotlight-client/build
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: spotlight-client/build


### PR DESCRIPTION
## Description of the change

Updates `download-artifact` and `update-artifact` to v4 to resolve a dependabot alert; docs indicate that download-artifact v4 is not backwards-compatible with uploads by v<4. 

Verified on this branch by temporarily removing the branch filter to trigger [a workflow run](https://github.com/Recidiviz/public-dashboard/actions/runs/11059975032). Once this is merged we will be able to trigger runs manually instead of hacking around the filter, but that change has to be in the default branch 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Resolves dependepot alert from #652

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
