### PR TITLE
Remove judicial district dropdown for ND

### DIFF
--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
@@ -15,12 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
+import contentFixture from "../contentModels/__fixtures__/tenant_content_exhaustive";
 import createMetricMapping from "../contentModels/createMetricMapping";
 import type PopulationBreakdownByLocationMetric from "../contentModels/PopulationBreakdownByLocationMetric";
-import contentFixture from "../contentModels/__fixtures__/tenant_content_exhaustive";
-import { reactImmediately } from "../testUtils";
 import LocalityFilterSelect from "./LocalityFilterSelect";
 
 const testTenantId = "US_ND";
@@ -57,40 +56,21 @@ test("has expected options", () => {
   const metric = getTestMetric();
   render(<LocalityFilterSelect metric={metric} />);
 
-  const menuButton = screen.getByRole("button", {
+  const menuButton = screen.queryByRole("button", {
     name: "Judicial District All Districts",
   });
-  fireEvent.click(menuButton);
 
-  const options = screen.getAllByRole("option");
-
-  expect(options.length).toBe(expectedLocalities.length);
-
-  options.forEach((option, index) =>
-    expect(option).toHaveTextContent(expectedLocalities[index].label)
-  );
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
 });
 
 test("changes demographic filter", () => {
   const metric = getTestMetric();
   render(<LocalityFilterSelect metric={metric} />);
 
-  const menuButton = screen.getByRole("button", {
+  const menuButton = screen.queryByRole("button", {
     name: "Judicial District All Districts",
   });
 
-  expectedLocalities.forEach((expectedLocality) => {
-    // open the menu
-    fireEvent.click(menuButton);
-
-    const option = screen.getByRole("option", { name: expectedLocality.label });
-    fireEvent.click(option);
-
-    reactImmediately(() => {
-      expect(metric.localityId).toBe(expectedLocality.id);
-      expect(menuButton).toHaveTextContent(expectedLocality.label);
-    });
-  });
-
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
   expect.hasAssertions();
 });

--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.test.tsx
@@ -60,7 +60,7 @@ test("has expected options", () => {
     name: "Judicial District All Districts",
   });
 
-  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer display for ND as of February 2025
 });
 
 test("changes demographic filter", () => {
@@ -71,6 +71,6 @@ test("changes demographic filter", () => {
     name: "Judicial District All Districts",
   });
 
-  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer display for ND  as of February 2025
   expect.hasAssertions();
 });

--- a/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
+++ b/spotlight-client/src/LocalityFilterSelect/LocalityFilterSelect.tsx
@@ -39,7 +39,12 @@ const LocalityFilterSelect: React.FC<LocalityFilterSelectProps> = ({
   });
 
   // if there are no locality entries, don't display the dropdown. We are skipping this for Idaho launch. See https://github.com/Recidiviz/public-dashboard/issues/582
-  if (metric.localityLabels.entries.length === 0) {
+  if (
+    metric.localityLabels.entries.length === 0 ||
+    // The judicial district dropdown for ND should no longer be visible in the UI due to unreliable disaggregation data (based on ND dashboard audit)
+    (metric.tenantId === "US_ND" &&
+      metric.localityLabels.label === "Judicial District")
+  ) {
     return null;
   }
 

--- a/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
@@ -138,5 +138,5 @@ test("locality filter", async () => {
     name: "Judicial District All Districts",
   });
 
-  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer display for ND as of February 2025
 });

--- a/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
+++ b/spotlight-client/src/VizSentenceTypeByLocation/VizSentenceTypeByLocation.test.tsx
@@ -134,11 +134,9 @@ test("locality filter", async () => {
 
   await when(() => !metric.isLoading);
 
-  const menuButton = screen.getByRole("button", {
+  const menuButton = screen.queryByRole("button", {
     name: "Judicial District All Districts",
   });
-  fireEvent.click(menuButton);
-  fireEvent.click(screen.getByRole("option", { name: "South Central" }));
 
-  verifySankey(["Total"], ["1,340", "735", "445"]);
+  expect(menuButton).toBeNull(); // Jurisdiction Dropdowns should no longer exist as of February 2025
 });


### PR DESCRIPTION
## Description of the change

Remove judicial district dropdown for North Dakota per a recent audit that found judicial district disaggregation data to be unreliable.

On `main`:

https://github.com/user-attachments/assets/fe1e3d0d-0d07-40a9-9eff-dfe3b7f36222

Current changes ("All Districts" dropdown should no longer be visible on the Sentencing & Probation views):

https://github.com/user-attachments/assets/50ea6b75-4c84-4563-b5b2-bb59eb2c003a



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
