### PR TITLE
Fix deploy, fix root tests, update README for prod deploy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(yarn test:sc)"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "install:api": "cd spotlight-api && yarn",
     "install:sc": "cd spotlight-client && yarn",
     "postinstall": "run-p install:sc install:api",
-    "test": "run-p \"test:* -- {@}\" --",
+    "test": "CI=true run-p test:api test:sc",
     "test:api": "cd spotlight-api && yarn test",
     "test:sc": "cd spotlight-client && yarn test",
     "prepare": "husky install"

--- a/spotlight-api/.gcloudignore
+++ b/spotlight-api/.gcloudignore
@@ -28,5 +28,4 @@ __mocks__/
 archive/
 build/report.html
 coverage/
-yarn.lock
 *.md

--- a/spotlight-api/README.md
+++ b/spotlight-api/README.md
@@ -81,6 +81,8 @@ Deploy to staging Google App Engine with `gcloud app deploy gae-staging.yaml --p
 
 Similarly to above, deploy to production GAE with `gcloud app deploy gae-production.yaml --project [production_project_id]`.
 
+The production project id is currently recidiviz-dashboard-production. 
+
 Test vigorously! Don't be afraid to rollback the deploy through the GAE console.
 
 ## Available Scripts

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,22 +67,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@recidiviz/tsconfig@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@recidiviz/tsconfig@npm:2.0.0"
-  dependencies:
-    "@tsconfig/node16": "npm:^1.0.2"
-  checksum: 10c0/257d14aa382c3b10d6d52ce6007e21a471269e3952be7f554f4cf32852784197da5586a98fee8ecc07cc861196b9ab4b9d4296f76bf6056e36b1e5eb385f2e9e
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
-  languageName: node
-  linkType: hard
-
 "@types/body-parser@npm:*":
   version: 1.19.5
   resolution: "@types/body-parser@npm:1.19.5"
@@ -1829,7 +1813,6 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@eslint/eslintrc": "npm:^3.3.5"
-    "@recidiviz/tsconfig": "npm:^2.0.0"
     axios: "npm:1.15.0"
     husky: "npm:^7.0.0"
     jwks-rsa: "npm:^3.1.0"


### PR DESCRIPTION
## Description of the change

A few cleanup things after the previous node upgrade.

- Allows `yarn.lock` to be uploaded to gcloud such that yarn is used to build dependencies rather than npm in GCP.
- Fixes `yarn test` from the root dir
- Update README to specify project for production BE deploys

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
